### PR TITLE
Add activity meter component

### DIFF
--- a/src/components/presentational/ActivityMeter/ActivityMeter.css
+++ b/src/components/presentational/ActivityMeter/ActivityMeter.css
@@ -1,0 +1,69 @@
+﻿.mdhui-activity-meter
+{
+    position: relative;
+    box-sizing: border-box;
+    padding-bottom: 0;
+    vertical-align: top;
+}
+
+    .mdhui-activity-meter .mdhui-activity-meter-icon
+    {
+        position: absolute;
+        line-height: 32px;
+        text-align: center;
+        left: 16px;
+        top: calc(50% - 8px);
+        color: var(--color-primary);
+        font-size: 1em;
+    }
+
+    .mdhui-activity-meter .mdhui-activity-meter-value
+    {
+        font-weight: bold;
+        margin-bottom: 4px;
+        margin-top: 4px;
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .mdhui-activity-meter .mdhui-activity-meter-label
+    {
+        font-size: .7em;
+        color: #555;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        text-transform: uppercase;
+    }
+
+    .mdhui-activity-meter .mdhui-activity-meter-meter
+    {
+        border-radius: 8px;
+        background: #f5f5f5;
+        position: relative;
+        height: 16px;
+    }
+
+        .mdhui-activity-meter .mdhui-activity-meter-meter .mdhui-activity-meter-average-marker
+        {
+            position: absolute;
+            top: -4px;
+            bottom: -4px;
+            border-left: dashed 1px #bbb;
+        }
+
+        .mdhui-activity-meter .mdhui-activity-meter-meter .mdhui-activity-meter-fill
+        {
+            height: 16px;
+            background: var(--color-primary);
+            position: relative;
+            border-radius: 8px;
+        }
+
+    .mdhui-activity-meter .mdhui-activity-meter-message
+    {
+        font-size: .7em;
+        margin-top: 4px;
+    }

--- a/src/components/presentational/ActivityMeter/ActivityMeter.stories.tsx
+++ b/src/components/presentational/ActivityMeter/ActivityMeter.stories.tsx
@@ -1,0 +1,42 @@
+﻿import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ActivityMeter, { ActivityMeterProps } from "./ActivityMeter";
+import Layout from "../Layout"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBed, faShoePrints } from "@fortawesome/free-solid-svg-icons";
+
+export default {
+	title: "Presentational/ActivityMeter",
+	component: ActivityMeter,
+	parameters: {
+		layout: 'fullscreen',
+	}
+} as ComponentMeta<typeof ActivityMeter>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof ActivityMeter> = (args: ActivityMeterProps) =>
+	<Layout bodyBackgroundColor="#FFF">
+		<ActivityMeter {...args} />
+	</Layout>;
+
+export const Sleep = Template.bind({});
+Sleep.args = {
+	fillPercent: .6,
+	averageFillPercent: .5,
+	color: "#7b88c6",
+	icon: <FontAwesomeIcon icon={faBed} />,
+	label: "Sleep",
+	value: "8h 5m",
+	message: "Above average"
+}
+
+export const Steps = Template.bind({});
+Steps.args = {
+	fillPercent: .4,
+	averageFillPercent: .5,
+	color: "#f5b722",
+	icon: <FontAwesomeIcon icon={faShoePrints} rotate={270} />,
+	label: "Steps",
+	value: "5,251",
+	message: "Below average"
+}

--- a/src/components/presentational/ActivityMeter/ActivityMeter.tsx
+++ b/src/components/presentational/ActivityMeter/ActivityMeter.tsx
@@ -1,0 +1,36 @@
+﻿import React, { ReactElement } from 'react';
+import { ShinyOverlay } from '..';
+import "./ActivityMeter.css"
+
+export interface ActivityMeterProps {
+	label: string;
+	value: string;
+	icon: ReactElement;
+	fillPercent: number;
+	averageFillPercent: number;
+	color: string;
+	message?: string;
+}
+
+export default function (props: ActivityMeterProps) {
+	return <div className="mdhui-activity-meter">
+		<div className="mdhui-activity-meter-label">
+			{props.label}
+		</div>
+		<span className="mdhui-activity-meter-value"><span style={{ color: props.color }}>{props.icon}</span> {props.value}</span>
+		<div className="mdhui-activity-meter-meter">
+			<div className="mdhui-activity-meter-fill" style={{ width: (props.fillPercent * 100) + "%", backgroundColor: props.color }}>
+				<ShinyOverlay />
+			</div>
+			<div className="mdhui-activity-meter-average-marker" style={{ left: props.averageFillPercent * 100 + "%" }} />
+		</div>
+		{props.message != undefined &&
+			<div style={{ color: props.color }} className="mdhui-activity-meter-message">
+				{!props.message &&
+					<>&nbsp;</>
+				}
+				{props.message}
+			</div>
+		}
+	</div>;
+}

--- a/src/components/presentational/ActivityMeter/index.ts
+++ b/src/components/presentational/ActivityMeter/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActivityMeter";

--- a/src/components/presentational/index.ts
+++ b/src/components/presentational/index.ts
@@ -1,4 +1,5 @@
 export { default as Action } from "./Action"
+export { default as ActivityMeter } from "./ActivityMeter"
 export { default as Button } from "./Button"
 export { default as Calendar } from "./Calendar"
 export { default as Card } from "./Card"


### PR DESCRIPTION
## Overview

Adds a new "ActivityMeter" component:
![image](https://user-images.githubusercontent.com/1643171/189679654-9371a194-dfba-4cf4-84b5-04bd516492fd.png)

This is currently in use in Symptom Shark, adding it back here in preparation for moving more of the Symptom Shark stuff back into the framework.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [X] MyDataHelps iOS app
- [X] MyDataHelps Android app
- [X] [MyDataHelps website](mydatahelps.org)

### Documentation
- [X] I have added relevant Storybook updates to this PR as well.
- [X] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner