### PR TITLE
Updating documentation for MyDataHelpsStarterKit Release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,6 @@
 
   * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-#### **Do you intend to add or update a visualization or view?**
-
-* Start writing code and testing your visualizations by setting up a MDH project. 
-* Once you've written and tested your changes, open a [new Github pull request](https://github.com/CareEvolution/MyDataHelpsUI/pulls) with the new feature.
-
 #### **Do you have questions about the source code?**
 
 * Ask any question about how to use MyDataHelpsUI by making a post on [our community forum](https://support.mydatahelps.org/hc/en-us/community/topics/4405770479123-Help-Q-A-).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ MyDataHelpsUI is a set of reusable React-based components based on the MyDataHel
 
 Utilize this component library to accelerate the development of [custom participant views](https://developer.mydatahelps.org/views/) for your digital clinical trial and digital therapeutic application powered by [MyDataHelps platform](https://careevolution.com/mydatahelps/). Integrating MyDataHelpsUI will help you follow best practices for implementing return of results and eCOA within your participant views.
 
+You may also find [MyDataHelpsStarterKit](https://github.com/CareEvolution/MyDataHelpsStarterKit) to be helpful. The starter kit is a react web app template designed for you to be able to fork/clone as a starting point for developing your custom view.
+
 Install via:
 
 ```npm install @careevolution/mydatahelps-ui```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MyDataHelpsUI
 
-MyDataHelpsUI is a set of reusable React-based components based on the MyDataHelps.js SDK: https://developer.mydatahelps.org/sdk/
+MyDataHelpsUI is a set of reusable React-based components based on the [MyDataHelps.js SDK](https://developer.mydatahelps.org/sdk/). Explore the component library at [ui.mydatahelps.org](https://ui.mydatahelps.org/).
 
 Utilize this component library to accelerate the development of [custom participant views](https://developer.mydatahelps.org/views/) for your digital clinical trial and digital therapeutic application powered by [MyDataHelps platform](https://careevolution.com/mydatahelps/). Integrating MyDataHelpsUI will help you follow best practices for implementing return of results and eCOA within your participant views.
 
@@ -35,21 +35,21 @@ export default function () {
 
 ## Storybook
 
-This library uses [Storybook](https://storybook.js.org/).  To look at examples, clone this repository and:
+This library uses [Storybook](https://storybook.js.org/). To look at examples, visit [ui.mydatahelps.org](https://ui.mydatahelps.org/).
 
-```npm run storybook```
+To run Storybook previews with data from one of your test MyDataHelps participants:
 
-to view the storybook.
-
-To run Storybook previews with the data from one of your test MyDataHelps participants:
-1. Obtain a participant access token using the MyDataHelps [JavaScript SDK](https://developer.mydatahelps.org/sdk/participant_tokens.html) 
-2. Create a .env file in your root directory with the token details
+1. Clone this repo
+2. Get a [participant access token](https://developer.mydatahelps.org/sdk/participant_tokens.html) - either using browser dev tools while logged in as a test participant at mydatahelps.org, or by using the REST API.
+    - Hint: if using browser dev tools, examine the response on the request to https://mydatahelps.org/identityserver/connect/token.
+3. Create a .env file in your root directory with the token details
 
 ```
 .env
 -----
 PARTICIPANT_ACCESS_TOKEN=05e211e4df46ca7537e064bde44148a7 
 ```
+4. Run `npm run storybook` to view the storybook.
 
 If you have issues getting storybook to run, particuarly around the NODE_OPTIONS being used, try upgrading Node to the latest version.
 

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -116,4 +116,35 @@ import StackAlt from './assets/stackalt.svg';
 
 # Welcome to MyDataHelps UI
 
-MyDataHelps UI allows you to compose interfaces for MyDataHelps quickly with reusable copmonents.
+[MyDataHelpsUI](https://github.com/CareEvolution/MyDataHelpsUI/) is a set of reusable React-based components based on the [MyDataHelps.js SDK](https://developer.mydatahelps.org/sdk/).This component library allows you to compose interfaces for MyDataHelps quickly with reusable copmonents.
+
+Utilize this component library to accelerate the development of [custom participant views](https://developer.mydatahelps.org/views/) for your digital clinical trial and digital therapeutic application powered by [MyDataHelps platform](https://careevolution.com/mydatahelps/). Integrating MyDataHelpsUI will help you follow best practices for implementing return of results and eCOA within your participant views.
+
+You may also find [MyDataHelpsStarterKit](https://github.com/CareEvolution/MyDataHelpsStarterKit) to be helpful. The starter kit is a react web app template designed for you to be able to fork/clone as a starting point for developing your custom view.
+
+Install via:
+
+```npm install @careevolution/mydatahelps-ui```
+
+### Example of how to use MyDataHelpsUI in your Participant View
+```
+import { Action, Card, Layout, SurveyTaskList } from "@careevolution/mydatahelps-ui"
+
+export default function () {
+  return (
+    <Layout>
+        <Card className='primary-card'>
+            <Action
+            title="Do you think you have COVID-19?"
+            subtitle="It's important to tell us immediately if might have COVID-19.  Click or tap here to report a new infection, symptoms, or close contact."
+            onClick={() => MyDataHelps.startSurvey('New COVID Infection')} />
+        </Card>
+        <Card>
+            <SurveyTaskList status="incomplete" title="Tasks" limit={3} />
+        </Card>
+    </Layout>
+    );
+```
+
+
+[© CareEvolution, LLC](https://developer.mydatahelps.org)

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -114,7 +114,7 @@ import StackAlt from './assets/stackalt.svg';
   
 `}</style>
 
-# Welcome to MyDataHelps UI
+# Welcome to MyDataHelps UI Storybook
 
 [MyDataHelpsUI](https://github.com/CareEvolution/MyDataHelpsUI/) is a set of reusable React-based components based on the [MyDataHelps.js SDK](https://developer.mydatahelps.org/sdk/).This component library allows you to compose interfaces for MyDataHelps quickly with reusable copmonents.
 
@@ -122,6 +122,7 @@ Utilize this component library to accelerate the development of [custom particip
 
 You may also find [MyDataHelpsStarterKit](https://github.com/CareEvolution/MyDataHelpsStarterKit) to be helpful. The starter kit is a react web app template designed for you to be able to fork/clone as a starting point for developing your custom view.
 
+# Using MyDataHelpsUI in your participant view
 Install via:
 
 ```npm install @careevolution/mydatahelps-ui```
@@ -146,5 +147,21 @@ export default function () {
     );
 ```
 
+# Using Storybook with participant data
+To run Storybook previews with data from one of your test MyDataHelps participants:
+
+1. Clone the [MyDataHelpsUI](https://github.com/CareEvolution/MyDataHelpsUI/) repo
+2. Get a [participant access token](https://developer.mydatahelps.org/sdk/participant_tokens.html) - either using browser dev tools while logged in as a test participant at mydatahelps.org, or by using the REST API.
+    - Hint: if using browser dev tools, examine the response on the request to https://mydatahelps.org/identityserver/connect/token.
+3. Create a .env file in your root directory with the token details
+
+```
+.env
+-----
+PARTICIPANT_ACCESS_TOKEN=05e211e4df46ca7537e064bde44148a7 
+```
+4. Run `npm run storybook` to view the storybook.
+
+If you have issues getting storybook to run, particuarly around the NODE_OPTIONS being used, try upgrading Node to the latest version.
 
 [© CareEvolution, LLC](https://developer.mydatahelps.org)


### PR DESCRIPTION
## Overview

Updating documentation to link to MyDataHelps StarterKit and ui.mydatahelps.org 

Adding documentation to storybook introduction linking back to MyDataHelpsUI, MyDataHelpsStarterKit. 

Removing language from Contributing that suggests we encourage external development. 

## Security

REMINDER: All file contents are public.

- [X ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Documentation updates that link to other public sites. No code changes.

## Checklist

### Testing
Tested in markdown previewer. 

### Documentation
- [X ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner