### PR TITLE
Connect any external account in new window

### DIFF
--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -76,7 +76,7 @@ export default function (props: ConnectDeviceProps) {
 	}
 
 	function connectToDevice() {
-		MyDataHelps.connectExternalAccount(props.providerIDCallback());
+		MyDataHelps.connectExternalAccount(props.providerIDCallback(), { openNewWindow: true });
 	}
 
 	useEffect(() => {

--- a/src/components/container/ExternalAccountList/ExternalAccountList.stories.tsx
+++ b/src/components/container/ExternalAccountList/ExternalAccountList.stories.tsx
@@ -57,3 +57,8 @@ HealthPlansAndDeviceManufacturers.args = {
     previewState: "Default",
     externalAccountProviderCategories: ["Health Plan", "Device Manufacturer"]
 };
+
+export const Live = Template.bind({});
+Default.args = {
+    externalAccountProviderCategories: ["Provider", "Health Plan", "Device Manufacturer"]
+};

--- a/src/components/container/ExternalAccountList/ExternalAccountList.tsx
+++ b/src/components/container/ExternalAccountList/ExternalAccountList.tsx
@@ -48,7 +48,7 @@ export default function (props: ExternalAccountListProps) {
     }
 
     function reconnectAccount(account: ExternalAccount) {
-        MyDataHelps.connectExternalAccount(account.provider.id)
+        MyDataHelps.connectExternalAccount(account.provider.id, {openNewWindow: true});
     }
 
     useEffect(() => {

--- a/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
@@ -35,3 +35,10 @@ onProviderSelected.args = {
 onProviderSelected.parameters = {
 	externalAccounts: []
 }
+
+export const Live = Template.bind({});
+Default.args = {
+}
+Default.parameters = {
+	externalAccounts: []
+}

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -12,7 +12,6 @@ import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
 export interface ProviderSearchProps {
     previewState?: ProviderSearchPreviewState;
     providerCategories?: string[];
-    openNewWindow?: boolean;
     onProviderSelected?: (provider: ExternalAccountProvider) => void;
     innerRef?: React.Ref<HTMLDivElement>
 }
@@ -99,7 +98,7 @@ export default function (props: ProviderSearchProps) {
     function connectToProvider(provider: ExternalAccountProvider) {
         const providerID = provider.id;
         if (!props.previewState && !(linkedExternalAccounts[providerID] && linkedExternalAccounts[providerID].status != 'unauthorized')) {
-            MyDataHelps.connectExternalAccount(providerID, { openNewWindow: props.openNewWindow ?? false });
+            MyDataHelps.connectExternalAccount(providerID, { openNewWindow: true });
         }
         if (props.onProviderSelected) {
             props.onProviderSelected(provider);

--- a/src/components/step/ConnectEhrStep/ConnectEhrStep.tsx
+++ b/src/components/step/ConnectEhrStep/ConnectEhrStep.tsx
@@ -37,7 +37,6 @@ export default function (props: ConnectEhrStepProps) {
             <ProviderSearch
                 previewState={props.previewState}
                 providerCategories={["Provider", "Health Plan"]}
-                openNewWindow={true}
                 onProviderSelected={props.onProviderSelected}
             />
             <StepNextButton


### PR DESCRIPTION
## Overview

This PR changes the behavior of the app so that it always opens a window for a participant to connect to an external account. 
Previously, we would simply reload the entire window, which led participants to lose context.

Address https://github.com/CareEvolution/MyDataHelpsDesignerUI/issues/231

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [x] If this feature requires a developer doc update, tag @CareEvolution/api-docs. 
  - Since there will be visible change for a user, it is worth mentioning the change in the release note and/or the user guide.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner