### PR TITLE
Add option for weekStartsOn to Calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "1.8.0",
+  "version": "1.7.1",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/presentational/Calendar/Calendar.stories.tsx
+++ b/src/components/presentational/Calendar/Calendar.stories.tsx
@@ -30,4 +30,5 @@ Default.args = {
   dayRenderer: (year, month, day) => {
     return plainCalendarDay(year, month, day);
   },
+  weekStartsOn: 0
 };

--- a/src/components/presentational/Calendar/Calendar.tsx
+++ b/src/components/presentational/Calendar/Calendar.tsx
@@ -6,7 +6,8 @@ import "./Calendar.css";
 export interface CalendarProps {
 	month: number,
 	year: number,
-	dayRenderer(year: number, month: number, day?: number): JSX.Element | null
+	dayRenderer(year: number, month: number, day?: number): JSX.Element | null,
+	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
 }
 
 interface CalendarWeek {
@@ -21,7 +22,14 @@ export default function (props: CalendarProps) {
 	var weeks: CalendarWeek[] = []
 	var locale = MyDataHelps.getCurrentLanguage().toLowerCase().startsWith("es") ? es : enUS;
 
-	const weekdays = Array.from(Array(7).keys()).map((i) =>
+	var daysOfTheWeekIndeces = Array.from(Array(7).keys());
+	if (props.weekStartsOn) {
+		while (daysOfTheWeekIndeces[0] !== props.weekStartsOn) {
+			daysOfTheWeekIndeces.push(daysOfTheWeekIndeces.shift());
+		}
+	}
+
+	const weekdays = daysOfTheWeekIndeces.map((i) =>
 		locale.localize?.day(i, { width: "narrow" })
 	);
 
@@ -38,7 +46,7 @@ export default function (props: CalendarProps) {
 				days: []
 			};
 			for (let j = 0; j < 7; j++) {
-				if (i === 0 && j < firstDay) {
+				if (i === 0 && j < firstDay + daysOfTheWeekIndeces[j]) {
 					week.days[j] = { day: undefined };
 				}
 				else if (date > daysInMonth(props.month, props.year)) {

--- a/src/components/presentational/Calendar/Calendar.tsx
+++ b/src/components/presentational/Calendar/Calendar.tsx
@@ -22,14 +22,15 @@ export default function (props: CalendarProps) {
 	var weeks: CalendarWeek[] = []
 	var locale = MyDataHelps.getCurrentLanguage().toLowerCase().startsWith("es") ? es : enUS;
 
-	var daysOfTheWeekIndeces = Array.from(Array(7).keys());
-	if (props.weekStartsOn) {
-		while (daysOfTheWeekIndeces[0] !== props.weekStartsOn) {
-			daysOfTheWeekIndeces.push(daysOfTheWeekIndeces.shift());
+	var daysOfTheWeekIndices = Array.from(Array(7).keys());
+	var weekStartsOn = !props.weekStartsOn || props.weekStartsOn < 7 ? props.weekStartsOn : 0;
+	if (weekStartsOn) {
+		while (daysOfTheWeekIndices[0] !== weekStartsOn) {
+			daysOfTheWeekIndices.push(daysOfTheWeekIndices.shift());
 		}
 	}
 
-	const weekdays = daysOfTheWeekIndeces.map((i) =>
+	const weekdays = daysOfTheWeekIndices.map((i) =>
 		locale.localize?.day(i, { width: "narrow" })
 	);
 
@@ -46,7 +47,7 @@ export default function (props: CalendarProps) {
 				days: []
 			};
 			for (let j = 0; j < 7; j++) {
-				if (i === 0 && j < firstDay + daysOfTheWeekIndeces[j]) {
+				if (i === 0 && j < firstDay + daysOfTheWeekIndices[j]) {
 					week.days[j] = { day: undefined };
 				}
 				else if (date > daysInMonth(props.month, props.year)) {

--- a/src/components/presentational/Calendar/Calendar.tsx
+++ b/src/components/presentational/Calendar/Calendar.tsx
@@ -39,7 +39,10 @@ export default function (props: CalendarProps) {
 	}
 
 	var generateWeeks = function () {
-		var firstDay = (new Date(props.year, props.month)).getDay();
+		var firstDay = (new Date(props.year, props.month)).getDay() - weekStartsOn;
+		if (firstDay < 0) {
+			firstDay = 7 + firstDay;
+		}
 		var newWeeks: CalendarWeek[] = [];
 		var date = 1;
 		for (let i = 0; i < 6; i++) {
@@ -47,7 +50,7 @@ export default function (props: CalendarProps) {
 				days: []
 			};
 			for (let j = 0; j < 7; j++) {
-				if (i === 0 && j < firstDay + daysOfTheWeekIndices[j]) {
+				if (i === 0 && j < firstDay) {
 					week.days[j] = { day: undefined };
 				}
 				else if (date > daysInMonth(props.month, props.year)) {

--- a/src/components/presentational/Calendar/Calendar.tsx
+++ b/src/components/presentational/Calendar/Calendar.tsx
@@ -23,7 +23,7 @@ export default function (props: CalendarProps) {
 	var locale = MyDataHelps.getCurrentLanguage().toLowerCase().startsWith("es") ? es : enUS;
 
 	var daysOfTheWeekIndices = Array.from(Array(7).keys());
-	var weekStartsOn = !props.weekStartsOn || props.weekStartsOn < 7 ? props.weekStartsOn : 0;
+	var weekStartsOn = props.weekStartsOn && props.weekStartsOn < 7 ? props.weekStartsOn : 0;
 	if (weekStartsOn) {
 		while (daysOfTheWeekIndices[0] !== weekStartsOn) {
 			daysOfTheWeekIndices.push(daysOfTheWeekIndices.shift());


### PR DESCRIPTION
Adds ability to have a Calendar that starts on a different day other than Sunday.

![1](https://user-images.githubusercontent.com/4117457/214092411-4a241b4e-9878-47a3-b2f0-fa5faedd34d2.png)
![2](https://user-images.githubusercontent.com/4117457/214092413-cbb69ab7-a6de-4217-82d6-56b2a2ce7ddc.png)


## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.
