### PR TITLE
Restrict StepLayout Component Reset Styles

### DIFF
--- a/src/components/step/StepLayout/StepLayout.css
+++ b/src/components/step/StepLayout/StepLayout.css
@@ -2,7 +2,28 @@
     background-color: #FFFFFF;
 }
 
-.step-container div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,form,fieldset,input,textarea,p,blockquote,th,td { 
+.step-container div,
+.step-container dl,
+.step-container dt,
+.step-container dd,
+.step-container ul,
+.step-container ol,
+.step-container li,
+.step-container h1,
+.step-container h2,
+.step-container h3,
+.step-container h4,
+.step-container h5,
+.step-container h6,
+.step-container pre,
+.step-container form,
+.step-container fieldset,
+.step-container input,
+.step-container textarea,
+.step-container p,
+.step-container blockquote,
+.step-container th,
+.step-container td { 
     margin: 0;
     padding: 0;
 }


### PR DESCRIPTION
## Overview
Small fix to properly nest and restrict scope of reset styles for StepLayout component. These still work as expected for the StepLayout and should not interfere with other non-step component styles.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner