### PR TITLE
Fix long task description wrapping.

### DIFF
--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.css
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.css
@@ -1,16 +1,14 @@
 .mdhui-single-survey-task
 {
     padding: 16px;
-    padding-left: 48px;
-    position: relative;
-    width: 100%;
+    display: grid;
+    grid-template-columns: max-content auto max-content;
+    grid-column-gap: 16px;
+    align-items: center;
 }
 
     .mdhui-single-survey-task .status-icon
     {
-        position: absolute;
-        left: 16px;
-        top: calc(50% - 8px);
         color: var(--color-muted2);
     }
 
@@ -52,9 +50,6 @@
 
     .mdhui-single-survey-task .indicator
     {
-        position: absolute;
-        top: calc(50% - 8px);
-        right: 16px;
         font-size: 16px;
         color: var(--color-muted2);
     }

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
@@ -68,3 +68,20 @@ InProgress.args = {
 	}
 }
 
+export const LongDescription = Template.bind({});
+LongDescription.args = {
+	task: {
+		id: "test",
+		status: "incomplete",
+		surveyDisplayName: "Long Description",
+		surveyDescription: "Here is a really long description that will likely need to wrap.  It should wrap before overlapping the right chevron.",
+		surveyName: "PainSurvey",
+		dueDate: (new Date()).toISOString(),
+		hasSavedProgress: false,
+		insertedDate: "2022-03-06T20:00:00Z",
+		modifiedDate: "2022-03-06T20:00:00Z",
+		surveyID: "1",
+		linkIdentifier:"1"
+	}
+}
+

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -70,11 +70,13 @@ export default function (props: SingleSurveyTaskProps) {
 						<FontAwesomeSvgIcon icon={faCircle} />
 					}
 				</div>
-				<div className="survey-name">{props.task.surveyDisplayName}</div>
-				<div className="survey-description">{props.descriptionIcon} {props.task.surveyDescription}</div>
-				{!props.hideDueDate && dueDateString &&
+				<div>
+					<div className="survey-name">{props.task.surveyDisplayName}</div>
+					<div className="survey-description">{props.descriptionIcon} {props.task.surveyDescription}</div>
+					{!props.hideDueDate && dueDateString &&
 					<div className={"due-date " + dueDateIntent}>{dueDateString}</div>
-				}
+					}
+				</div>
 				<div className="indicator">
 					<FontAwesomeSvgIcon icon={faChevronRight} />
 				</div>
@@ -88,8 +90,10 @@ export default function (props: SingleSurveyTaskProps) {
 				<div className="status-icon">
 					<FontAwesomeSvgIcon icon={faCircleCheck} />
 				</div>
-				<div className="survey-name">{props.task.surveyDisplayName}</div>
-				<div className="completed-date">{language["completed"]} {formatRelative(parseISO(props.task.endDate), new Date(), { locale: locale })}</div>
+				<div>
+					<div className="survey-name">{props.task.surveyDisplayName}</div>
+					<div className="completed-date">{language["completed"]} {formatRelative(parseISO(props.task.endDate), new Date(), {locale: locale})}</div>
+				</div>
 			</div>
 		)
 	}


### PR DESCRIPTION
## Overview

Fixes: https://github.com/CareEvolution/MyDataHelpsUI/issues/22

A small layout/CSS adjustment to prevent long task descriptions from overlapping the right chevron.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [x] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner