### PR TITLE
ConnectDeviceAccountStep: Replace 'providerName' parameter with 'providerID'.

### DIFF
--- a/src/components/step/ConnectDeviceAccountStep/ConnectDeviceAccountStep.stories.tsx
+++ b/src/components/step/ConnectDeviceAccountStep/ConnectDeviceAccountStep.stories.tsx
@@ -21,7 +21,7 @@ ConnectDeviceAccountStepGarminDefault.args = {
     title: "Connect Garmin",
     text: "Connect your Garmin account to MyDataHelps to share your activity data.",
     deviceType: "Garmin",
-    providerName: "Garmin QA",
+    providerID: 1,
     styles: {}
 };
 
@@ -30,7 +30,7 @@ ConnectDeviceAccountStepGarminCustom.args = {
     title: "Connect Garmin",
     text: "Connect your Garmin account to MyDataHelps to share your activity data.",
     deviceType: "Garmin",
-    providerName: "Garmin QA",
+    providerID: 1,
     styles: {
         "nextButtonBackgroundColor": "#000000",
         "nextButtonBackgroundGradient": {
@@ -58,7 +58,7 @@ ConnectDeviceAccountStepFitbitDefault.args = {
     title: "Connect Fitbit",
     text: "Connect your Fitbit account to MyDataHelps to share your activity data.",
     deviceType: "Fitbit",
-    providerName: "Fitbit Staging",
+    providerID: 2,
     styles: {}
 };
 
@@ -67,6 +67,6 @@ ConnectDeviceAccountStepOmronDefault.args = {
     title: "Connect Omron",
     text: "Connect your Omron account to MyDataHelps to share your activity data.",
     deviceType: "Omron",
-    providerName: "Omron QA",
+    providerID: 3,
     styles: {}
 };

--- a/src/components/step/ConnectDeviceAccountStep/ConnectDeviceAccountStep.tsx
+++ b/src/components/step/ConnectDeviceAccountStep/ConnectDeviceAccountStep.tsx
@@ -1,17 +1,15 @@
 import React from "react";
-import MyDataHelps, {
-    ExternalAccountProvidersPage,
-} from "@careevolution/mydatahelps-js";
 import StepLayout from "../StepLayout";
 import StepTitle from "../StepTitle";
 import StepText from "../StepText";
 import StepNextButton from "../StepNextButton";
+import MyDataHelps from "@careevolution/mydatahelps-js";
 
 export interface ConnectDeviceAccountStepProps {
     title?: string;
     text?: string;
     deviceType: string; // "Fitbit" | "Garmin" | "Omron";
-    providerName: string;
+    providerID: number;
     styles: { [key: string]: any };
 }
 
@@ -19,31 +17,9 @@ export default function (props: ConnectDeviceAccountStepProps) {
     const nextButtonText = `Connect to ${props.deviceType}`;
 
     function handleClick() {
-        if (!props.providerName || props.providerName.length === 0) return;
-        MyDataHelps.getExternalAccountProviders(
-            props.providerName,
-            "Device Manufacturer",
-            10,
-            0
-        )
-            .then((page: ExternalAccountProvidersPage) => {
-                if (page.totalExternalAccountProviders === 0) {
-                    throw new Error(
-                        `No external account provider ${props.providerName} found.`
-                    );
-                } else if (page.totalExternalAccountProviders > 1) {
-                    throw new Error(
-                        `More than one external account provider ${props.providerName} found.`
-                    );
-                }
-
-                return page.externalAccountProviders[0].id;
-            })
-            .then((providerId) => {
-                return MyDataHelps.connectExternalAccount(providerId, {
-                    openNewWindow: true,
-                });
-            });
+        return MyDataHelps.connectExternalAccount(props.providerID, {
+            openNewWindow: true,
+        });
     }
 
     return (

--- a/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.stories.tsx
+++ b/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.stories.tsx
@@ -1,7 +1,6 @@
 ﻿import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import ConnectDeviceAccountStepContainer, {
-    ConnectDeviceAccountStepContainerProps,
 } from "./ConnectDeviceAccountStepContainer";
 
 export default {
@@ -13,15 +12,6 @@ export default {
 } as ComponentMeta<typeof ConnectDeviceAccountStepContainer>;
 
 const Template: ComponentStory<typeof ConnectDeviceAccountStepContainer> = (
-    args: ConnectDeviceAccountStepContainerProps
-) => <ConnectDeviceAccountStepContainer {...args} />;
+) => <ConnectDeviceAccountStepContainer />;
 
 export const ConnectDeviceAccountStepContainerDefault = Template.bind({});
-ConnectDeviceAccountStepContainerDefault.args = {
-    providerName: "",
-};
-
-export const ConnectDeviceAccountStepContainerGarmin = Template.bind({});
-ConnectDeviceAccountStepContainerGarmin.args = {
-    providerName: "Garmin QA",
-};

--- a/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.tsx
+++ b/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.tsx
@@ -7,10 +7,11 @@ export default function () {
     const [text, setText] = useState<string>();
     const [styles, setStyles] = useState<any>({});
     const [deviceType, setDeviceType] = useState<string>("");
-    const [providerID, setProviderID] = useState<number>(0);
+    const [providerID, setProviderID] = useState<number>();
     const [connected, setConnected] = useState<boolean>();
 
     useEffect(() => {
+        // Get the step configuration from MyDataHelps.
         MyDataHelps.getStepConfiguration().then(function (
             config: StepConfiguration
         ) {
@@ -34,6 +35,7 @@ export default function () {
     }, []);
 
     useEffect(() => {
+        // Start polling for connected status after a providerID is selected.
         if (!providerID || connected) return;
 
         const interval = setInterval(async () => {
@@ -50,13 +52,14 @@ export default function () {
     }, [providerID, connected]);
 
     useEffect(() => {
+        // Complete the step when connected.
         if (connected) {
             console.log("Connected to provider ID ", providerID);
             MyDataHelps.completeStep("");
         }
     }, [connected]);
 
-    return (
+    return providerID && (
         <ConnectDeviceAccountStep
             title={title}
             text={text}

--- a/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.tsx
+++ b/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.tsx
@@ -2,16 +2,12 @@ import React, { useState, useEffect } from "react";
 import MyDataHelps, { StepConfiguration } from "@careevolution/mydatahelps-js";
 import ConnectDeviceAccountStep from "../ConnectDeviceAccountStep";
 
-export interface ConnectDeviceAccountStepContainerProps {
-    providerName?: string;
-}
-
-export default function (props: ConnectDeviceAccountStepContainerProps) {
+export default function () {
     const [title, setTitle] = useState<string>();
     const [text, setText] = useState<string>();
     const [styles, setStyles] = useState<any>({});
     const [deviceType, setDeviceType] = useState<string>("");
-    const [providerName, setProviderName] = useState<string>(props.providerName ?? "");
+    const [providerID, setProviderID] = useState<number>(0);
     const [connected, setConnected] = useState<boolean>();
 
     useEffect(() => {
@@ -28,34 +24,34 @@ export default function (props: ConnectDeviceAccountStepContainerProps) {
             }
             setDeviceType(config.properties.deviceType);
 
-            if (!config.properties.providerName) {
-                throw new Error("providerName is required");
+            if (!config.properties.providerID) {
+                throw new Error("providerID is required");
             }
-            setProviderName(config.properties.providerName);
+            setProviderID(config.properties.providerID);
 
             setStyles(config.styles ?? {});
         });
     }, []);
 
     useEffect(() => {
-        if (!providerName || providerName.length === 0 || connected) return;
+        if (!providerID || connected) return;
 
         const interval = setInterval(async () => {
             const accounts = await MyDataHelps.getExternalAccounts();
-            const containProviderName = accounts.some(
-                (acc) => acc.provider.name === providerName
+            const containProvider = accounts.some(
+                (acc) => acc.provider.id === providerID
             );
-            if (!connected && containProviderName) {
-                setConnected(containProviderName);
+            if (!connected && containProvider) {
+                setConnected(containProvider);
             }
         }, 1000);
 
         return () => clearInterval(interval);
-    }, [providerName, connected]);
+    }, [providerID, connected]);
 
     useEffect(() => {
         if (connected) {
-            console.log("Connected to", providerName);
+            console.log("Connected to provider ID ", providerID);
             MyDataHelps.completeStep("");
         }
     }, [connected]);
@@ -65,7 +61,7 @@ export default function (props: ConnectDeviceAccountStepContainerProps) {
             title={title}
             text={text}
             deviceType={deviceType}
-            providerName={providerName}
+            providerID={providerID}
             styles={styles}
         />
     );


### PR DESCRIPTION
## Overview

This PR changes the ConnectDeviceAccountStep to use an input of `providerName` to `providerID`.

While we test #104 in QA, I realized an implicit dependency about `providerName`, which is that the FHIR provider must have its name in its key word list. @DKaczmar tried to use Fitbit Staging provider but couldn't connect to the provider. The reason was that "Fitbit Staging" was not in the keyword list.

I picked `providerName` over `providerID` at the time of writing #104 because I thought the former would be more intuitive for users. But given the additional maintenance overhead, I think now it makes more sense to just use a `providerID` for the ConnectDeviceAccountStep, which actually was the way to go in the long covid (AOU) app. 

![Screenshot 2023-09-18 150720](https://github.com/CareEvolution/MyDataHelpsUI/assets/3732224/2a12663c-3848-4e2c-8b6b-52910a10f3b8)


## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [x] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner