### PR TITLE
Adjust cicd workflows to publish release and snapshot/prerelease tags slightly differently.

### DIFF
--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -1,10 +1,11 @@
-name: Publish to npmjs
+name: Publish to npmjs and ProGet (releases)
 
 on:
   workflow_dispatch:
   push:
     tags:
       - '*.*.*'
+      - "!*-*"
 
 permissions:
   id-token: write

--- a/.github/workflows/cicd-snapshot.yml
+++ b/.github/workflows/cicd-snapshot.yml
@@ -1,0 +1,35 @@
+name: Publish to npmjs and ProGet (snapshots / prereleases)
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*-*"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "17.3.0"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Build
+        run: npm run rollup
+      - name: Deploy to npmjs
+        run: |
+          npm config set @careevolution:registry=https://registry.npmjs.org/
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPMJS_TOKEN }}
+          npm publish --tag next --access public
+      - name: Deploy to ProGet
+        run: |
+          echo "@careevolution:registry=https://proget.careevolution.com/npm/npm/" > .npmrc
+          npm config set @careevolution:registry=https://proget.careevolution.com/npm/npm/
+          npm config set //proget.careevolution.com/npm/npm/:_authToken ${{ secrets.PROGET_TOKEN }}
+          npm publish --tag next

--- a/Snapshot.ps1
+++ b/Snapshot.ps1
@@ -1,0 +1,12 @@
+﻿$branch= &git rev-parse --abbrev-ref HEAD
+
+if($branch -eq "main"){
+    throw 'Cannot snapshot the main branch'
+}
+
+$branch = ($branch -split "/")[-1]
+
+$newVersion = npm version prerelease --preid $branch
+echo $newVersion
+git push
+git push origin $newVersion


### PR DESCRIPTION
## Overview

This change is necessary to ensure that snapshot/pre-release tags do not result in populating the `latest` version of the library. Otherwise, feature branch pre-releases can get picked up as the `latest` version.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- This change adds a further limitation to publishing to help ensure that feature branch pre-releases are not picked up as the `latest` version of the library from npm.

## Checklist

### Testing

This change is related to build/deploy config, not the app functionality itself.  Testing of the build/deploy config will be performed as soon as changes are available on `main`.

### Documentation

N/A - Other than a possible update to the README to describe how to use the `Snapshot.ps1` script.
