### PR TITLE
Relative Activity Today Component

### DIFF
--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.css
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.css
@@ -1,0 +1,11 @@
+.mdhui-relative-activity-today .mdhui-relative-activity-today-meter {
+    margin: 16px;
+}
+
+.mdhui-relative-activity-today .mdhui-relative-activity-average-marker {
+    text-align: center;
+    margin: 16px;
+    font-size: .7em;
+    margin-bottom: 16px;
+    color: var(--mdhui-text-color-2);
+}

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
@@ -24,6 +24,7 @@ const Template: ComponentStory<typeof RelativeActivityToday> = (args: RelativeAc
 
 export const Default = Template.bind({});
 Default.args = {
+    title: "Activity Today",
     previewState: "Default",
     dataTypes: [{
         dailyDataType: DailyDataType.Steps,
@@ -86,6 +87,7 @@ Default.args = {
 
 export const Live = Template.bind({});
 Live.args = {
+    title: "Activity Today",
     dataTypes: [{
         dailyDataType: DailyDataType.Steps,
         label: "Steps",

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
@@ -22,127 +22,73 @@ const Template: ComponentStory<typeof RelativeActivityToday> = (args: RelativeAc
         </Card>
     </Layout>;
 
+let dataTypes = [{
+    dailyDataType: DailyDataType.Steps,
+    label: "Steps",
+    icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
+    color: "rgba(255, 166, 102, 1)",
+    formatter: function (number: number) {
+        return Math.floor(number).toLocaleString()
+    }
+}, {
+    dailyDataType: DailyDataType.FitbitActiveMinutes,
+    label: "Active Minutes",
+    icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
+    color: "rgba(255, 166, 102, 1)",
+    formatter: function (number: number) {
+        return Math.floor(number).toString() + " minutes";
+    }
+},
+{
+    dailyDataType: DailyDataType.AppleHealthSleepMinutes,
+    label: "Sleep Time",
+    icon: <FontAwesomeSvgIcon icon={faBed} />,
+    color: "rgba(74, 144, 226, 1)",
+    formatter: function (number: number) {
+        var hours = Math.floor(number / 60);
+        var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
+        return displayValue;
+    }
+},
+{
+    dailyDataType: DailyDataType.FitbitSleepMinutes,
+    label: "Sleep Time",
+    icon: <FontAwesomeSvgIcon icon={faBed} />,
+    color: "rgba(74, 144, 226, 1)",
+    formatter: function (number: number) {
+        var hours = Math.floor(number / 60);
+        var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
+        return displayValue;
+    }
+},
+{
+    dailyDataType: DailyDataType.AppleHealthMaxHeartRate,
+    label: "Max Heart Rate",
+    icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
+    color: "rgba(239, 132, 129, 1)",
+    formatter: function (number: number) {
+        return Math.floor(number).toString() + " bpm";
+    }
+},
+{
+    dailyDataType: DailyDataType.FitbitElevatedHeartRateMinutes,
+    label: "Elevated Heart Rate Time",
+    icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
+    color: "rgba(239, 132, 129, 1)",
+    formatter: function (number: number) {
+        return Math.floor(number).toString() + " minutes";
+    }
+}];
+
 export const Default = Template.bind({});
 Default.args = {
     title: "Activity Today",
     previewState: "Default",
-    dataTypes: [{
-        dailyDataType: DailyDataType.Steps,
-        label: "Steps",
-        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
-        color: "rgba(255, 166, 102, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toLocaleString()
-        }
-    }, {
-        dailyDataType: DailyDataType.FitbitActiveMinutes,
-        label: "Active Minutes",
-        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
-        color: "rgba(255, 166, 102, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toString() + " minutes";
-        }
-    },
-    {
-        dailyDataType: DailyDataType.AppleHealthSleepMinutes,
-        label: "Sleep Time",
-        icon: <FontAwesomeSvgIcon icon={faBed} />,
-        color: "rgba(74, 144, 226, 1)",
-        formatter: function (number: number) {
-            var hours = Math.floor(number / 60);
-            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
-            return displayValue;
-        }
-    },
-    {
-        dailyDataType: DailyDataType.FitbitSleepMinutes,
-        label: "Sleep Time",
-        icon: <FontAwesomeSvgIcon icon={faBed} />,
-        color: "rgba(74, 144, 226, 1)",
-        formatter: function (number: number) {
-            var hours = Math.floor(number / 60);
-            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
-            return displayValue;
-        }
-    },
-    {
-        dailyDataType: DailyDataType.AppleHealthMaxHeartRate,
-        label: "Max Heart Rate",
-        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
-        color: "rgba(239, 132, 129, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toString() + " bpm";
-        }
-    },
-    {
-        dailyDataType: DailyDataType.FitbitElevatedHeartRateMinutes,
-        label: "Elevated Heart Rate Time",
-        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
-        color: "rgba(239, 132, 129, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toString() + " minutes";
-        }
-    }]
+    dataTypes: dataTypes
 }
 
 export const Live = Template.bind({});
 Live.args = {
     title: "Activity Today",
-    dataTypes: [{
-        dailyDataType: DailyDataType.Steps,
-        label: "Steps",
-        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
-        color: "rgba(255, 166, 102, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toLocaleString()
-        }
-    }, {
-        dailyDataType: DailyDataType.FitbitActiveMinutes,
-        label: "Active Minutes",
-        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
-        color: "rgba(255, 166, 102, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toString() + " minutes";
-        }
-    },
-    {
-        dailyDataType: DailyDataType.AppleHealthSleepMinutes,
-        label: "Sleep Time",
-        icon: <FontAwesomeSvgIcon icon={faBed} />,
-        color: "rgba(74, 144, 226, 1)",
-        formatter: function (number: number) {
-            var hours = Math.floor(number / 60);
-            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
-            return displayValue;
-        }
-    },
-    {
-        dailyDataType: DailyDataType.FitbitSleepMinutes,
-        label: "Sleep Time",
-        icon: <FontAwesomeSvgIcon icon={faBed} />,
-        color: "rgba(74, 144, 226, 1)",
-        formatter: function (number: number) {
-            var hours = Math.floor(number / 60);
-            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
-            return displayValue;
-        }
-    },
-    {
-        dailyDataType: DailyDataType.AppleHealthMaxHeartRate,
-        label: "Max Heart Rate",
-        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
-        color: "rgba(239, 132, 129, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toString() + " bpm";
-        }
-    },
-    {
-        dailyDataType: DailyDataType.FitbitElevatedHeartRateMinutes,
-        label: "Elevated Heart Rate Time",
-        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
-        color: "rgba(239, 132, 129, 1)",
-        formatter: function (number: number) {
-            return Math.floor(number).toString() + " minutes";
-        }
-    }]
+    dataTypes: dataTypes
 }

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
@@ -1,0 +1,84 @@
+import React from "react"
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import RelativeActivityToday, { RelativeActivityTodayProps } from "./RelativeActivityToday"
+import Card from "../../presentational/Card"
+import Layout from "../../presentational/Layout"
+import { FontAwesomeSvgIcon } from "react-fontawesome-svg-icon"
+import { DailyDataType } from "../../../helpers/query-daily-data"
+import { faBed, faHeartbeat, faPersonRunning } from "@fortawesome/free-solid-svg-icons"
+
+export default {
+    title: "Container/RelativeActivityToday",
+    component: RelativeActivityToday,
+    parameters: {
+        layout: 'fullscreen',
+    }
+} as ComponentMeta<typeof RelativeActivityToday>;
+
+const Template: ComponentStory<typeof RelativeActivityToday> = (args: RelativeActivityTodayProps) =>
+    <Layout colorScheme="auto">
+        <Card>
+            <RelativeActivityToday {...args} />
+        </Card>
+    </Layout>;
+
+export const Default = Template.bind({});
+Default.args = {
+    dataTypes: [{
+        dailyDataType: DailyDataType.Steps,
+        label: "Steps",
+        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
+        color: "rgba(255, 166, 102, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toLocaleString()
+        }
+    }, {
+        dailyDataType: DailyDataType.FitbitActiveMinutes,
+        label: "Active Minutes",
+        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
+        color: "rgba(255, 166, 102, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toString() + " minutes";
+        }
+    },
+    {
+        dailyDataType: DailyDataType.AppleHealthSleepMinutes,
+        label: "Sleep Time",
+        icon: <FontAwesomeSvgIcon icon={faBed} />,
+        color: "rgba(74, 144, 226, 1)",
+        formatter: function (number: number) {
+            var hours = Math.floor(number / 60);
+            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
+            return displayValue;
+        }
+    },
+    {
+        dailyDataType: DailyDataType.FitbitSleepMinutes,
+        label: "Sleep Time",
+        icon: <FontAwesomeSvgIcon icon={faBed} />,
+        color: "rgba(74, 144, 226, 1)",
+        formatter: function (number: number) {
+            var hours = Math.floor(number / 60);
+            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
+            return displayValue;
+        }
+    },
+    {
+        dailyDataType: DailyDataType.AppleHealthMaxHeartRate,
+        label: "Max Heart Rate",
+        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
+        color: "rgba(239, 132, 129, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toString() + " bpm";
+        }
+    },
+    {
+        dailyDataType: DailyDataType.FitbitElevatedHeartRateMinutes,
+        label: "Elevated Heart Rate Time",
+        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
+        color: "rgba(239, 132, 129, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toString() + " minutes";
+        }
+    }]
+}

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.stories.tsx
@@ -24,6 +24,68 @@ const Template: ComponentStory<typeof RelativeActivityToday> = (args: RelativeAc
 
 export const Default = Template.bind({});
 Default.args = {
+    previewState: "Default",
+    dataTypes: [{
+        dailyDataType: DailyDataType.Steps,
+        label: "Steps",
+        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
+        color: "rgba(255, 166, 102, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toLocaleString()
+        }
+    }, {
+        dailyDataType: DailyDataType.FitbitActiveMinutes,
+        label: "Active Minutes",
+        icon: <FontAwesomeSvgIcon icon={faPersonRunning} />,
+        color: "rgba(255, 166, 102, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toString() + " minutes";
+        }
+    },
+    {
+        dailyDataType: DailyDataType.AppleHealthSleepMinutes,
+        label: "Sleep Time",
+        icon: <FontAwesomeSvgIcon icon={faBed} />,
+        color: "rgba(74, 144, 226, 1)",
+        formatter: function (number: number) {
+            var hours = Math.floor(number / 60);
+            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
+            return displayValue;
+        }
+    },
+    {
+        dailyDataType: DailyDataType.FitbitSleepMinutes,
+        label: "Sleep Time",
+        icon: <FontAwesomeSvgIcon icon={faBed} />,
+        color: "rgba(74, 144, 226, 1)",
+        formatter: function (number: number) {
+            var hours = Math.floor(number / 60);
+            var displayValue = hours + "h " + Math.round(number - (hours * 60)) + "m";
+            return displayValue;
+        }
+    },
+    {
+        dailyDataType: DailyDataType.AppleHealthMaxHeartRate,
+        label: "Max Heart Rate",
+        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
+        color: "rgba(239, 132, 129, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toString() + " bpm";
+        }
+    },
+    {
+        dailyDataType: DailyDataType.FitbitElevatedHeartRateMinutes,
+        label: "Elevated Heart Rate Time",
+        icon: <FontAwesomeSvgIcon icon={faHeartbeat} />,
+        color: "rgba(239, 132, 129, 1)",
+        formatter: function (number: number) {
+            return Math.floor(number).toString() + " minutes";
+        }
+    }]
+}
+
+export const Live = Template.bind({});
+Live.args = {
     dataTypes: [{
         dailyDataType: DailyDataType.Steps,
         label: "Steps",

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
@@ -11,6 +11,7 @@ import "./RelativeActivityToday.css"
 
 export interface RelativeActivityTodayProps {
     dataTypes: RelativeActivityDataType[];
+    previewState?: "Default";
 }
 
 export interface RelativeActivityDataType {
@@ -25,6 +26,10 @@ export default function (props: RelativeActivityTodayProps) {
     let [dailyData, setDailyData] = useState<{ [key: string]: DailyDataQueryResult } | null>(null);
 
     function loadData() {
+        if (props.previewState === "Default") {
+            setDailyData({});
+            return;
+        };
         let today = new Date();
         let startDate = add(new Date(), { days: -31 });
         let promises = props.dataTypes.map(dataType => queryDailyData(dataType.dailyDataType, startDate, add(today, { days: 1 })));
@@ -58,7 +63,7 @@ export default function (props: RelativeActivityTodayProps) {
     let todayKey = getDayKey(new Date());
     props.dataTypes.forEach(dataType => {
         let data = dailyData![dataType.dailyDataType];
-        if (!data[todayKey]) {
+        if (!data || !data[todayKey]) {
             return;
         }
 
@@ -85,6 +90,26 @@ export default function (props: RelativeActivityTodayProps) {
             value: dataType.formatter(data[todayKey])
         });
     });
+
+    if (props.previewState === "Default") {
+        computedResults = [
+            {
+                dailyDataType: DailyDataType.Steps,
+                fillPercent: 0.7,
+                value: "3,995"
+            },
+            {
+                dailyDataType: DailyDataType.AppleHealthSleepMinutes,
+                fillPercent: 0.55,
+                value: "8h 12m"
+            },
+            {
+                dailyDataType: DailyDataType.AppleHealthMaxHeartRate,
+                fillPercent: 0.42,
+                value: "90 bpm"
+            }
+        ]
+    }
 
     if (!computedResults.length) {
         return null;

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
@@ -1,0 +1,105 @@
+import MyDataHelps from "@careevolution/mydatahelps-js";
+import { faBed, faChevronUp, faHeartbeat, faPersonRunning } from "@fortawesome/free-solid-svg-icons";
+import { add } from "date-fns";
+import React from "react";
+import { useEffect, useState } from "react";
+import { FontAwesomeSvgIcon } from "react-fontawesome-svg-icon";
+import getDayKey from "../../../helpers/get-day-key";
+import { DailyDataQueryResult, DailyDataType, queryDailyData } from "../../../helpers/query-daily-data";
+import { ActivityMeter } from "../../presentational";
+import "./RelativeActivityToday.css"
+
+export interface RelativeActivityTodayProps {
+    dataTypes: RelativeActivityDataType[];
+}
+
+export interface RelativeActivityDataType {
+    dailyDataType: string;
+    label: string;
+    icon: React.ReactElement;
+    color: string;
+    formatter: (number: number) => string;
+}
+
+export default function (props: RelativeActivityTodayProps) {
+    let [dailyData, setDailyData] = useState<{ [key: string]: DailyDataQueryResult } | null>(null);
+
+    function loadData() {
+        let today = new Date();
+        let startDate = add(new Date(), { days: -31 });
+        let promises = props.dataTypes.map(dataType => queryDailyData(dataType.dailyDataType, startDate, add(today, { days: 1 })));
+        Promise.all(promises).then(results => {
+            let resultsMap: { [key: string]: DailyDataQueryResult } = {};
+            results.forEach((result, index) => {
+                resultsMap[props.dataTypes[index].dailyDataType] = result;
+            });
+            setDailyData(resultsMap);
+        });
+    }
+
+    useEffect(() => {
+        loadData();
+        MyDataHelps.on("externalAccountSyncComplete", loadData);
+        MyDataHelps.on("applicationDidBecomeVisible", loadData);
+        return () => {
+            MyDataHelps.off("externalAccountSyncComplete", loadData);
+            MyDataHelps.off("applicationDidBecomeVisible", loadData);
+        }
+    }, []);
+
+    let computedResults: {
+        dailyDataType: string,
+        fillPercent: number,
+        value: string
+    }[] = [];
+
+    if (!dailyData) return null;
+
+    let todayKey = getDayKey(new Date());
+    props.dataTypes.forEach(dataType => {
+        let data = dailyData![dataType.dailyDataType];
+        if (!data[todayKey]) {
+            return;
+        }
+
+        let sumValues = 0;
+        let totalValues = 0;
+        for (var i = 1; i < 31; i++) {
+            let key = getDayKey(add(new Date(), { days: -i }));
+            if (data[key] !== undefined) {
+                sumValues += data[key];
+                totalValues++;
+            }
+        }
+
+        if (totalValues < 5) {
+            return;
+        }
+
+        let average = sumValues / totalValues;
+        let fillPercent = data[todayKey] / (average * 2);
+        if (fillPercent > 1) { fillPercent = 1; }
+        computedResults.push({
+            dailyDataType: dataType.dailyDataType,
+            fillPercent: fillPercent,
+            value: dataType.formatter(data[todayKey])
+        });
+    });
+
+    if (!computedResults.length) {
+        return null;
+    }
+
+    return <div className="mdhui-relative-activity-today">
+        {computedResults.map(c => {
+            let dataType = props.dataTypes.find(dt => dt.dailyDataType === c.dailyDataType)!;
+            return <ActivityMeter key={dataType.dailyDataType} className="mdhui-relative-activity-today-meter" label={dataType.label} value={c.value} fillPercent={c.fillPercent} averageFillPercent={0.5} icon={dataType.icon} color={dataType.color} />
+        })}
+        <div className="mdhui-relative-activity-average-marker">
+            <div>
+                <FontAwesomeSvgIcon icon={faChevronUp} />
+            </div>
+            30 day average
+        </div>
+    </div>
+}

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
@@ -6,12 +6,13 @@ import { useEffect, useState } from "react";
 import { FontAwesomeSvgIcon } from "react-fontawesome-svg-icon";
 import getDayKey from "../../../helpers/get-day-key";
 import { DailyDataQueryResult, DailyDataType, queryDailyData } from "../../../helpers/query-daily-data";
-import { ActivityMeter } from "../../presentational";
+import { ActivityMeter, CardTitle } from "../../presentational";
 import "./RelativeActivityToday.css"
 
 export interface RelativeActivityTodayProps {
     dataTypes: RelativeActivityDataType[];
     previewState?: "Default";
+    title?: string;
 }
 
 export interface RelativeActivityDataType {
@@ -116,6 +117,7 @@ export default function (props: RelativeActivityTodayProps) {
     }
 
     return <div className="mdhui-relative-activity-today">
+        {props.title && <CardTitle title={props.title} />}
         {computedResults.map(c => {
             let dataType = props.dataTypes.find(dt => dt.dailyDataType === c.dailyDataType)!;
             return <ActivityMeter key={dataType.dailyDataType} className="mdhui-relative-activity-today-meter" label={dataType.label} value={c.value} fillPercent={c.fillPercent} averageFillPercent={0.5} icon={dataType.icon} color={dataType.color} />

--- a/src/components/container/RelativeActivityToday/index.ts
+++ b/src/components/container/RelativeActivityToday/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RelativeActivityToday";


### PR DESCRIPTION
## Overview

This component can be used to visualize your activity today relative to your 30 day average.  

It takes a list of data types that you want it to display - for instance, your sleep or steps or other activity - queries the data, and displays an activity meter filled relative to your 30 day average.

![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/1643171/e9258d3f-becd-4a77-a0a5-6bafc3bf4972)

This kind of component could be useful for pacing, for instance - patients with ME/CFS or Long COVID may want to ensure their steps or other activity does not go that high.

If there is no data to display for an individual metric or not at least 5 days of data to calculate a 30 day average, it will hide the metric.  If there are no metrics that would be displayed, it will hide the entire component.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [X] MyDataHelps iOS app
- [X] MyDataHelps Android app
- [X] [MyDataHelps website](mydatahelps.org)

### Documentation
- [X] I have added relevant Storybook updates to this PR as well.
- [X] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner