### PR TITLE
Update Image CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ To run Storybook previews with data from one of your test MyDataHelps participan
 -----
 PARTICIPANT_ACCESS_TOKEN=05e211e4df46ca7537e064bde44148a7 
 ```
-4. Run `npm run storybook` to view the storybook.
+4. Run `npm ci` to install dependencies.
+5. Run `npm run storybook` to view the storybook.
 
-If you have issues getting storybook to run, particuarly around the NODE_OPTIONS being used, try upgrading Node to the latest version.
+If you have issues getting storybook to run, particularly around the NODE_OPTIONS being used, try upgrading Node to the latest version.
 
 ## Components
 
@@ -63,7 +64,7 @@ Presentational components do NOT fetch data to populate themselves.  They are th
 
 ### Container Components
 
-Container components fetch data via the MyDataHelps.js SDK.  These components will only function if used in a view inside MyDataHelps or via manually setting an access token into the SDK.  
+Container components fetch data via the MyDataHelps.js SDK.  These components will only function if used in a view inside MyDataHelps or via manually passing an access token to the SDK.  
 
 ### Views
 

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -19,7 +19,7 @@ customHeaders:
                 script-src 'self' 'unsafe-inline' ; 
                 object-src 'self'; 
                 style-src 'self' 'unsafe-inline' ; 
-                img-src 'self' data: mydatahelps.org mdhorg.ce.dev; 
+                img-src 'self' data: mydatahelps.org mdhorg.ce.dev rkstudio-customer-assets.s3.amazonaws.com; 
                 media-src 'self'; 
                 frame-src 'self'; 
                 font-src 'self'; 


### PR DESCRIPTION
## Overview

Some of the example stories use images from the assets bucket, such as this one: https://ui.mydatahelps.org/?path=/docs/surveystep-celebrationstep--docs

They're showing up as broken links due to being blocked by the CSP. I added that site to the CSP, and also made a few typo/wording tweaks to the readme.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

Allowing images from our internal asset bucket does not introduce any new security risks.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

The above are n/a. Must be tested with the amplify deployment of the storybook site.

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

No documentation needed

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner