### PR TITLE
Show Youtube Step When No Video ID Provided

### DIFF
--- a/src/components/step/YouTubeStep/YouTubeStep.tsx
+++ b/src/components/step/YouTubeStep/YouTubeStep.tsx
@@ -18,9 +18,6 @@ export interface YouTubeStepProps {
 
 export default function (props: YouTubeStepProps) {
 
-    if (!props.videoId) {
-        return (<StepLayout></StepLayout>)
-    }
     // ref player params at https://developers.google.com/youtube/player_parameters
     let frameHeight = (props.height ? props.height : "225") + "px";
     let ccLanguage = MyDataHelps.getCurrentLanguage(); // used to set default CC language


### PR DESCRIPTION
## Overview

Small change to remove the early return when rendering Youtube steps without a videoId. Originally I had concerns about rendering the blank youtube embed page, but on reflection it looks broken and worse to have no response when inputting text or having a blank area show up on initial creation.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner