### PR TITLE
Survey Step Alternative Styling POC

### DIFF
--- a/src/components/step/StepStyle/StepStyle.tsx
+++ b/src/components/step/StepStyle/StepStyle.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+export interface StepStyleProps {
+  titleAlignment?: string;
+  titleColor?: string;
+  titleFontSize?: string;
+  titleFontWeight?: string;
+}
+
+export default function (props: StepStyleProps) {
+    return (
+      <style>
+          .step-container .step-title &#123;
+            text-align: {props.titleAlignment};
+            color: {props.titleColor};
+            font-size: {props.titleFontSize};
+            font-weight: {props.titleFontWeight};
+            &#125;
+      </style>  
+    );
+}
+

--- a/src/components/step/StepStyle/StepStyle.tsx
+++ b/src/components/step/StepStyle/StepStyle.tsx
@@ -1,22 +1,16 @@
 import React from 'react'
-
-export interface StepStyleProps {
-  titleAlignment?: string;
-  titleColor?: string;
-  titleFontSize?: string;
-  titleFontWeight?: string;
-}
+import { StepStyleProps } from '../shared';
 
 export default function (props: StepStyleProps) {
     return (
       <style>
           .step-container .step-title &#123;
-            text-align: {props.titleAlignment};
-            color: {props.titleColor};
-            font-size: {props.titleFontSize};
-            font-weight: {props.titleFontWeight};
-            &#125;
-      </style>  
+            {props.titleAlignment ? `text-align: ${props.titleAlignment};` : ""}
+            {props.titleColor ? `color: ${props.titleColor};` : ""}
+            {props.titleFontSize ? `font-size: ${props.titleFontSize}px;` : ""}
+            {props.titleFontWeight ? `font-weight: ${props.titleFontWeight};` : ""}
+          &#125;
+      </style>
     );
 }
 

--- a/src/components/step/StepStyle/index.ts
+++ b/src/components/step/StepStyle/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StepStyle";

--- a/src/components/step/StepTitle/StepTitle.stories.tsx
+++ b/src/components/step/StepTitle/StepTitle.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import StepTitle from "./StepTitle";
 import {StepElementProps} from "../shared"
 import StepLayout from "../StepLayout";
+import StepStyle from "../StepStyle";
 
 export default {
     title: "SurveyStep/Components/StepTitle",
@@ -15,6 +16,12 @@ export default {
 const Template: ComponentStory<typeof StepTitle> = (args: StepElementProps) =>
     <StepLayout>
         <StepTitle {...args} />
+        <StepStyle 
+              titleAlignment="Right"
+              titleColor="Pink"
+              titleFontSize="100px"
+              titleFontWeight="100"
+              ></StepStyle>
     </StepLayout>
 
 export const StepTitleDefault = Template.bind({});

--- a/src/components/step/StepTitle/StepTitle.stories.tsx
+++ b/src/components/step/StepTitle/StepTitle.stories.tsx
@@ -19,7 +19,7 @@ const Template: ComponentStory<typeof StepTitle> = (args: StepElementProps) =>
         <StepStyle 
               titleAlignment="Right"
               titleColor="Pink"
-              titleFontSize="100px"
+              titleFontSize="100"
               titleFontWeight="100"
               ></StepStyle>
     </StepLayout>
@@ -36,9 +36,5 @@ StepTitleMarkdownItalics.args = {
 
 export const StepTitleCustomStyle = Template.bind({});
 StepTitleCustomStyle.args = {
-    text: "This is the title",
-    textAlign: "Left",
-    color: "#FF0000",
-    fontSize: "72",
-    fontWeight: "900"
+    text: "This is the title"
 }

--- a/src/components/step/StepTitle/StepTitle.tsx
+++ b/src/components/step/StepTitle/StepTitle.tsx
@@ -10,7 +10,7 @@ export default function (props: StepElementProps) {
       return null
     }
     return (
-      <div className="step-title" style={stepElementStyle(props)}>
+      <div className="step-title" >
           <StepMarkdown 
             text={props.text} 
             inline={true}

--- a/src/components/step/YouTubeStep/YouTubeStep.stories.tsx
+++ b/src/components/step/YouTubeStep/YouTubeStep.stories.tsx
@@ -19,7 +19,8 @@ YouTubeStepDefault.args = {
     text: "Meet Participants Where They Are",
     transcript: "Meet participants where they are with MyDataHelps™—your one-stop digital health platform for conducting clinical research, clinical trials, and wellness projects! eConsent and enroll participants, collect digital biomarkers, automate survey delivery, and begin analyzing digital phenotype and EHR data in hours.",
     videoId: "Ee3x4oK_qv8",
-    styles: {}
+    styles: {},
+    styles2: {}
 }
 
 export const YouTubeStepCustomStyling = Template.bind({});
@@ -48,7 +49,9 @@ YouTubeStepCustomStyling.args = {
         "textAlignment": "Left",
         "textColor": "#0000FF",
         "textFontSize": "18",
-        "textFontWeight": "300",
+        "textFontWeight": "300"
+    },
+    styles2: {
         "titleAlignment": "Left",
         "titleColor": "#0000FF",
         "titleFontSize": "36",

--- a/src/components/step/YouTubeStep/YouTubeStep.tsx
+++ b/src/components/step/YouTubeStep/YouTubeStep.tsx
@@ -5,6 +5,7 @@ import StepTitle from '../StepTitle';
 import StepText from '../StepText';
 import StepDetailText from '../StepDetailText'
 import StepNextButton from '../StepNextButton';
+import StepStyle from '../StepStyle';
 
 export interface YouTubeStepProps {
     properties: { [key: string]: any };
@@ -65,7 +66,13 @@ export default function (props: YouTubeStepProps) {
               textTransform={props.styles.nextButtonTextTransform?.toLowerCase()}
               gradient={props.styles.nextButtonBackgroundGradient}
               onClick={() => MyDataHelps.completeStep('')}
-            />            
+            />
+            <StepStyle 
+              titleAlignment={props.styles.titleAlignment}
+              titleColor={props.styles.titleAlignment}
+              titleFontSize={props.styles.titleAlignment}
+              titleFontWeight={props.styles.titleAlignment}
+              ></StepStyle>
       </StepLayout>
     );
 }

--- a/src/components/step/YouTubeStep/YouTubeStep.tsx
+++ b/src/components/step/YouTubeStep/YouTubeStep.tsx
@@ -6,6 +6,7 @@ import StepText from '../StepText';
 import StepDetailText from '../StepDetailText'
 import StepNextButton from '../StepNextButton';
 import StepStyle from '../StepStyle';
+import { StepStyleProps } from '../shared';
 
 export interface YouTubeStepProps {
     title?: string;
@@ -15,6 +16,8 @@ export interface YouTubeStepProps {
     nextButtonText?: string;
     height?: string;
     styles: { [key: string]: any };
+    styles2: StepStyleProps;
+    children?: any;
 }
 
 export default function (props: YouTubeStepProps) {
@@ -34,10 +37,6 @@ export default function (props: YouTubeStepProps) {
       <StepLayout>
            <StepTitle 
               text={props.title} 
-              textAlign={props.styles.titleAlignment}
-              color={props.styles.titleColor}
-              fontSize={props.styles.titleFontSize}
-              fontWeight={props.styles.titleFontWeight}
             />
            <StepText 
               text={props.text} 
@@ -72,12 +71,12 @@ export default function (props: YouTubeStepProps) {
               gradient={props.styles.nextButtonBackgroundGradient}
               onClick={() => MyDataHelps.completeStep('')}
             />
-            <StepStyle 
-              titleAlignment={props.styles.titleAlignment}
-              titleColor={props.styles.titleAlignment}
-              titleFontSize={props.styles.titleAlignment}
-              titleFontWeight={props.styles.titleAlignment}
-              ></StepStyle>
+            <StepStyle
+              titleAlignment={props.styles2.titleAlignment}
+              titleColor={props.styles2.titleColor}
+              titleFontSize={props.styles2.titleFontSize}
+              titleFontWeight={props.styles2.titleFontWeight}
+             />
       </StepLayout>
     );
 }

--- a/src/components/step/YouTubeStepContainer/YouTubeStepContainer.tsx
+++ b/src/components/step/YouTubeStepContainer/YouTubeStepContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import MyDataHelps, {StepConfiguration} from '@careevolution/mydatahelps-js';
 import YouTubeStep from '../YouTubeStep';
+import StepStyle from '../StepStyle';
 
 export default function () {
 
@@ -36,6 +37,8 @@ export default function () {
           height={height}
           videoId={videoId}
           styles={styles}
-         />
+          styles2={styles}
+         >
+      </YouTubeStep>
     );
 }

--- a/src/components/step/shared.ts
+++ b/src/components/step/shared.ts
@@ -6,3 +6,10 @@ export interface StepElementProps {
     fontSize?: string;
     fontWeight?: string;
 }
+
+export interface StepStyleProps {
+    titleAlignment?: string;
+    titleColor?: string;
+    titleFontSize?: string;
+    titleFontWeight?: string;
+  }


### PR DESCRIPTION
## Overview

Experiments with a different approach to step styling than passing a style blob object through the top level step component down to the low level components. This is a partial implementation to demonstrate the pattern with just StepTitle.

To use this approach a step implementer would add styling support by 

1. Adding a style: StepStyleProps object to their step props definition
2. Adding a StepStyle component within their step component.

This feels more inline with how you would normally override css styling/appearance outside React and makes the style overrides clearer and more self-documenting.

Custom steps not explicitly supported in MyDataHelps should be able to follow a variation of this pattern to override default styling of the low level components without being forced to reimplement them.

If we agree this is the preferred approach it should be easy to apply to the other low level components.

## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.


## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner