### PR TITLE
Support "innerRef" property on most components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.5.0",
+  "version": "2.5.1-InnerRef.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.5.0",
+      "version": "2.5.1-InnerRef.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.5.0",
+  "version": "2.5.1-InnerRef.0",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/container/AppDownload/AppDownload.tsx
+++ b/src/components/container/AppDownload/AppDownload.tsx
@@ -13,6 +13,7 @@ import language from "../../../helpers/language";
 export interface AppDownloadProps {
 	previewProjectPlatforms?: string[]
 	previewDevicePlatform?: string;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: AppDownloadProps) {
@@ -35,7 +36,7 @@ export default function (props: AppDownloadProps) {
 	}
 
 	return (
-		<div className="mdhui-app-download">
+		<div className="mdhui-app-download" ref={props.innerRef}>
 			<PlatformSpecificContent platforms={['Web']} previewDevicePlatform={props.previewDevicePlatform}>
 				<Card>
 					<div className="mdhui-app-download-title">{language('app-download-title')}</div>

--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -19,6 +19,7 @@ export interface ConnectDeviceProps {
 	previewState?: ConnectDevicePreviewState,
 	disabledBehavior?: 'hide' | 'displayError',
 	dataCollectionProperty:	string 
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ConnectDevicePreviewState = ExternalAccountStatus | "notConnected" | "notEnabled";
@@ -112,7 +113,7 @@ export default function (props: ConnectDeviceProps) {
 	}
 
 	return (
-		<div className="mdhui-connect-device">
+		<div className="mdhui-connect-device" ref={props.innerRef}>
 			{props.title &&
 				<CardTitle title={props.title} />
 			}

--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -103,7 +103,7 @@ export default function (props: ConnectDeviceProps) {
 	if (!deviceEnabled) {
 		if (props.disabledBehavior == 'displayError' && !loading) {
 			return (
-				<div className="mdhui-connect-device">
+				<div className="mdhui-connect-device" ref={props.innerRef}>
 					<div className="content">{props.title} is not enabled for this project.</div>
 				</div>
 			);

--- a/src/components/container/ConnectEhr/ConnectEhr.css
+++ b/src/components/container/ConnectEhr/ConnectEhr.css
@@ -5,7 +5,6 @@
     text-align: left;
     border: none;
     font-size: 1em;
-    line-height: 1.2em;
     cursor: pointer;
 }
 

--- a/src/components/container/ConnectEhr/ConnectEhr.tsx
+++ b/src/components/container/ConnectEhr/ConnectEhr.tsx
@@ -15,6 +15,7 @@ export interface ConnectEhrProps {
 	previewState?: ConnectEhrPreviewState,
 	disabledBehavior?: 'hide' | 'displayError'
 	bottomBorder?: boolean
+	innerRef?: React.Ref<HTMLButtonElement>
 }
 
 export type ConnectEhrApplicationUrl = "preview" | string;
@@ -95,7 +96,7 @@ export default function (props: ConnectEhrProps) {
 	}
 
 	return (
-		<Action bottomBorder={props.bottomBorder} title={language('connect-ehr-title-prefix') + language('connect-ehr-title-providers') + language('connect-ehr-title-divider') + language('connect-ehr-title-health-plans')} className="mdhui-connect-ehr" onClick={() => connectToEhr()}>
+		<Action innerRef={props.innerRef} bottomBorder={props.bottomBorder} title={language('connect-ehr-title-prefix') + language('connect-ehr-title-providers') + language('connect-ehr-title-divider') + language('connect-ehr-title-health-plans')} className="mdhui-connect-ehr" onClick={() => connectToEhr()}>
 			{connected
 				? <>
 					<div className="connection-status">

--- a/src/components/container/ConnectEhr/ConnectEhr.tsx
+++ b/src/components/container/ConnectEhr/ConnectEhr.tsx
@@ -15,7 +15,7 @@ export interface ConnectEhrProps {
 	previewState?: ConnectEhrPreviewState,
 	disabledBehavior?: 'hide' | 'displayError'
 	bottomBorder?: boolean
-	innerRef?: React.Ref<HTMLButtonElement>
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ConnectEhrApplicationUrl = "preview" | string;
@@ -82,7 +82,7 @@ export default function (props: ConnectEhrProps) {
 	if (!ehrEnabled) {
 		if (props.disabledBehavior == 'displayError') {
 			return (
-				<div className="mdhui-connect-ehr">
+				<div ref={props.innerRef} className="mdhui-connect-ehr">
 					<div className="error-content">{language("connect-ehr-not-enabled")}</div>
 				</div>
 			);
@@ -96,23 +96,25 @@ export default function (props: ConnectEhrProps) {
 	}
 
 	return (
-		<Action innerRef={props.innerRef} bottomBorder={props.bottomBorder} title={language('connect-ehr-title-prefix') + language('connect-ehr-title-providers') + language('connect-ehr-title-divider') + language('connect-ehr-title-health-plans')} className="mdhui-connect-ehr" onClick={() => connectToEhr()}>
-			{connected
-				? <>
-					<div className="connection-status">
-						{needsAttention
-							? <div className="warning">
-								<FontAwesomeSvgIcon icon={faTriangleExclamation} /> {language("connect-ehr-needs-attention")}
-							</div>
-							: <div className="success">
-								<FontAwesomeSvgIcon icon={faCheckCircle} /> {language("connect-ehr-connected")}
-							</div>
-						}
-					</div>
-					<div className="content">{language("connect-ehr-text-connected").replace("@@PROJECT_NAME@@", projectName as any)}</div>
-				</>
-				: <div className="content">{language("connect-ehr-text").replace("@@PROJECT_NAME@@", projectName as any)}</div>
-			}
-		</Action>
+		<div ref={props.innerRef} className="mdhui-connect-ehr">
+			<Action bottomBorder={props.bottomBorder} title={language('connect-ehr-title-prefix') + language('connect-ehr-title-providers') + language('connect-ehr-title-divider') + language('connect-ehr-title-health-plans')} onClick={() => connectToEhr()}>
+				{connected
+					? <>
+						<div className="connection-status">
+							{needsAttention
+								? <div className="warning">
+									<FontAwesomeSvgIcon icon={faTriangleExclamation} /> {language("connect-ehr-needs-attention")}
+								</div>
+								: <div className="success">
+									<FontAwesomeSvgIcon icon={faCheckCircle} /> {language("connect-ehr-connected")}
+								</div>
+							}
+						</div>
+						<div className="content">{language("connect-ehr-text-connected").replace("@@PROJECT_NAME@@", projectName as any)}</div>
+					</>
+					: <div className="content">{language("connect-ehr-text").replace("@@PROJECT_NAME@@", projectName as any)}</div>
+				}
+			</Action>
+		</div>
 	);
 }

--- a/src/components/container/ConnectFitbit/ConnectFitbit.tsx
+++ b/src/components/container/ConnectFitbit/ConnectFitbit.tsx
@@ -7,6 +7,7 @@ export interface ConnectFitbitProps {
 	fitbitProviderID?: number,
 	previewState?: ConnectFitbitPreviewState,
 	disabledBehavior?: 'hide' | 'displayError'
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ConnectFitbitPreviewState = ExternalAccountStatus | "notConnected" | "notEnabled";
@@ -23,6 +24,6 @@ export default function(props: ConnectFitbitProps) {
 		return fitbitProviderID;
 	}
 	
-	return (<ConnectDevice title="Fitbit" providerName="Fitbit" dataCollectionProperty='fitbitEnabled' providerIDCallback={getFitbitProviderID} previewState={props.previewState} disabledBehavior={props.disabledBehavior} />);
+	return (<ConnectDevice innerRef={props.innerRef} title="Fitbit" providerName="Fitbit" dataCollectionProperty='fitbitEnabled' providerIDCallback={getFitbitProviderID} previewState={props.previewState} disabledBehavior={props.disabledBehavior} />);
   }
 

--- a/src/components/container/ConnectGarmin/ConnectGarmin.tsx
+++ b/src/components/container/ConnectGarmin/ConnectGarmin.tsx
@@ -7,6 +7,7 @@ export interface ConnectGarminProps {
 	garminProviderID?: number,
 	previewState?: ConnectGarminPreviewState,
 	disabledBehavior?: 'hide' | 'displayError'
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ConnectGarminPreviewState = ExternalAccountStatus | "notConnected" | "notEnabled";
@@ -23,5 +24,5 @@ export default function(props: ConnectGarminProps) {
 		return garminProviderID;
 	}
 	
-	return (<ConnectDevice title="Garmin" providerName="Garmin" dataCollectionProperty='garminEnabled' providerIDCallback={getGarminProviderID} previewState={props.previewState} disabledBehavior={props.disabledBehavior} />);
+	return (<ConnectDevice innerRef={props.innerRef} title="Garmin" providerName="Garmin" dataCollectionProperty='garminEnabled' providerIDCallback={getGarminProviderID} previewState={props.previewState} disabledBehavior={props.disabledBehavior} />);
   }

--- a/src/components/container/ConnectedDevices/ConnectedDevices.tsx
+++ b/src/components/container/ConnectedDevices/ConnectedDevices.tsx
@@ -20,6 +20,7 @@ export interface ConnectedDevicesProps {
 	providerNamespace: DeviceDataNamespace;
 	previewState?: ConnectedDevicesPreviewState;
 	previewData: DeviceDataPoint[]
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ConnectedDevicesPreviewState = "notEnabled" | "notConnected" | "connected";
@@ -63,7 +64,7 @@ export default function (props: ConnectedDevicesProps) {
 
 	var locale = MyDataHelps.getCurrentLanguage().toLowerCase().startsWith("es") ? es : enUS;
 	return (
-		<div className="mdhui-connected-devices">
+		<div className="mdhui-connected-devices" ref={props.innerRef}>
 			<CardTitle title={props.providerName+ " " + language("devices")} />
 			{connectedDevices.map((device) =>
 				<div key={device.id.toString()} className="connected-device">

--- a/src/components/container/DailyDataChart/DailyDataChart.tsx
+++ b/src/components/container/DailyDataChart/DailyDataChart.tsx
@@ -21,7 +21,7 @@ export interface DailyDataChartProps {
     options?: LineChartOptions | BarChartOptions | AreaChartOptions
     hideIfNoData?: boolean
     previewDataProvider?: DailyDataProvider
-	innerRef?: React.Ref<HTMLDivElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 export interface LineChartOptions {
@@ -39,7 +39,7 @@ export interface AreaChartOptions {
 }
 
 function getDefaultIntervalStart(intervalType: "Week" | "Month", weekStartsOn?: WeekStartsOn) {
-    let intervalStart:Date;
+    let intervalStart: Date;
     if (intervalType === "Week") {
         intervalStart = getWeekStart(weekStartsOn);
     } else {
@@ -81,7 +81,7 @@ export default function DailyDataChart(props: DailyDataChartProps) {
     }
 
     useEffect(() => {
-        function checkAvailability(){
+        function checkAvailability() {
             if (props.previewDataProvider) {
                 setHasAnyData(true);
                 return;
@@ -155,7 +155,7 @@ export default function DailyDataChart(props: DailyDataChartProps) {
             return <text className={isToday(currentDate) ? "today" : ""} fill="var(--mdhui-text-color-2)" x={x} y={y + 15} textAnchor="middle" fontSize="12">{value}</text>;
         } else {
             let currentDate = intervalStart;
-            let dayOfWeek:string = "";
+            let dayOfWeek: string = "";
             for (let i = 0; i < 7; i++) {
                 if (currentDate.getDate() == value) {
                     dayOfWeek = format(currentDate, "EEEEEE");

--- a/src/components/container/DailyDataChart/DailyDataChart.tsx
+++ b/src/components/container/DailyDataChart/DailyDataChart.tsx
@@ -21,6 +21,7 @@ export interface DailyDataChartProps {
     options?: LineChartOptions | BarChartOptions | AreaChartOptions
     hideIfNoData?: boolean
     previewDataProvider?: DailyDataProvider
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export interface LineChartOptions {
@@ -207,7 +208,7 @@ export default function DailyDataChart(props: DailyDataChartProps) {
         return null;
     }
 
-    return <div className="mdhui-daily-data-chart">
+    return <div className="mdhui-daily-data-chart" ref={props.innerRef}>
         {props.title &&
             <CardTitle title={props.title}></CardTitle>
         }

--- a/src/components/container/DeviceDataMonthChart/DeviceDataMonthChart.tsx
+++ b/src/components/container/DeviceDataMonthChart/DeviceDataMonthChart.tsx
@@ -17,6 +17,7 @@ export interface DeviceDataMonthChartProps {
 	title?: string,
 	previewState?: DeviceDataMonthChartPreviewState,
 	onDataDetected?: Function
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export interface DeviceDataChartLine {
@@ -214,7 +215,7 @@ export default function (props: DeviceDataMonthChartProps) {
 
 	var average = calculateAverage();
 	return (
-		<div className="mdhui-device-data-month-chart">
+		<div className="mdhui-device-data-month-chart" ref={props.innerRef}>
 			{props.title &&
 				<div className="title">
 					{props.title}

--- a/src/components/container/ExternalAccountList/ExternalAccountList.tsx
+++ b/src/components/container/ExternalAccountList/ExternalAccountList.tsx
@@ -7,6 +7,7 @@ export interface ExternalAccountListProps {
     externalAccountProviderCategories?: string[];
     previewState?: NotificationListPreviewState;
     onExternalAccountsLoaded?: (accounts: ExternalAccount[]) => void;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type NotificationListPreviewState = "Default"
@@ -61,7 +62,7 @@ export default function (props: ExternalAccountListProps) {
     }, []);
 
     return (
-        <div className="mdhui-external-account-list">
+        <div ref={props.innerRef} className="mdhui-external-account-list">
             {externalAccounts && externalAccounts.map((externalAccount) =>
                 <Card key={externalAccount.id.toString() + externalAccount.lastRefreshDate}>
                     <SingleExternalAccount

--- a/src/components/container/ExternalAccountList/ExternalAccountList.tsx
+++ b/src/components/container/ExternalAccountList/ExternalAccountList.tsx
@@ -1,13 +1,13 @@
-import React, {useEffect, useState} from 'react'
-import MyDataHelps, {ExternalAccount} from '@careevolution/mydatahelps-js';
-import {Card, LoadingIndicator, SingleExternalAccount} from '../../presentational'
-import {previewExternalAccounts} from './ExternalAccountList.previewdata'
+import React, { useEffect, useState } from 'react'
+import MyDataHelps, { ExternalAccount } from '@careevolution/mydatahelps-js';
+import { Card, LoadingIndicator, SingleExternalAccount } from '../../presentational'
+import { previewExternalAccounts } from './ExternalAccountList.previewdata'
 
 export interface ExternalAccountListProps {
     externalAccountProviderCategories?: string[];
     previewState?: NotificationListPreviewState;
     onExternalAccountsLoaded?: (accounts: ExternalAccount[]) => void;
-	innerRef?: React.Ref<HTMLDivElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type NotificationListPreviewState = "Default"
@@ -68,11 +68,11 @@ export default function (props: ExternalAccountListProps) {
                     <SingleExternalAccount
                         externalAccount={externalAccount}
                         onAccountRemoved={(account: ExternalAccount) => onAccountRemoved(account)}
-                        onReconnectAccount={(account: ExternalAccount) => reconnectAccount(account)}/>
+                        onReconnectAccount={(account: ExternalAccount) => reconnectAccount(account)} />
                 </Card>
             )}
             {loading &&
-            <LoadingIndicator/>
+                <LoadingIndicator />
             }
         </div>
     );

--- a/src/components/container/ExternalAccountsLoadingIndicator/ExternalAccountsLoadingIndicator.tsx
+++ b/src/components/container/ExternalAccountsLoadingIndicator/ExternalAccountsLoadingIndicator.tsx
@@ -11,6 +11,7 @@ import language from "../../../helpers/language";
 export interface ExternalAccountsLoadingIndicatorProps {
     previewState?: "externalAccountsFetchingData" | "externalAccountsLoaded"
     externalAccountCategories?: string[];
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 let previewStateAccounts: ExternalAccount[] = [{
@@ -89,7 +90,7 @@ export default function (props: ExternalAccountsLoadingIndicatorProps) {
 
     if (!anyRefreshingAccounts) return null;
 
-    return <div className="mdhui-external-accounts-loading-indicator">
+    return <div ref={props.innerRef} className="mdhui-external-accounts-loading-indicator">
         <LoadingIndicator variant="inline" />
         <span className="mdhui-external-accounts-loading-indicator-message">{language("external-account-fetching-data")}</span>
     </div>

--- a/src/components/container/ExternalAccountsLoadingIndicator/ExternalAccountsLoadingIndicator.tsx
+++ b/src/components/container/ExternalAccountsLoadingIndicator/ExternalAccountsLoadingIndicator.tsx
@@ -11,7 +11,7 @@ import language from "../../../helpers/language";
 export interface ExternalAccountsLoadingIndicatorProps {
     previewState?: "externalAccountsFetchingData" | "externalAccountsLoaded"
     externalAccountCategories?: string[];
-	innerRef?: React.Ref<HTMLDivElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 let previewStateAccounts: ExternalAccount[] = [{

--- a/src/components/container/ExternalAccountsPreview/ExternalAccountsPreview.tsx
+++ b/src/components/container/ExternalAccountsPreview/ExternalAccountsPreview.tsx
@@ -1,9 +1,9 @@
-import React, {useEffect, useState} from 'react'
+import React, { useEffect, useState } from 'react'
 import "./ExternalAccountsPreview.css"
-import MyDataHelps, {ExternalAccount} from "@careevolution/mydatahelps-js"
-import {Action} from '../../presentational'
+import MyDataHelps, { ExternalAccount } from "@careevolution/mydatahelps-js"
+import { Action } from '../../presentational'
 import language from '../../../helpers/language'
-import {previewAccounts} from './ExternalAccountsPreview.previewdata'
+import { previewAccounts } from './ExternalAccountsPreview.previewdata'
 
 export interface ExternalAccountsPreviewProps {
     excludeProviders?: boolean;
@@ -11,7 +11,7 @@ export interface ExternalAccountsPreviewProps {
     excludeDeviceManufacturers?: boolean;
     applicationUrl: ExternalAccountsApplicationUrl;
     previewState?: ExternalAccountsPreviewPreviewState;
-	innerRef?: React.Ref<HTMLDivElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ExternalAccountsApplicationUrl = "preview" | string;

--- a/src/components/container/ExternalAccountsPreview/ExternalAccountsPreview.tsx
+++ b/src/components/container/ExternalAccountsPreview/ExternalAccountsPreview.tsx
@@ -11,6 +11,7 @@ export interface ExternalAccountsPreviewProps {
     excludeDeviceManufacturers?: boolean;
     applicationUrl: ExternalAccountsApplicationUrl;
     previewState?: ExternalAccountsPreviewPreviewState;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ExternalAccountsApplicationUrl = "preview" | string;
@@ -80,7 +81,7 @@ export default function (props: ExternalAccountsPreviewProps) {
     }
 
     return (
-        <div className="mdhui-external-accounts-preview">
+        <div ref={props.innerRef} className="mdhui-external-accounts-preview">
             <Action title={title} onClick={() => manageExternalAccounts()}>
                 {externalAccounts.map((account) =>
                     <div key={account.id} className="external-account-title">{account.provider.name}</div>

--- a/src/components/container/FitbitDevices/FitbitDevices.tsx
+++ b/src/components/container/FitbitDevices/FitbitDevices.tsx
@@ -10,5 +10,5 @@ export interface FitbitDevicesProps {
 }
 
 export default function (props: FitbitDevicesProps) {
-	return (<ConnectedDevices innerRef={props.innerRef} providerName="Fitbit" providerNamespace="Fitbit" previewData={fitbitDevicePreviewData} previewState={props.previewState}/>);
+	return (<ConnectedDevices innerRef={props.innerRef} providerName="Fitbit" providerNamespace="Fitbit" previewData={fitbitDevicePreviewData} previewState={props.previewState} />);
 }

--- a/src/components/container/FitbitDevices/FitbitDevices.tsx
+++ b/src/components/container/FitbitDevices/FitbitDevices.tsx
@@ -6,8 +6,9 @@ import { ConnectedDevicesPreviewState } from '../ConnectedDevices/ConnectedDevic
 
 export interface FitbitDevicesProps {
 	previewState?: ConnectedDevicesPreviewState;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export default function (props: FitbitDevicesProps) {
-	return (<ConnectedDevices providerName="Fitbit" providerNamespace="Fitbit" previewData={fitbitDevicePreviewData} previewState={props.previewState}/>);
+	return (<ConnectedDevices innerRef={props.innerRef} providerName="Fitbit" providerNamespace="Fitbit" previewData={fitbitDevicePreviewData} previewState={props.previewState}/>);
 }

--- a/src/components/container/GarminDevices/GarminDevices.tsx
+++ b/src/components/container/GarminDevices/GarminDevices.tsx
@@ -5,8 +5,9 @@ import ConnectedDevices, { ConnectedDevicesPreviewState } from '../ConnectedDevi
 
 export interface GarminDevicesProps {
 	previewState?: ConnectedDevicesPreviewState;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export default function (props: GarminDevicesProps) {
-	return (<ConnectedDevices providerName="Garmin" providerNamespace="Garmin" previewData={garminDevicePreviewData} previewState={props.previewState}/>);
+	return (<ConnectedDevices innerRef={props.innerRef} providerName="Garmin" providerNamespace="Garmin" previewData={garminDevicePreviewData} previewState={props.previewState}/>);
 }

--- a/src/components/container/HealthPreviewSection/HealthPreviewSection.tsx
+++ b/src/components/container/HealthPreviewSection/HealthPreviewSection.tsx
@@ -19,7 +19,7 @@ export interface HealthPreviewSectionProps {
     onClick(): void;
     previewState?: "NoData" | "Default";
     indicatorPosition?: "default" | "topRight";
-	innerRef?: React.Ref<HTMLButtonElement>
+    innerRef?: React.Ref<HTMLButtonElement>
 }
 
 export default function (props: HealthPreviewSectionProps) {

--- a/src/components/container/HealthPreviewSection/HealthPreviewSection.tsx
+++ b/src/components/container/HealthPreviewSection/HealthPreviewSection.tsx
@@ -19,6 +19,7 @@ export interface HealthPreviewSectionProps {
     onClick(): void;
     previewState?: "NoData" | "Default";
     indicatorPosition?: "default" | "topRight";
+	innerRef?: React.Ref<HTMLButtonElement>
 }
 
 export default function (props: HealthPreviewSectionProps) {
@@ -98,7 +99,7 @@ export default function (props: HealthPreviewSectionProps) {
         return null;
     }
 
-    return <Action indicatorPosition={props.indicatorPosition} bottomBorder indicatorValue={model.Count} className="mdhui-health-preview-section" title={getTitle()} titleIcon={<img className="mdhui-health-preview-icon" src={getIconUrl()} />} onClick={() => props.onClick()}>
+    return <Action innerRef={props.innerRef} indicatorPosition={props.indicatorPosition} bottomBorder indicatorValue={model.Count} className="mdhui-health-preview-section" title={getTitle()} titleIcon={<img className="mdhui-health-preview-icon" src={getIconUrl()} />} onClick={() => props.onClick()}>
         <div>
             {model.PreviewValues.map((item: any) => <div key={item} className="mdhui-health-preview-item">{item}</div>)}
         </div>

--- a/src/components/container/HealthPreviewSection/HealthPreviewSection.tsx
+++ b/src/components/container/HealthPreviewSection/HealthPreviewSection.tsx
@@ -19,7 +19,7 @@ export interface HealthPreviewSectionProps {
     onClick(): void;
     previewState?: "NoData" | "Default";
     indicatorPosition?: "default" | "topRight";
-    innerRef?: React.Ref<HTMLButtonElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 export default function (props: HealthPreviewSectionProps) {
@@ -92,16 +92,18 @@ export default function (props: HealthPreviewSectionProps) {
     }
 
     if (!model) {
-        return <div className="mdhui-health-preview-section"><LoadingIndicator /></div>
+        return <div ref={props.innerRef} className="mdhui-health-preview-section"><LoadingIndicator /></div>
     }
 
     if (!model.PreviewValues.length) {
         return null;
     }
 
-    return <Action innerRef={props.innerRef} indicatorPosition={props.indicatorPosition} bottomBorder indicatorValue={model.Count} className="mdhui-health-preview-section" title={getTitle()} titleIcon={<img className="mdhui-health-preview-icon" src={getIconUrl()} />} onClick={() => props.onClick()}>
-        <div>
-            {model.PreviewValues.map((item: any) => <div key={item} className="mdhui-health-preview-item">{item}</div>)}
-        </div>
-    </Action>
+    return <div ref={props.innerRef} className="mdhui-health-preview-section">
+        <Action indicatorPosition={props.indicatorPosition} bottomBorder indicatorValue={model.Count} title={getTitle()} titleIcon={<img className="mdhui-health-preview-icon" src={getIconUrl()} />} onClick={() => props.onClick()}>
+            <div>
+                {model.PreviewValues.map((item: any) => <div key={item} className="mdhui-health-preview-item">{item}</div>)}
+            </div>
+        </Action>
+    </div>
 }

--- a/src/components/container/LabResultsSummary/LabResultsSummary.tsx
+++ b/src/components/container/LabResultsSummary/LabResultsSummary.tsx
@@ -13,6 +13,7 @@ export interface LabResultsSummaryProps {
     previewState?: "ImportantLabs" | "RecentLabs" | "NoData"
     onClick(): void;
     onViewTermInfo(termInfo: TermInformation): void
+	innerRef?: React.Ref<HTMLButtonElement>
 }
 
 export default function (props: LabResultsSummaryProps) {
@@ -87,6 +88,7 @@ export default function (props: LabResultsSummaryProps) {
     }
 
     return <Action
+        innerRef={props.innerRef}
         bottomBorder
         title={language("lab-results-title")}
         titleIcon={<img className="mdhui-health-preview-icon" src={icon} alt="Lab Results" />}

--- a/src/components/container/LabResultsSummary/LabResultsSummary.tsx
+++ b/src/components/container/LabResultsSummary/LabResultsSummary.tsx
@@ -13,7 +13,7 @@ export interface LabResultsSummaryProps {
     previewState?: "ImportantLabs" | "RecentLabs" | "NoData"
     onClick(): void;
     onViewTermInfo(termInfo: TermInformation): void
-	innerRef?: React.Ref<HTMLButtonElement>
+    innerRef?: React.Ref<HTMLButtonElement>
 }
 
 export default function (props: LabResultsSummaryProps) {

--- a/src/components/container/LabResultsSummary/LabResultsSummary.tsx
+++ b/src/components/container/LabResultsSummary/LabResultsSummary.tsx
@@ -13,7 +13,7 @@ export interface LabResultsSummaryProps {
     previewState?: "ImportantLabs" | "RecentLabs" | "NoData"
     onClick(): void;
     onViewTermInfo(termInfo: TermInformation): void
-    innerRef?: React.Ref<HTMLButtonElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 export default function (props: LabResultsSummaryProps) {
@@ -75,7 +75,7 @@ export default function (props: LabResultsSummaryProps) {
     };
 
     if (!model) {
-        return <div className="mdhui-health-preview-section"><LoadingIndicator /></div>
+        return <div ref={props.innerRef} className="mdhui-health-preview-section"><LoadingIndicator /></div>
     }
 
     if (model && !model.ImportantLabs.length && !model.RecentLabs?.RecentLabReports.length) {
@@ -87,39 +87,40 @@ export default function (props: LabResultsSummaryProps) {
         props.onClick();
     }
 
-    return <Action
-        innerRef={props.innerRef}
-        bottomBorder
-        title={language("lab-results-title")}
-        titleIcon={<img className="mdhui-health-preview-icon" src={icon} alt="Lab Results" />}
-        onClick={() => drilldown()}
-        indicatorValue={model?.RecentLabs?.TotalLabReports}
-        indicatorPosition={model.ImportantLabs?.length ? "topRight" : undefined}
-        className="mdhui-lab-results-summary mdhui-health-preview-section">
-        {!model &&
-            <LoadingIndicator />
-        }
-        {model &&
-            <>
-                {!!model.ImportantLabs.length &&
-                    <div className={"mdhui-lab-results-values-container" + (noOverflow ? " no-overflow" : "")} style={{ height: model.ImportantLabs[0].length * 5.64 + "em" }}>
-                        <div className="mdhui-lab-results-values-slider" style={{ width: (model.ImportantLabs.length * 13 + 0.5) + "em" }}>
-                            {model.ImportantLabs.map((column: any, index: number) =>
-                                <div key={index} className="mdhui-lab-results-values-column">
-                                    {column.map((lab: any, index: number) =>
-                                        <LabResultWithSparkline onViewTermInfo={(t) => props.onViewTermInfo(t)} labResultValue={lab} key={index} />
-                                    )}
-                                </div>
-                            )}
+    return <div ref={props.innerRef} className="mdhui-lab-results-summary mdhui-health-preview-section">
+        <Action
+            bottomBorder
+            title={language("lab-results-title")}
+            titleIcon={<img className="mdhui-health-preview-icon" src={icon} alt="Lab Results" />}
+            onClick={() => drilldown()}
+            indicatorValue={model?.RecentLabs?.TotalLabReports}
+            indicatorPosition={model.ImportantLabs?.length ? "topRight" : undefined}
+            className="mdhui-lab-results-summary mdhui-health-preview-section">
+            {!model &&
+                <LoadingIndicator />
+            }
+            {model &&
+                <>
+                    {!!model.ImportantLabs.length &&
+                        <div className={"mdhui-lab-results-values-container" + (noOverflow ? " no-overflow" : "")} style={{ height: model.ImportantLabs[0].length * 5.64 + "em" }}>
+                            <div className="mdhui-lab-results-values-slider" style={{ width: (model.ImportantLabs.length * 13 + 0.5) + "em" }}>
+                                {model.ImportantLabs.map((column: any, index: number) =>
+                                    <div key={index} className="mdhui-lab-results-values-column">
+                                        {column.map((lab: any, index: number) =>
+                                            <LabResultWithSparkline onViewTermInfo={(t) => props.onViewTermInfo(t)} labResultValue={lab} key={index} />
+                                        )}
+                                    </div>
+                                )}
+                            </div>
                         </div>
-                    </div>
-                }
-                {!model.ImportantLabs.length &&
-                    <div>
-                        {model.RecentLabs.RecentLabReports.map((item: any) => <div key={item} className="mdhui-health-preview-item">{item}</div>)}
-                    </div>
-                }
-            </>
-        }
-    </Action>
+                    }
+                    {!model.ImportantLabs.length &&
+                        <div>
+                            {model.RecentLabs.RecentLabReports.map((item: any) => <div key={item} className="mdhui-health-preview-item">{item}</div>)}
+                        </div>
+                    }
+                </>
+            }
+        </Action>
+    </div>
 }

--- a/src/components/container/MostRecentNotification/MostRecentNotification.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.tsx
@@ -11,6 +11,7 @@ export interface MostRecentNotificationProps {
 	onViewMore?: Function,
 	hideAfterHours?: number,
 	previewState?: MostRecentNotificationPreviewState
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type MostRecentNotificationPreviewState = "Default";
@@ -57,7 +58,7 @@ export default function (props: MostRecentNotificationProps) {
 	}
 
 	return (
-		<div className="mdhui-most-recent-notification">
+		<div ref={props.innerRef} className="mdhui-most-recent-notification">
 			<SingleNotification notification={notification} />
 			{props.onViewMore &&
 				<Action subtitle={language("all-notifications")} onClick={props.onViewMore} />

--- a/src/components/container/NotificationList/NotificationList.tsx
+++ b/src/components/container/NotificationList/NotificationList.tsx
@@ -8,6 +8,7 @@ import OnVisibleTrigger from '../../presentational/OnVisibleTrigger/OnVisibleTri
 export interface NotificationListProps {
 	notificationType?: NotificationType,
 	previewState?: NotificationListPreviewState
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type NotificationListPreviewState = "Default" | "NoData";
@@ -67,7 +68,7 @@ export default function (props: NotificationListProps) {
 	}, []);
 
 	return (
-		<div className="mdhui-notification-list">
+		<div ref={props.innerRef} className="mdhui-notification-list">
 			{notifications && notifications.map((notification) =>
 				<Card key={notification.id.toString()}>
 					<SingleNotification notification={notification} />

--- a/src/components/container/PlatformSpecificContent/PlatformSpecificContent.tsx
+++ b/src/components/container/PlatformSpecificContent/PlatformSpecificContent.tsx
@@ -5,6 +5,7 @@ export interface PlatformSpecificContentProps {
 	platforms: string[];
 	children?: React.ReactNode;
 	previewDevicePlatform?: string;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export default function (props: PlatformSpecificContentProps) {
@@ -27,7 +28,7 @@ export default function (props: PlatformSpecificContentProps) {
 	}
 
 	return (
-		<div>
+		<div ref={props.innerRef}>
 			{props.children}
 		</div>
 	);

--- a/src/components/container/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/container/ProjectHeader/ProjectHeader.tsx
@@ -5,6 +5,7 @@ import { LoadingIndicator } from '../../presentational';
 
 export interface ProjectHeaderProps {
 	previewState?: ProjectHeaderPropsPreviewState
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ProjectHeaderPropsPreviewState = "Default";
@@ -49,7 +50,7 @@ export default function (props: ProjectHeaderProps) {
 	}
 
 	return (
-		<div className="mdhui-project-header">
+		<div ref={props.innerRef} className="mdhui-project-header">
 			{loading &&
 				<LoadingIndicator />
 			}

--- a/src/components/container/ProjectSupport/ProjectSupport.tsx
+++ b/src/components/container/ProjectSupport/ProjectSupport.tsx
@@ -9,6 +9,7 @@ import language from '../../../helpers/language';
 
 export interface ProjectSupportProps {
 	previewState?: ProjectSupportPropsPreviewState
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ProjectSupportPropsPreviewState = "Default";
@@ -48,7 +49,7 @@ export default function (props: ProjectSupportProps) {
 	}
 
 	return (
-		<div className="mdhui-project-support">
+		<div ref={props.innerRef} className="mdhui-project-support">
 			<div className="title">{language("support")}</div>
 			{loading &&
 				<LoadingIndicator />

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -14,7 +14,7 @@ export interface ProviderSearchProps {
     providerCategories?: string[];
     openNewWindow?: boolean;
     onProviderSelected?: (provider: ExternalAccountProvider) => void;
-	innerRef?: React.Ref<HTMLDivElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ProviderSearchPreviewState = "Default"

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -14,6 +14,7 @@ export interface ProviderSearchProps {
     providerCategories?: string[];
     openNewWindow?: boolean;
     onProviderSelected?: (provider: ExternalAccountProvider) => void;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type ProviderSearchPreviewState = "Default"
@@ -134,7 +135,7 @@ export default function (props: ProviderSearchProps) {
     }, [currentPage]);
 
     return (
-        <div className="mdhui-provider-search">
+        <div ref={props.innerRef} className="mdhui-provider-search">
             <div className="search-bar-wrapper">
                 <div className="search-bar">
                     <input title={language("search")} type="text" value={searchString} onChange={(event) => updateSearch(event)} placeholder={language("search")} spellCheck="false" autoComplete="off" autoCorrect="off" autoCapitalize="off" />

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
@@ -14,7 +14,7 @@ export interface RelativeActivityTodayProps {
     dataTypes: RelativeActivityDataType[];
     previewState?: "Default";
     title?: string;
-	innerRef?: React.Ref<HTMLDivElement>
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 export interface RelativeActivityDataType {
@@ -129,7 +129,7 @@ export default function (props: RelativeActivityTodayProps) {
                 <FontAwesomeSvgIcon icon={faChevronUp} />
             </div>
             {language("30-day-average")}
-            
+
         </div>
     </div>
 }

--- a/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
+++ b/src/components/container/RelativeActivityToday/RelativeActivityToday.tsx
@@ -14,6 +14,7 @@ export interface RelativeActivityTodayProps {
     dataTypes: RelativeActivityDataType[];
     previewState?: "Default";
     title?: string;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export interface RelativeActivityDataType {
@@ -117,7 +118,7 @@ export default function (props: RelativeActivityTodayProps) {
         return null;
     }
 
-    return <div className="mdhui-relative-activity-today">
+    return <div ref={props.innerRef} className="mdhui-relative-activity-today">
         {props.title && <CardTitle title={props.title} />}
         {computedResults.map(c => {
             let dataType = props.dataTypes.find(dt => dt.dailyDataType === c.dailyDataType)!;

--- a/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
+++ b/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
@@ -16,6 +16,7 @@ export interface RestingHeartRateCalendarProps {
 	month: number,
 	year: number,
 	showPreviewData: RestingHeartRateCalendarPreviewState
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export default function (props: RestingHeartRateCalendarProps) {
@@ -82,7 +83,7 @@ export default function (props: RestingHeartRateCalendarProps) {
 	}, [props]);
 
 	return (
-		<div>
+		<div ref={props.innerRef}>
 			{loading && <LoadingIndicator />}
 			{!loading && <Calendar year={props.year} month={props.month} dayRenderer={renderDay}></Calendar>}
 		</div>

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -14,6 +14,7 @@ export interface SurveyTaskListProps {
 	onDetailLinkClick?: Function,
 	previewState?: SurveyTaskListListPreviewState
 	variant?: "noCard" | "singleCard" | "multiCard"
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export type SurveyTaskListListPreviewState = "IncompleteTasks" | "CompleteTasks";
@@ -95,7 +96,7 @@ export default function (props: SurveyTaskListProps) {
 
 	let variant = props.variant ?? "noCard";
 	return (
-		<TaskListWrapper card={variant == "singleCard"}>
+		<TaskListWrapper innerRef={props.innerRef} card={variant == "singleCard"}>
 			<div className="mdhui-survey-task-list">
 				{props.title &&
 					<CardTitle title={props.title} detailLinkText={props.onDetailLinkClick ? language("view-all") + " (" + (tasks?.length ?? 0) + ")" : undefined} onDetailClick={props.onDetailLinkClick} />
@@ -114,6 +115,6 @@ export default function (props: SurveyTaskListProps) {
 	);
 }
 
-function TaskListWrapper(props: { children?: React.ReactNode, card: boolean }) {
-	return props.card ? <Card>{props.children}</Card> : <>{props.children}</>;
+function TaskListWrapper(props: { children?: React.ReactNode, card: boolean, innerRef?: React.Ref<HTMLDivElement> }) {
+	return props.card ? <Card innerRef={props.innerRef}>{props.children}</Card> : <div ref={props.innerRef}>{props.children}</div>;
 }

--- a/src/components/presentational/Action/Action.tsx
+++ b/src/components/presentational/Action/Action.tsx
@@ -18,12 +18,13 @@ export interface ActionProps {
 	indicatorValue?: string;
 	indicatorPosition?: "default" | "topRight";
 	bottomBorder?: boolean;
+	innerRef?: React.Ref<HTMLButtonElement>
 }
 
 export default function (props: ActionProps) {
 	var indicatorIcon = props.indicatorIcon ?? faChevronRight;
 	return (
-		<UnstyledButton className={(props.className || "") + " mdhui-action" + (props.bottomBorder ? " mdhui-action-bottom-border" : "")} onClick={() => props.onClick()}>
+		<UnstyledButton innerRef={props.innerRef} className={(props.className || "") + " mdhui-action" + (props.bottomBorder ? " mdhui-action-bottom-border" : "")} onClick={() => props.onClick()}>
 			{props.icon && <div className="mdhui-action-icon">{props.icon}</div>}
 			<div className='mdhui-action-body'>
 				{props.title &&

--- a/src/components/presentational/ActivityMeter/ActivityMeter.tsx
+++ b/src/components/presentational/ActivityMeter/ActivityMeter.tsx
@@ -11,10 +11,11 @@ export interface ActivityMeterProps {
 	color: string;
 	message?: string;
 	className?: string;
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 export default function (props: ActivityMeterProps) {
-	return <div className={"mdhui-activity-meter " + (props.className || "")}>
+	return <div ref={props.innerRef} className={"mdhui-activity-meter " + (props.className || "")}>
 		<div className="mdhui-activity-meter-label">
 			{props.label}
 		</div>

--- a/src/components/presentational/Button/Button.tsx
+++ b/src/components/presentational/Button/Button.tsx
@@ -14,6 +14,7 @@ export interface ButtonProps {
 	color?: string;
 	loading?: boolean;
 	variant?: "default" | "subtle" | "light";
+	innerRef?: React.Ref<HTMLButtonElement>
 }
 
 export default function (props: ButtonProps) {
@@ -34,7 +35,7 @@ export default function (props: ButtonProps) {
 	}
 
 	return (
-		<button style={{ backgroundColor: props.disabled ? undefined : backgroundColor, color: props.disabled ? undefined : textColor }}
+		<button ref={props.innerRef} style={{ backgroundColor: props.disabled ? undefined : backgroundColor, color: props.disabled ? undefined : textColor }}
 			className={classes.join(" ")}
 			disabled={(props.disabled || props.loading)}
 			onClick={() => {

--- a/src/components/presentational/Calendar/Calendar.tsx
+++ b/src/components/presentational/Calendar/Calendar.tsx
@@ -8,6 +8,7 @@ export interface CalendarProps {
 	year: number,
 	dayRenderer(year: number, month: number, day?: number): JSX.Element | null,
 	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+	innerRef?: React.Ref<HTMLDivElement>
 }
 
 interface CalendarWeek {
@@ -69,7 +70,7 @@ export default function (props: CalendarProps) {
 	generateWeeks();
 
 	return (
-		<div className="mdhui-calendar">
+		<div ref={props.innerRef} className="mdhui-calendar">
 			<table cellPadding="0" cellSpacing="0">
 				<thead>
 					<tr>

--- a/src/components/presentational/CardTitle/CardTitle.tsx
+++ b/src/components/presentational/CardTitle/CardTitle.tsx
@@ -5,11 +5,12 @@ export interface CardTitleProps {
 	title: string;
 	onDetailClick?: Function;
 	detailLinkText?: string;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: CardTitleProps) {
 	return (
-		<div className="mdhui-card-title">
+		<div ref={props.innerRef} className="mdhui-card-title">
 			{props.title}
 			{props.onDetailClick && props.detailLinkText &&
 				<a className="detail-link" onClick={() => props.onDetailClick ? props.onDetailClick() : null}>

--- a/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.tsx
+++ b/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.tsx
@@ -8,6 +8,7 @@ export interface DateRangeCoordinatorProps {
     weekStartsOn?: WeekStartsOn;
     variant?: "default" | "rounded";
     children: React.ReactNode;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface DateRangeContext {
@@ -30,15 +31,16 @@ export default function DateRangeNavigatorContext(props: DateRangeCoordinatorPro
 
     //reset the interval if the interval type changes
     useEffect(() => {
-        setCurrentContext({ intervalType:props.intervalType, intervalStart: initialIntervalStart });
+        setCurrentContext({ intervalType: props.intervalType, intervalStart: initialIntervalStart });
     }, [props.intervalType, props.weekStartsOn]);
 
-    return <DateRangeContext.Provider value={currentContext}>
+    return <div ref={props.innerRef}> <DateRangeContext.Provider value={currentContext}>
         <DateRangeNavigator
             intervalType={props.intervalType}
             intervalStart={currentContext.intervalStart}
-            onIntervalChange={(d) => setCurrentContext({...currentContext, intervalStart: d})}
+            onIntervalChange={(d) => setCurrentContext({ ...currentContext, intervalStart: d })}
             variant={props.variant} />
         {props.children}
     </DateRangeContext.Provider>
+    </div>
 }

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
@@ -16,7 +16,7 @@ export interface DateRangeNavigatorProps {
 	variant?: "default" | "rounded";
 	onIntervalChange(newIntervalStart: Date, newIntervalEnd: Date): void;
 	className?: string;
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: DateRangeNavigatorProps) {

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
@@ -16,6 +16,7 @@ export interface DateRangeNavigatorProps {
 	variant?: "default" | "rounded";
 	onIntervalChange(newIntervalStart: Date, newIntervalEnd: Date): void;
 	className?: string;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: DateRangeNavigatorProps) {
@@ -55,7 +56,7 @@ export default function (props: DateRangeNavigatorProps) {
 	}
 
 	return (
-		<div className={classes.join(" ")}>
+		<div ref={props.innerRef} className={classes.join(" ")}>
 			<div className="mdhui-date-range-navigator-inner">
 				<UnstyledButton title="Previous" className="navigator-button navigate-previous" onClick={() => previousInterval()}>
 					<FontAwesomeSvgIcon icon={faChevronLeft} />

--- a/src/components/presentational/DayTrackerSymbol/DayTrackerSymbol.tsx
+++ b/src/components/presentational/DayTrackerSymbol/DayTrackerSymbol.tsx
@@ -5,6 +5,7 @@ export interface DayTrackerSymbolProps {
 	primaryColors: string[]
 	secondaryColors: string[]
 	className?: string
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: DayTrackerSymbolProps) {
@@ -25,7 +26,7 @@ export default function (props: DayTrackerSymbolProps) {
 	var style = { background: background };
 
 	return (
-		<div className={"mdhui-day-tracker-symbol " + (props.className || "")}>
+		<div ref={props.innerRef} className={"mdhui-day-tracker-symbol " + (props.className || "")}>
 			<div className="day-circle" style={style}>
 				{props.secondaryColors.slice(0, 3).map((color, index) =>
 					<div key={index} className="secondary-color" style={{ background: color }}></div>

--- a/src/components/presentational/DayTrackerSymbol/DayTrackerSymbol.tsx
+++ b/src/components/presentational/DayTrackerSymbol/DayTrackerSymbol.tsx
@@ -5,7 +5,7 @@ export interface DayTrackerSymbolProps {
 	primaryColors: string[]
 	secondaryColors: string[]
 	className?: string
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: DayTrackerSymbolProps) {

--- a/src/components/presentational/Face/Face.tsx
+++ b/src/components/presentational/Face/Face.tsx
@@ -13,7 +13,7 @@ export interface FaceProps {
 	selected?: boolean;
 	onClick?: MouseEventHandler;
 	className?: string;
-    innerRef?: React.Ref<HTMLButtonElement>;
+	innerRef?: React.Ref<HTMLButtonElement>;
 }
 
 export default function (props: FaceProps) {

--- a/src/components/presentational/Face/Face.tsx
+++ b/src/components/presentational/Face/Face.tsx
@@ -13,6 +13,7 @@ export interface FaceProps {
 	selected?: boolean;
 	onClick?: MouseEventHandler;
 	className?: string;
+    innerRef?: React.Ref<HTMLButtonElement>;
 }
 
 export default function (props: FaceProps) {
@@ -39,7 +40,7 @@ export default function (props: FaceProps) {
 	}
 
 	if (props.onClick) {
-		return <UnstyledButton className={className} onClick={props.onClick}>
+		return <UnstyledButton innerRef={props.innerRef} className={className} onClick={props.onClick}>
 			<img src={getFace()} style={imageStyle} />
 			<ShinyOverlay />
 		</UnstyledButton>

--- a/src/components/presentational/Histogram/Histogram.tsx
+++ b/src/components/presentational/Histogram/Histogram.tsx
@@ -10,7 +10,7 @@ export interface HistogramProps {
 		onSelect?(): void;
 	}[];
 	className?: string;
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: HistogramProps) {

--- a/src/components/presentational/Histogram/Histogram.tsx
+++ b/src/components/presentational/Histogram/Histogram.tsx
@@ -10,6 +10,7 @@ export interface HistogramProps {
 		onSelect?(): void;
 	}[];
 	className?: string;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: HistogramProps) {
@@ -23,7 +24,7 @@ export default function (props: HistogramProps) {
 	var sortedEntries = [...props.entries].sort((a, b) => b.value - a.value || ((a.label > b.label) ? 1 : ((b.label > a.label) ? -1 : 0)));
 
 	return (
-		<div className={"mdhui-histogram " + (props.className || "")}>
+		<div ref={props.innerRef} className={"mdhui-histogram " + (props.className || "")}>
 			{sortedEntries.map((entry, index) => {
 				return <div className={"mdhui-histogram-entry" + (entry.onSelect ? " mdhui-histogram-entry-clickable" : "")} key={index} onClick={() => entry.onSelect?.()}>
 					<div className="mdhui-histogram-entry-bar-wrapper">

--- a/src/components/presentational/LabResultWithSparkline/LabResultWithSparkline.tsx
+++ b/src/components/presentational/LabResultWithSparkline/LabResultWithSparkline.tsx
@@ -30,6 +30,7 @@ export interface TermInformation {
 export interface LabResultWithSparklineProps {
     labResultValue: LabResultValue;
     onViewTermInfo(termInfo: TermInformation): void;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: LabResultWithSparklineProps) {
@@ -52,7 +53,7 @@ export default function (props: LabResultWithSparklineProps) {
         props.onViewTermInfo(termInfo);
     }
 
-    return <div className="mdhui-lab-result-with-sparkline">
+    return <div ref={props.innerRef} className="mdhui-lab-result-with-sparkline">
         <div className="mdhui-lab-result-with-sparkline-title">{props.labResultValue.Type}</div>
         <div className="mdhui-lab-result-with-sparkline-flex">
             <div className="mdhui-lab-result-with-sparkline-value">

--- a/src/components/presentational/Layout/Layout.tsx
+++ b/src/components/presentational/Layout/Layout.tsx
@@ -16,6 +16,7 @@ export interface LayoutProps {
 	  * @deprecated 
 	  */
 	stylesheetPath?: string;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface LayoutContext {
@@ -68,7 +69,7 @@ export default function (props: LayoutProps) {
 			{!props.noGlobalStyles &&
 				<EmotionGlobal styles={global} />
 			}
-			<div className={className}>
+			<div ref={props.innerRef} className={className}>
 				{props.stylesheetPath &&
 					<link rel="stylesheet" type="text/css" href={props.stylesheetPath} />
 				}

--- a/src/components/presentational/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/presentational/LoadingIndicator/LoadingIndicator.tsx
@@ -8,6 +8,7 @@ export interface LoadingIndicatorProps {
 	variant?: "default" | "inline";
 	color?: string;
 	className?: string;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 function LoadingIndicator(props: LoadingIndicatorProps) {
@@ -19,7 +20,7 @@ function LoadingIndicator(props: LoadingIndicatorProps) {
 		classes.push("mdhui-loading-indicator-inline");
 	}
 	return (
-		<div style={{ color: props.color }} className={classes.join(" ")}>
+		<div ref={props.innerRef} style={{ color: props.color }} className={classes.join(" ")}>
 			<FontAwesomeSvgIcon icon={faRefresh} spin />
 		</div>
 	);

--- a/src/components/presentational/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/presentational/LoadingIndicator/LoadingIndicator.tsx
@@ -8,7 +8,7 @@ export interface LoadingIndicatorProps {
 	variant?: "default" | "inline";
 	color?: string;
 	className?: string;
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 function LoadingIndicator(props: LoadingIndicatorProps) {

--- a/src/components/presentational/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/presentational/SegmentedControl/SegmentedControl.tsx
@@ -9,12 +9,13 @@ export interface SegmentedControlProps {
 	onSegmentSelected: Function;
 	className?: string;
 	color?: string;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SegmentedControlProps) {
 	var width = 100 / props.segments.length;
 	return (
-		<div style={{ borderColor: props.color }} className={"mdhui-segmented-control " + (props.className || "")}>
+		<div ref={props.innerRef} style={{ borderColor: props.color }} className={"mdhui-segmented-control " + (props.className || "")}>
 			{props.segments.map((s) =>
 				<UnstyledButton className={"mdhui-segment " + (s.key == props.selectedSegment ? "mdhui-segment-selected" : "")}
 					key={s.key}

--- a/src/components/presentational/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/presentational/SegmentedControl/SegmentedControl.tsx
@@ -9,7 +9,7 @@ export interface SegmentedControlProps {
 	onSegmentSelected: Function;
 	className?: string;
 	color?: string;
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SegmentedControlProps) {

--- a/src/components/presentational/SingleExternalAccount/SingleExternalAccount.tsx
+++ b/src/components/presentational/SingleExternalAccount/SingleExternalAccount.tsx
@@ -16,7 +16,7 @@ export interface SingleExternalAccountProps {
 	externalAccount: ExternalAccount;
 	onAccountRemoved: (account: ExternalAccount) => void;
 	onReconnectAccount: (account: ExternalAccount) => void;
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SingleExternalAccountProps) {

--- a/src/components/presentational/SingleExternalAccount/SingleExternalAccount.tsx
+++ b/src/components/presentational/SingleExternalAccount/SingleExternalAccount.tsx
@@ -16,6 +16,7 @@ export interface SingleExternalAccountProps {
 	externalAccount: ExternalAccount;
 	onAccountRemoved: (account: ExternalAccount) => void;
 	onReconnectAccount: (account: ExternalAccount) => void;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SingleExternalAccountProps) {
@@ -42,7 +43,7 @@ export default function (props: SingleExternalAccountProps) {
 	}
 
 	return (
-		<div className="mdhui-single-external-account">
+		<div ref={props.innerRef} className="mdhui-single-external-account">
 			<div className="external-account-header">
 				{props.externalAccount.provider.logoUrl &&
 					<img alt={props.externalAccount.provider.name} src={props.externalAccount.provider.logoUrl} className="external-account-provider-logo" />

--- a/src/components/presentational/SingleNotification/SingleNotification.tsx
+++ b/src/components/presentational/SingleNotification/SingleNotification.tsx
@@ -7,6 +7,7 @@ import { enUS, es } from 'date-fns/locale'
 
 export interface SingleNotificationProps {
 	notification: Notification
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SingleNotificationProps) {
@@ -16,7 +17,7 @@ export default function (props: SingleNotificationProps) {
 
 	var locale = MyDataHelps.getCurrentLanguage().toLowerCase().startsWith("es") ? es : enUS;
 	return (
-		<div className="mdhui-single-notification">
+		<div ref={props.innerRef} className="mdhui-single-notification">
 			{props.notification.content?.title &&
 				<div className="notification-title">{props.notification.content.title}</div>
 			}

--- a/src/components/presentational/SingleNotification/SingleNotification.tsx
+++ b/src/components/presentational/SingleNotification/SingleNotification.tsx
@@ -7,7 +7,7 @@ import { enUS, es } from 'date-fns/locale'
 
 export interface SingleNotificationProps {
 	notification: Notification
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SingleNotificationProps) {

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -18,7 +18,7 @@ export interface SingleSurveyTaskProps {
 	task: SurveyTask,
 	descriptionIcon?: IconDefinition,
 	disableClick?: boolean
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SingleSurveyTaskProps) {

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -18,6 +18,7 @@ export interface SingleSurveyTaskProps {
 	task: SurveyTask,
 	descriptionIcon?: IconDefinition,
 	disableClick?: boolean
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SingleSurveyTaskProps) {
@@ -58,7 +59,7 @@ export default function (props: SingleSurveyTaskProps) {
 
 	if (props.task.status == 'incomplete') {
 		return (
-			<div className="mdhui-single-survey-task incomplete" onClick={() => startSurvey(props.task.surveyName!)}>
+			<div ref={props.innerRef} className="mdhui-single-survey-task incomplete" onClick={() => startSurvey(props.task.surveyName!)}>
 				<div>
 					<div className="survey-name">{props.task.surveyDisplayName}</div>
 					<div className="survey-description"><>{props.descriptionIcon} {props.task.surveyDescription}</></div>
@@ -77,7 +78,7 @@ export default function (props: SingleSurveyTaskProps) {
 
 	if (props.task.status == 'complete' && props.task.endDate) {
 		return (
-			<div className="mdhui-single-survey-task complete">
+			<div ref={props.innerRef} className="mdhui-single-survey-task complete">
 				<div>
 					<div className="survey-name">{props.task.surveyDisplayName}</div>
 					<div className="completed-date">{language("completed")} {formatRelative(parseISO(props.task.endDate), new Date(), { locale: locale })}</div>

--- a/src/components/presentational/SparkBarChart/SparkBarChart.tsx
+++ b/src/components/presentational/SparkBarChart/SparkBarChart.tsx
@@ -5,7 +5,7 @@ import "./SparkBarChart.css"
 export interface SparkBarChartProps {
 	averageFillPercent: number;
 	bars: SparkBarChartBar[];
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface SparkBarChartBar {

--- a/src/components/presentational/SparkBarChart/SparkBarChart.tsx
+++ b/src/components/presentational/SparkBarChart/SparkBarChart.tsx
@@ -5,6 +5,7 @@ import "./SparkBarChart.css"
 export interface SparkBarChartProps {
 	averageFillPercent: number;
 	bars: SparkBarChartBar[];
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface SparkBarChartBar {
@@ -15,7 +16,7 @@ export interface SparkBarChartBar {
 export default function (props: SparkBarChartProps) {
 	var width = (100 / props.bars.length);
 
-	return <div className="mdhui-spark-bar-chart">
+	return <div ref={props.innerRef} className="mdhui-spark-bar-chart">
 		<div className="mdhui-spark-bar-chart-average" style={{ bottom: props.averageFillPercent * 100 + "%" }}></div>
 		<div className="mdhui-spark-bar-chart-bars">
 			{props.bars.map((b, index) =>

--- a/src/components/presentational/StatusBarBackground/StatusBarBackground.tsx
+++ b/src/components/presentational/StatusBarBackground/StatusBarBackground.tsx
@@ -5,7 +5,7 @@ import "./StatusBarBackground.css"
 
 export default interface StatusBarBackgroundProps {
 	color?: string
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: StatusBarBackgroundProps) {

--- a/src/components/presentational/StatusBarBackground/StatusBarBackground.tsx
+++ b/src/components/presentational/StatusBarBackground/StatusBarBackground.tsx
@@ -5,6 +5,7 @@ import "./StatusBarBackground.css"
 
 export default interface StatusBarBackgroundProps {
 	color?: string
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: StatusBarBackgroundProps) {
@@ -22,7 +23,7 @@ export default function (props: StatusBarBackgroundProps) {
 	}
 
 	return (
-		<div className="mdhui-status-bar-background" style={style}>
+		<div ref={props.innerRef} className="mdhui-status-bar-background" style={style}>
 		</div>
 	);
 }

--- a/src/components/presentational/Switch/Switch.tsx
+++ b/src/components/presentational/Switch/Switch.tsx
@@ -7,7 +7,7 @@ export interface SwitchProps {
 	onBackgroundColor?: string;
 	onValueChanged(value: boolean): void;
 	className?: string;
-    innerRef?: React.Ref<HTMLButtonElement>;
+	innerRef?: React.Ref<HTMLButtonElement>;
 }
 
 export default function (props: SwitchProps) {

--- a/src/components/presentational/Switch/Switch.tsx
+++ b/src/components/presentational/Switch/Switch.tsx
@@ -7,11 +7,12 @@ export interface SwitchProps {
 	onBackgroundColor?: string;
 	onValueChanged(value: boolean): void;
 	className?: string;
+    innerRef?: React.Ref<HTMLButtonElement>;
 }
 
 export default function (props: SwitchProps) {
 	return (
-		<UnstyledButton
+		<UnstyledButton innerRef={props.innerRef}
 			onClick={() => props.onValueChanged(!props.isOn)}
 			className={"mdhui-switch" + (props.isOn ? " mdhui-switch-on" : "") + (props.className ? " " + props.className : "")}
 			style={{ backgroundColor: props.isOn ? props.onBackgroundColor : "var(--mdhui-background-color-2)" }}>

--- a/src/components/presentational/TextBlock/TextBlock.tsx
+++ b/src/components/presentational/TextBlock/TextBlock.tsx
@@ -4,6 +4,7 @@ import "./TextBlock.css"
 export interface TextBlockProps {
 	children?: React.ReactNode;
 	className?: string;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: TextBlockProps) {
@@ -12,7 +13,7 @@ export default function (props: TextBlockProps) {
 	}
 
 	return (
-		<div className={"mdhui-text-block " + (props.className || "")}>
+		<div ref={props.innerRef} className={"mdhui-text-block " + (props.className || "")}>
 			{props.children}
 		</div>
 	);

--- a/src/components/presentational/TextBlock/TextBlock.tsx
+++ b/src/components/presentational/TextBlock/TextBlock.tsx
@@ -4,7 +4,7 @@ import "./TextBlock.css"
 export interface TextBlockProps {
 	children?: React.ReactNode;
 	className?: string;
-    innerRef?: React.Ref<HTMLDivElement>;
+	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: TextBlockProps) {

--- a/src/components/presentational/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/presentational/UnstyledButton/UnstyledButton.tsx
@@ -8,11 +8,13 @@ export interface UnstyledButtonProps {
     title?: string;
     style?: React.CSSProperties;
     disabled?: boolean;
+    innerRef?: React.Ref<HTMLButtonElement>;
 }
 
 export default function (props: UnstyledButtonProps) {
     return (
         <button
+            ref={props.innerRef}
             title={props.title}
             className={"mdhui-unstyled-button " + (props.className || "")}
             onClick={props.onClick}


### PR DESCRIPTION
## Overview

This adds "innerRef" to the props of most of the components (basically anywhere it was convenient to do so).

In general I think this is useful for attaching additional behaviors to these components.  The most pressing reason, however, had to do with a situation I wasn't able to cleanly work around.

Currently to attach a ref to a "DailyDataChart" or something you would have to just wrap it inside a div. 

Cards are also supposed to hide themselves when they are empty.

However, if you have a situation like this:
```
<Card>
    <div ref="myRef">
        <DailyDataChart hideIfNoData ... />
    </div>
    <div ref="myRef2">
        <DailyDataChart hideIfNoData ... />
    </div>
</Card>
```

The Card is not actually empty if both charts are hidden; it still has 2 divs in it.

I attempted to fix this with CSS using the "has" pseudo-selector to detect if a card ONLY has empty elements; however unfortunately a number of browsers do not support that.

So the most elegant solution I can think of is to support innerRefs such that we can do:

```
<Card>
    <DailyDataChart  innerRef="myRef" hideIfNoData ... />
    <DailyDataChart  innerRef="myRe2" hideIfNoData ... />
</Card>
```

## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [x] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner