### PR TITLE
Fix bugs with garmin sleep calculations

### DIFF
--- a/src/helpers/daily-data-providers/garmin-sleep.ts
+++ b/src/helpers/daily-data-providers/garmin-sleep.ts
@@ -1,7 +1,7 @@
 import { add, formatISO, parseISO } from "date-fns";
 import queryAllDeviceData from "./query-all-device-data";
 
-function querySleep(property: string, startDate: Date, endDate: Date, sumValues: boolean, divideBy?: number) {
+function querySleep(property: string, startDate: Date, endDate: Date, divideBy?: number) {
     return queryAllDeviceData({
         namespace: "Garmin",
         type: "Sleep",
@@ -24,10 +24,8 @@ function querySleep(property: string, startDate: Date, endDate: Date, sumValues:
                 value = value / divideBy;
             }
 
-            if (!data[dataKey]) {
+            if (!data[dataKey] || data[dataKey] < value) {
                 data[dataKey] = value;
-            } else if (sumValues) {
-                data[dataKey] += parseFloat(d.properties[property]);
             }
         });
         return data;
@@ -35,25 +33,25 @@ function querySleep(property: string, startDate: Date, endDate: Date, sumValues:
 }
 
 export function totalSleepMinutes(startDate: Date, endDate: Date) {
-    return querySleep("DurationInSeconds", startDate, endDate, true, 60);
+    return querySleep("DurationInSeconds", startDate, endDate, 60);
 }
 
 export function remSleepMinutes(startDate: Date, endDate: Date) {
-    return querySleep("RemSleepInSeconds", startDate, endDate, true, 60);
+    return querySleep("RemSleepInSeconds", startDate, endDate, 60);
 }
 
 export function deepSleepMinutes(startDate: Date, endDate: Date) {
-    return querySleep("DeepSleepDurationInSeconds", startDate, endDate, true, 60);
+    return querySleep("DeepSleepDurationInSeconds", startDate, endDate, 60);
 }
 
 export function lightSleepMinutes(startDate: Date, endDate: Date) {
-    return querySleep("LightSleepDurationInSeconds", startDate, endDate, true, 60);
+    return querySleep("LightSleepDurationInSeconds", startDate, endDate, 60);
 }
 
 export function awakeSleepMinutes(startDate: Date, endDate: Date) {
-    return querySleep("AwakeDurationInSeconds", startDate, endDate, true, 60);
+    return querySleep("AwakeDurationInSeconds", startDate, endDate, 60);
 }
 
 export function sleepScore(startDate: Date, endDate: Date) {
-    return querySleep("OverallSleepScore.Value", startDate, endDate, false);
+    return querySleep("OverallSleepScore.Value", startDate, endDate);
 }

--- a/src/helpers/daily-data-providers/garmin-sleep.ts
+++ b/src/helpers/daily-data-providers/garmin-sleep.ts
@@ -24,7 +24,7 @@ function querySleep(property: string, startDate: Date, endDate: Date, divideBy?:
                 value = value / divideBy;
             }
 
-            if (!data[dataKey] || data[dataKey] < value) {
+            if (!data[dataKey] || data[dataKey] > value) {
                 data[dataKey] = value;
             }
         });

--- a/src/helpers/query-daily-data.ts
+++ b/src/helpers/query-daily-data.ts
@@ -22,8 +22,6 @@ export function checkDailyDataAvailability(type: string, modifiedAfter?: Date) {
 
 export function queryDailyData(type: string, startDate: Date, endDate: Date) {
 	var dailyDataType = dailyDataTypes[type];
-	console.log(type);
-	console.log(dailyDataType);
 	return dailyDataType.provider(startDate, endDate).then(function (data) {
 		var result: DailyDataQueryResult = {};
 		while (startDate < endDate) {


### PR DESCRIPTION
## Overview

Garmin has a couple data idiosyncracies that I didn't account for.

It appears that Garmin can produce multiple sleep data points on a given night that overlap, e.g. 
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/1643171/2a59cf66-ad04-46d1-a469-3a6d275b3c3e)
This might just be a temporary artifact for the most recent night's sleep until Garmin syncs and removes the shorter sleep period.

To account for this state, however, I am now taking the max value.  

Previously I also missed dividing the value when we summed the values together which caused the sleep values to be massively inflated.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner