### PR TITLE
Updates to survey task list look / feel

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -19,7 +19,7 @@ customHeaders:
                 script-src 'self' 'unsafe-inline' ; 
                 object-src 'self'; 
                 style-src 'self' 'unsafe-inline' ; 
-                img-src 'self' data: mydatahelps.org mdhorg.ce.dev; 
+                img-src 'self' data: mydatahelps.org mdhorg.ce.dev rkstudio-customer-assets.s3.amazonaws.com; 
                 media-src 'self'; 
                 frame-src 'self'; 
                 font-src 'self'; 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.2.1-VB2.2",
+  "version": "2.2.1-VB2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.2.1-VB2.2",
+      "version": "2.2.1-VB2.3",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.2.1-VB2.1",
+  "version": "2.2.1-VB2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.2.1-VB2.1",
+      "version": "2.2.1-VB2.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.2.1-VB2.1",
+  "version": "2.2.1-VB2.2",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.2.1-VB2.2",
+  "version": "2.2.1-VB2.3",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/container/ProjectHeader/ProjectHeader.css
+++ b/src/components/container/ProjectHeader/ProjectHeader.css
@@ -4,6 +4,7 @@
     text-align: center;
     background: #FFF;
     border-bottom: solid 1px var(--mdhui-border-color-1);
+    line-height: normal;
 }
 
     .mdhui-project-header .logo

--- a/src/components/container/SurveyTaskList/SurveyTaskList.previewdata.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.previewdata.tsx
@@ -24,7 +24,7 @@ export var previewIncompleteTasks: SurveyTask[] =
 			"surveyDisplayName": "Pregnancy: Followup",
 			"surveyDescription": "3 minutes",
 			"status": "incomplete",
-			"hasSavedProgress": false,
+			"hasSavedProgress": true,
 			"dueDate": add(new Date(), { days: 0 }).toISOString(),
 			"insertedDate": "2022-03-14T19:13:48.283Z",
 			"modifiedDate": "2022-03-14T19:13:48.283Z",

--- a/src/components/container/SurveyTaskList/SurveyTaskList.stories.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.stories.tsx
@@ -22,7 +22,8 @@ Incomplete.args = {
 	limit: 3,
 	status: 'incomplete',
 	title: 'Incomplete Tasks',
-	previewState: "IncompleteTasks"
+	previewState: "IncompleteTasks",
+	variant: "singleCard"
 }
 
 export const Complete = Template.bind({});
@@ -30,5 +31,15 @@ Complete.args = {
 	limit: 3,
 	status: 'complete',
 	title: 'Completed Tasks',
-	previewState: "CompleteTasks"
+	previewState: "CompleteTasks",
+	variant: "singleCard"
+}
+
+export const Multicard = Template.bind({});
+Multicard.args = {
+	limit: 3,
+	status: 'incomplete',
+	title: 'Incomplete Tasks',
+	previewState: "IncompleteTasks",
+	variant: "multiCard"
 }

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -10,6 +10,7 @@ export interface SurveyTaskListProps {
 	status: SurveyTaskStatus,
 	limit?: number,
 	title?: string,
+	surveys?: string[],
 	onDetailLinkClick?: Function,
 	hideDueDate?: boolean,
 	previewState?: SurveyTaskListListPreviewState
@@ -47,7 +48,7 @@ export default function (props: SurveyTaskListProps) {
 		var loadData = function () {
 			var allTasks: SurveyTask[] = [];
 			var makeRequest = function (pageID: Guid | null) {
-				var parameters: SurveyTaskQueryParameters = { status: props.status }
+				var parameters: SurveyTaskQueryParameters = { status: props.status, surveyName: props.surveys }
 				if (pageID) {
 					parameters.pageID = pageID;
 				}

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -12,7 +12,6 @@ export interface SurveyTaskListProps {
 	title?: string,
 	surveys?: string[],
 	onDetailLinkClick?: Function,
-	hideDueDate?: boolean,
 	previewState?: SurveyTaskListListPreviewState
 	variant?: "noCard" | "singleCard" | "multiCard"
 }
@@ -29,7 +28,7 @@ export default function (props: SurveyTaskListProps) {
 		return () => {
 			MyDataHelps.off("applicationDidBecomeVisible", initialize);
 		}
-	}, []);
+	}, [props.previewState]);
 
 	function getSurveyTaskElement(task: SurveyTask) {
 		return <SingleSurveyTask key={task.id.toString()} task={task} disableClick={loading} />
@@ -105,7 +104,7 @@ export default function (props: SurveyTaskListProps) {
 					<div className="empty-message">{language["all-tasks-complete"]}</div>
 				}
 				{tasks?.slice(0, props.limit).map((task) =>
-					variant == "multiCard" ? <Card>{getSurveyTaskElement(task)}</Card> : getSurveyTaskElement(task)
+					variant == "multiCard" ? <Card key={task.id as string}>{getSurveyTaskElement(task)}</Card> : getSurveyTaskElement(task)
 				)}
 			</div>
 		</TaskListWrapper>

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -47,7 +47,10 @@ export default function (props: SurveyTaskListProps) {
 		var loadData = function () {
 			var allTasks: SurveyTask[] = [];
 			var makeRequest = function (pageID: Guid | null) {
-				var parameters: SurveyTaskQueryParameters = { status: props.status, surveyName: props.surveys }
+				var parameters: SurveyTaskQueryParameters = { status: props.status }
+				if (props.surveys) {
+					parameters.surveyName = props.surveys;
+				}
 				if (pageID) {
 					parameters.pageID = pageID;
 				}

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import "./SurveyTaskList.css"
 import MyDataHelps, { Guid, SurveyTask, SurveyTaskQueryParameters, SurveyTaskStatus } from "@careevolution/mydatahelps-js"
-import { CardTitle, LoadingIndicator, SingleSurveyTask } from '../../presentational'
+import { Card, CardTitle, LoadingIndicator, SingleSurveyTask } from '../../presentational'
 import parseISO from 'date-fns/parseISO'
 import { previewCompleteTasks, previewIncompleteTasks } from './SurveyTaskList.previewdata'
 import language from '../../../helpers/language'
@@ -13,6 +13,7 @@ export interface SurveyTaskListProps {
 	onDetailLinkClick?: Function,
 	hideDueDate?: boolean,
 	previewState?: SurveyTaskListListPreviewState
+	variant?: "noCard" | "singleCard" | "multiCard"
 }
 
 export type SurveyTaskListListPreviewState = "IncompleteTasks" | "CompleteTasks";
@@ -28,6 +29,10 @@ export default function (props: SurveyTaskListProps) {
 			MyDataHelps.off("applicationDidBecomeVisible", initialize);
 		}
 	}, []);
+
+	function getSurveyTaskElement(task: SurveyTask) {
+		return <SingleSurveyTask key={task.id.toString()} task={task} disableClick={loading} />
+	}
 
 	function initialize() {
 		if (props.previewState == "IncompleteTasks") {
@@ -85,20 +90,27 @@ export default function (props: SurveyTaskListProps) {
 		return null;
 	}
 
+	let variant = props.variant ?? "noCard";
 	return (
-		<div className="mdhui-survey-task-list">
-			{props.title &&
-				<CardTitle title={props.title} detailLinkText={props.onDetailLinkClick ? language["view-all"] + " (" + (tasks?.length ?? 0) + ")" : undefined} onDetailClick={props.onDetailLinkClick} />
-			}
-			{loading && !tasks &&
-				<LoadingIndicator />
-			}
-			{!tasks?.length && !loading &&
-				<div className="empty-message">{language["all-tasks-complete"]}</div>
-			}
-			{tasks?.slice(0, props.limit).map((task) =>
-				<SingleSurveyTask key={task.id.toString()} task={task} disableClick={loading} hideDueDate={props.hideDueDate} />
-			)}
-		</div>
+		<TaskListWrapper card={variant == "singleCard"}>
+			<div className="mdhui-survey-task-list">
+				{props.title &&
+					<CardTitle title={props.title} detailLinkText={props.onDetailLinkClick ? language["view-all"] + " (" + (tasks?.length ?? 0) + ")" : undefined} onDetailClick={props.onDetailLinkClick} />
+				}
+				{loading && !tasks &&
+					<LoadingIndicator />
+				}
+				{!tasks?.length && !loading &&
+					<div className="empty-message">{language["all-tasks-complete"]}</div>
+				}
+				{tasks?.slice(0, props.limit).map((task) =>
+					variant == "multiCard" ? <Card>{getSurveyTaskElement(task)}</Card> : getSurveyTaskElement(task)
+				)}
+			</div>
+		</TaskListWrapper>
 	);
+}
+
+function TaskListWrapper(props: { children?: React.ReactNode, card: boolean }) {
+	return props.card ? <Card>{props.children}</Card> : <>{props.children}</>;
 }

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.css
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.css
@@ -6,6 +6,9 @@
     grid-column-gap: 16px;
     align-items: center;
     width: 100%;
+    display: flex;
+    justify-content: space-between;
+    box-sizing: border-box;
 }
 
     .mdhui-single-survey-task .status-icon

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -68,7 +68,7 @@ export default function (props: SingleSurveyTaskProps) {
 				</div>
 				<div>
 					<Button variant="light" onClick={() => { }}>
-						{!props.task.hasSavedProgress ? language["start"] : language["result"]}
+						{!props.task.hasSavedProgress ? language["start"] : language["resume"]}
 					</Button>
 				</div>
 			</div>

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -68,7 +68,7 @@ export default function (props: SingleSurveyTaskProps) {
 				</div>
 				<div>
 					<Button variant="light" onClick={() => { }}>
-						{!props.task.hasSavedProgress ? "Start" : "Resume"}
+						{!props.task.hasSavedProgress ? language["start"] : language["result"]}
 					</Button>
 				</div>
 			</div>

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -2,10 +2,7 @@ import React from 'react'
 import "./SingleSurveyTask.css"
 import MyDataHelps, { SurveyTask } from "@careevolution/mydatahelps-js"
 import { IconDefinition } from '@fortawesome/fontawesome-common-types';
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight'
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons/faCircleCheck'
-import { faCircleHalfStroke } from '@fortawesome/free-solid-svg-icons/faCircleHalfStroke'
-import { faCircle } from '@fortawesome/free-regular-svg-icons/faCircle'
 import formatRelative from 'date-fns/formatRelative'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import parseISO from 'date-fns/parseISO'
@@ -15,12 +12,11 @@ import language from '../../../helpers/language'
 import { enUS, es } from 'date-fns/locale'
 import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
 import '@fortawesome/fontawesome-svg-core/styles.css';
-import UnstyledButton from '../UnstyledButton';
+import Button from '../Button';
 
 export interface SingleSurveyTaskProps {
 	task: SurveyTask,
 	descriptionIcon?: IconDefinition,
-	hideDueDate?: boolean,
 	disableClick?: boolean
 }
 
@@ -62,38 +58,32 @@ export default function (props: SingleSurveyTaskProps) {
 
 	if (props.task.status == 'incomplete') {
 		return (
-			<UnstyledButton className="mdhui-single-survey-task incomplete" onClick={() => startSurvey(props.task.surveyName!)}>
-				<div className="status-icon">
-					{props.task.hasSavedProgress &&
-						<FontAwesomeSvgIcon icon={faCircleHalfStroke} />
-					}
-					{!props.task.hasSavedProgress &&
-						<FontAwesomeSvgIcon icon={faCircle} />
-					}
-				</div>
+			<div className="mdhui-single-survey-task incomplete" onClick={() => startSurvey(props.task.surveyName!)}>
 				<div>
 					<div className="survey-name">{props.task.surveyDisplayName}</div>
 					<div className="survey-description"><>{props.descriptionIcon} {props.task.surveyDescription}</></div>
-					{!props.hideDueDate && dueDateString &&
-					<div className={"due-date " + dueDateIntent}>{dueDateString}</div>
+					{dueDateString &&
+						<div className={"due-date " + dueDateIntent}>{dueDateString}</div>
 					}
 				</div>
-				<div className="indicator">
-					<FontAwesomeSvgIcon icon={faChevronRight} />
+				<div>
+					<Button variant="light" onClick={() => { }}>
+						{!props.task.hasSavedProgress ? "Start" : "Resume"}
+					</Button>
 				</div>
-			</UnstyledButton>
+			</div>
 		);
 	}
 
 	if (props.task.status == 'complete' && props.task.endDate) {
 		return (
 			<div className="mdhui-single-survey-task complete">
-				<div className="status-icon">
-					<FontAwesomeSvgIcon icon={faCircleCheck} />
-				</div>
 				<div>
 					<div className="survey-name">{props.task.surveyDisplayName}</div>
-					<div className="completed-date">{language["completed"]} {formatRelative(parseISO(props.task.endDate), new Date(), {locale: locale})}</div>
+					<div className="completed-date">{language["completed"]} {formatRelative(parseISO(props.task.endDate), new Date(), { locale: locale })}</div>
+				</div>
+				<div className="status-icon">
+					<FontAwesomeSvgIcon icon={faCircleCheck} />
 				</div>
 			</div>
 		)

--- a/src/components/view/HomeView/HomeView.tsx
+++ b/src/components/view/HomeView/HomeView.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Layout, StatusBarBackground, ProjectHeader, Card, MostRecentNotification, SurveyTaskList, ConnectFitbit, ConnectGarmin, ProjectSupport} from "../../.."
+import { Layout, StatusBarBackground, ProjectHeader, Card, MostRecentNotification, SurveyTaskList, ConnectFitbit, ConnectGarmin, ProjectSupport } from "../../.."
 import MyDataHelps, { NotificationType } from "@careevolution/mydatahelps-js"
 import language from "../../../helpers/language"
 import ConnectEhr from "../../container/ConnectEhr";
@@ -44,9 +44,9 @@ export default function (props: HomeViewProps) {
 
 	return (
 		<Layout colorScheme={props.colorScheme ?? "auto"}>
-			<StatusBarBackground color='#FFFFFF'  />
+			<StatusBarBackground color='#FFFFFF' />
 			<ProjectHeader previewState={props.preview ? "Default" : undefined} />
-			<AppDownload previewDevicePlatform={props.preview ? 'Web' : undefined} previewProjectPlatforms={props.preview ? ['Web', 'Android', 'iOS'] : undefined}/>
+			<AppDownload previewDevicePlatform={props.preview ? 'Web' : undefined} previewProjectPlatforms={props.preview ? ['Web', 'Android', 'iOS'] : undefined} />
 			<Card>
 				<MostRecentNotification
 					notificationType={notificationType}
@@ -54,16 +54,15 @@ export default function (props: HomeViewProps) {
 					previewState={props.preview ? "Default" : undefined}
 					hideAfterHours={props.notificationHideAfterHours} />
 			</Card>
-			<Card>
-				<SurveyTaskList
-					status="incomplete"
-					limit={3}
-					title={language["tasks"]}
-					onDetailLinkClick={props.tasksViewUrl ? () => viewAllTasks() : undefined}
-					hideDueDate={props.hideTaskDueDate}
-					previewState={props.preview ? "IncompleteTasks" : undefined}
-				/>
-			</Card>
+			<SurveyTaskList
+				variant='singleCard'
+				status="incomplete"
+				limit={3}
+				title={language["tasks"]}
+				onDetailLinkClick={props.tasksViewUrl ? () => viewAllTasks() : undefined}
+				hideDueDate={props.hideTaskDueDate}
+				previewState={props.preview ? "IncompleteTasks" : undefined}
+			/>
 			<Card>
 				<ConnectFitbit title="Fitbit" previewState={props.preview ? "notConnected" : undefined} />
 			</Card>

--- a/src/components/view/SurveyTasksView/SurveyTasksView.tsx
+++ b/src/components/view/SurveyTasksView/SurveyTasksView.tsx
@@ -25,22 +25,20 @@ export default function (props: SurveyTasksViewProps) {
 				<StatusBarBackground />
 			}
 			{!props.hideIncompleteTasks &&
-				<Card>
-					<SurveyTaskList
-						title={language["incomplete-tasks"]}
-						status="incomplete"
-						hideDueDate={props.hideDueDate}
-						previewState={props.preview ? "IncompleteTasks" : undefined} />
-				</Card>
+				<SurveyTaskList
+					variant='multiCard'
+					title={language["incomplete-tasks"]}
+					status="incomplete"
+					hideDueDate={props.hideDueDate}
+					previewState={props.preview ? "IncompleteTasks" : undefined} />
 			}
 			{!props.hideCompleteTasks &&
-				<Card>
-					<SurveyTaskList
-						title={language["completed-tasks"]}
-						status="complete"
-						hideDueDate={props.hideDueDate}
-						previewState={props.preview ? "CompleteTasks" : undefined} />
-				</Card>
+				<SurveyTaskList
+					variant='multiCard'
+					title={language["completed-tasks"]}
+					status="complete"
+					hideDueDate={props.hideDueDate}
+					previewState={props.preview ? "CompleteTasks" : undefined} />
 			}
 		</Layout>
 	)

--- a/src/helpers/strings-en.ts
+++ b/src/helpers/strings-en.ts
@@ -70,7 +70,9 @@
     "app-download-title": "Next: Download the App",
     "app-download-subtitle": "Downloading the MyDataHelps app makes it even easier to participate in @@PROJECT_NAME@@.",
     "app-download-google-play-link-alt": "Download on the Google Play Store",
-    "app-download-app-store-link-alt": "Download on the Apple App Store"
+    "app-download-app-store-link-alt": "Download on the Apple App Store",
+    "start": "Start",
+    "resume": "Resume"
 };
 
 export default strings;

--- a/src/helpers/strings-es.ts
+++ b/src/helpers/strings-es.ts
@@ -70,7 +70,9 @@
     "app-download-title": "Siguiente: Descarga la aplicación",
     "app-download-subtitle": "La descarga de la aplicación MyDataHelps hace que sea aún más fácil participar en @@PROJECT_NAME@@.",
     "app-download-google-play-link-alt": "Descargar en Google Play Store",
-    "app-download-app-store-link-alt": "Descargar en la tienda de aplicaciones de Apple"
+    "app-download-app-store-link-alt": "Descargar en la tienda de aplicaciones de Apple",
+    "start": "Inicio",
+    "resume": "Continuar"
 };
 
 export default strings;


### PR DESCRIPTION
## Overview

This updates the look / feel of the survey tasks / survey task list a bit based on some recent designs and adds some more options.  

The individual survey tasks no longer have the checkmark on the left side; instead there is a button to start/resume that is more explicit and user friendly:
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/1643171/2db0a737-cd86-43dd-ba76-6cf77c1b00e1)
Start changes to "resume" once progress has been saved for a task.  Completed tasks display the checkmark:
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/1643171/c3bd065e-a2db-4e16-a273-24e1e602da2c)

Additionally, there are now a few variants/options for SurveyTaskList.

- "noCard" is the default to preserve backwards compatibility; basically it is the same as today
- "singleCard" means that the task list will be embedded in a card
- "multiCard" expands the task list so each task has it's own card, and this is now what is used by default on the survey tasks view to give it more breathing room:
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/1643171/a5516740-76b9-4095-807c-a88c4eef9f56)

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [X] [MyDataHelps website](mydatahelps.org)

### Documentation
- [X] I have added relevant Storybook updates to this PR as well.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner