### PR TITLE
Clickable Histogram items, non-clickable overlay, layout class

### DIFF
--- a/src/components/presentational/Histogram/Histogram.css
+++ b/src/components/presentational/Histogram/Histogram.css
@@ -1,25 +1,41 @@
-﻿.mdhui-histogram {
+﻿.mdhui-histogram
+{
     padding: 16px;
 }
 
-.mdhui-histogram-entry {
-    padding-top: 8px;
-    font-size: 15px;
-}
+    .mdhui-histogram .mdhui-histogram-entry
+    {
+        padding-top: 8px;
+        font-size: 15px;
+    }
 
-.mdhui-histogram-entry-bar-wrapper {
-    display: flex;
-}
+        .mdhui-histogram .mdhui-histogram-entry.mdhui-histogram-entry-clickable
+        {
+            cursor: pointer;
+        }
 
-.mdhui-histogram-entry-bar {
-    position: relative;
-    height: 16px;
-    border-radius: 8px;
-}
+            .mdhui-histogram .mdhui-histogram-entry.mdhui-histogram-entry-clickable .mdhui-histogram-entry-label
+            {
+                text-decoration: underline;
+                color: #429bdf;
+            }
 
-.mdhui-histogram-entry-value {
-    padding-left: 4px;
-    line-height: 16px;
-    font-size: 12px;
-    font-weight: bold;
-}
+    .mdhui-histogram .mdhui-histogram-entry-bar-wrapper
+    {
+        display: flex;
+    }
+
+    .mdhui-histogram .mdhui-histogram-entry-bar
+    {
+        position: relative;
+        height: 16px;
+        border-radius: 8px;
+    }
+
+    .mdhui-histogram .mdhui-histogram-entry-value
+    {
+        padding-left: 4px;
+        line-height: 16px;
+        font-size: 12px;
+        font-weight: bold;
+    }

--- a/src/components/presentational/Histogram/Histogram.css
+++ b/src/components/presentational/Histogram/Histogram.css
@@ -17,7 +17,7 @@
             .mdhui-histogram .mdhui-histogram-entry.mdhui-histogram-entry-clickable .mdhui-histogram-entry-label
             {
                 text-decoration: underline;
-                color: #429bdf;
+                color: var(--color-theme);
             }
 
     .mdhui-histogram .mdhui-histogram-entry-bar-wrapper

--- a/src/components/presentational/Histogram/Histogram.tsx
+++ b/src/components/presentational/Histogram/Histogram.tsx
@@ -1,36 +1,39 @@
 import React from 'react';
+import ShinyOverlay from '../ShinyOverlay';
 import "./Histogram.css"
-import ShinyOverlay from "../ShinyOverlay";
 
 export interface HistogramProps {
-    entries: {
-        label: string;
-        color: string;
-        value: number;
-    }[];
+	entries: {
+		label: string;
+		color: string;
+		value: number;
+		onSelect?(): void;
+	}[];
 }
 
 export default function (props: HistogramProps) {
-    let maxValue = 0;
-    props.entries.forEach(function (e) {
-        if (e.value > maxValue) {
-            maxValue = e.value;
-        }
-    });
+	let maxValue = 0;
+	props.entries.forEach(function (e) {
+		if (e.value > maxValue) {
+			maxValue = e.value;
+		}
+	});
 
-    return (
-        <div className="mdhui-histogram">
-            {props.entries.map((entry, index) => {
-                return <div className="mdhui-histogram-entry" key={index}>
-                    <div className="mdhui-histogram-entry-bar-wrapper">
-                        <div className="mdhui-histogram-entry-bar" style={{background: entry.color, width: ((entry.value / maxValue) * 100) + "%"}}>
-                            <ShinyOverlay/>
-                        </div>
-                        <div className="mdhui-histogram-entry-value" style={{width: (maxValue.toString().length * 8) + "px"}}>{entry.value}</div>
-                    </div>
-                    <div className="mdhui-histogram-entry-label">{entry.label}</div>
-                </div>;
-            })}
-        </div>
-    );
+	var sortedEntries = [...props.entries].sort((a, b) => b.value - a.value || ((a.label > b.label) ? 1 : ((b.label > a.label) ? -1 : 0)));
+
+	return (
+		<div className="mdhui-histogram">
+			{sortedEntries.map((entry, index) => {
+				return <div className={"mdhui-histogram-entry" + (entry.onSelect ? " mdhui-histogram-entry-clickable" : "")} key={index} onClick={() => entry.onSelect?.()}>
+					<div className="mdhui-histogram-entry-bar-wrapper">
+						<div className="mdhui-histogram-entry-bar" style={{ background: entry.color, width: ((entry.value / maxValue) * 100) + "%" }}>
+							<ShinyOverlay />
+						</div>
+						<div className="mdhui-histogram-entry-value" style={{ width: (maxValue.toString().length * 8) + "px" }}>{entry.value}</div>
+					</div>
+					<div className="mdhui-histogram-entry-label">{entry.label}</div>
+				</div>;
+			})}
+		</div>
+	);
 }

--- a/src/components/presentational/Layout/Layout.tsx
+++ b/src/components/presentational/Layout/Layout.tsx
@@ -6,7 +6,8 @@ export interface LayoutProps {
 	children?: React.ReactNode;
 	stylesheetPath?: string;
 	bodyBackgroundColor?: string;
-	statusBarStyle?: StatusBarStyle
+	statusBarStyle?: StatusBarStyle;
+	className?: string;
 }
 
 export default function (props: LayoutProps) {
@@ -21,7 +22,7 @@ export default function (props: LayoutProps) {
 	}
 
 	return (
-		<div className="mdhui-layout">
+		<div className={"mdhui-layout" + (props.className ? (" " + props.className) : "")}>
 			{props.stylesheetPath &&
 				<link rel="stylesheet" type="text/css" href={props.stylesheetPath} />
 			}

--- a/src/components/presentational/ShinyOverlay/ShinyOverlay.css
+++ b/src/components/presentational/ShinyOverlay/ShinyOverlay.css
@@ -6,4 +6,5 @@
     bottom: 0;
     top: 0;
     background: linear-gradient(to left, rgba(255, 255, 255, 0) 0%, rgba(255, 244, 240, 0.2) 100%);
+    pointer-events: none;
 }


### PR DESCRIPTION
## Overview

Some minor tweaks on things that would have been nice downstream.
- Histogram elements can now be clickable (to enable viewing details for instance) - this is used in Symptom Shark
- The ShinyOverlay now has pointer-events:none to prevent it from blocking clicks
- Layout can have a className

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [X] MyDataHelps iOS app
- [X] MyDataHelps Android app
- [X] [MyDataHelps website](mydatahelps.org)

### Documentation
- [X] I have added relevant Storybook updates to this PR as well.
- [X] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner