### PR TITLE
Remove Card from App Download

### DIFF
--- a/src/components/container/AppDownload/AppDownload.css
+++ b/src/components/container/AppDownload/AppDownload.css
@@ -1,12 +1,4 @@
-﻿.mdhui-app-download {
-}
-
-.mdhui-app-download-title {
-    padding: 16px 0 0 16px;
-    font-weight: bold;
-}
-
-.mdhui-app-download-subtitle {
+﻿.mdhui-app-download-subtitle {
     margin-bottom: 16px;
 }
 

--- a/src/components/container/AppDownload/AppDownload.stories.tsx
+++ b/src/components/container/AppDownload/AppDownload.stories.tsx
@@ -2,6 +2,7 @@
 import { Meta, StoryFn } from '@storybook/react'
 import Layout from '../../presentational/Layout'
 import AppDownload, { AppDownloadProps } from './AppDownload';
+import { Card } from '../../presentational';
 
 export default {
 	title: 'Container/AppDownload',
@@ -13,7 +14,7 @@ export default {
 
 const Template: StoryFn<typeof AppDownload> = (args: AppDownloadProps) =>
 	<Layout colorScheme="auto">
-		<AppDownload {...args} />
+		<Card><AppDownload {...args} /></Card>
 	</Layout>;
 
 export const WebBoth = Template.bind({});

--- a/src/components/container/AppDownload/AppDownload.tsx
+++ b/src/components/container/AppDownload/AppDownload.tsx
@@ -43,7 +43,7 @@ export default function (props: AppDownloadProps) {
 		<div className="mdhui-app-download" ref={props.innerRef}>
 			<PlatformSpecificContent platforms={['Web']} previewDevicePlatform={props.previewDevicePlatform}>
 				<CardTitle title={title} />
-				<TextBlock>Í
+				<TextBlock>
 					<div className="mdhui-app-download-subtitle">
 						{text}
 					</div>

--- a/src/components/container/AppDownload/AppDownload.tsx
+++ b/src/components/container/AppDownload/AppDownload.tsx
@@ -4,16 +4,18 @@ import MyDataHelps, { ProjectInfo } from '@careevolution/mydatahelps-js'
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import PlatformSpecificContent from '../PlatformSpecificContent/PlatformSpecificContent';
 import { useInitializeView } from '../../../helpers/Initialization';
-import Card from '../../presentational/Card';
 import TextBlock from '../../presentational/TextBlock';
 import googlePlayDownload from '../../../assets/google-play-download.svg';
 import appStoreDownload from '../../../assets/app-store-download.svg';
 import language from "../../../helpers/language";
+import { CardTitle } from '../../presentational';
 
 export interface AppDownloadProps {
 	previewProjectPlatforms?: string[]
 	previewDevicePlatform?: string;
 	innerRef?: React.Ref<HTMLDivElement>;
+	title?: string;
+	text?: string;
 }
 
 export default function (props: AppDownloadProps) {
@@ -22,7 +24,7 @@ export default function (props: AppDownloadProps) {
 	useInitializeView(() => {
 		if (props.previewProjectPlatforms) {
 			// @ts-ignore
-			setProjectInfo({name: 'PROJECT', platforms: props.previewProjectPlatforms || []});
+			setProjectInfo({ name: 'PROJECT', platforms: props.previewProjectPlatforms || [] });
 			return;
 		}
 
@@ -35,29 +37,29 @@ export default function (props: AppDownloadProps) {
 		return null;
 	}
 
+	let title = props.title || language('app-download-title');
+	let text = props.text || language('app-download-subtitle').replace("@@PROJECT_NAME@@", projectInfo.name);
 	return (
 		<div className="mdhui-app-download" ref={props.innerRef}>
 			<PlatformSpecificContent platforms={['Web']} previewDevicePlatform={props.previewDevicePlatform}>
-				<Card>
-					<div className="mdhui-app-download-title">{language('app-download-title')}</div>
-					<TextBlock>
-						<div className="mdhui-app-download-subtitle">
-							{language('app-download-subtitle').replace("@@PROJECT_NAME@@", projectInfo.name)}
-						</div>
-						<div className="mdhui-app-download-links">
-							{projectInfo.platforms.includes('Android') &&
+				<CardTitle title={title} />
+				<TextBlock>Í
+					<div className="mdhui-app-download-subtitle">
+						{text}
+					</div>
+					<div className="mdhui-app-download-links">
+						{projectInfo.platforms.includes('Android') &&
 							<a target="_blank" className="mdhui-app-download-link" href="https://play.google.com/store/apps/details?id=com.careevolution.mydatahelps&hl=en_US&gl=US">
-								<img src={googlePlayDownload} alt={language('app-download-google-play-link-alt')}/>
+								<img src={googlePlayDownload} alt={language('app-download-google-play-link-alt')} />
 							</a>
-							}
-							{projectInfo.platforms.includes('iOS') &&
+						}
+						{projectInfo.platforms.includes('iOS') &&
 							<a target="_blank" className="mdhui-app-download-link" href="https://apps.apple.com/us/app/mydatahelps/id1286789190">
-								<img src={appStoreDownload} alt={language('app-download-app-store-link-alt')}/>
+								<img src={appStoreDownload} alt={language('app-download-app-store-link-alt')} />
 							</a>
-							}
-						</div>
-					</TextBlock>
-				</Card>
+						}
+					</div>
+				</TextBlock>
 			</PlatformSpecificContent>
 		</div>
 	);

--- a/src/components/view/HomeView/HomeView.tsx
+++ b/src/components/view/HomeView/HomeView.tsx
@@ -46,7 +46,9 @@ export default function (props: HomeViewProps) {
 		<Layout colorScheme={props.colorScheme ?? "auto"}>
 			<StatusBarBackground color='#FFFFFF' />
 			<ProjectHeader previewState={props.preview ? "Default" : undefined} />
-			<AppDownload previewDevicePlatform={props.preview ? 'Web' : undefined} previewProjectPlatforms={props.preview ? ['Web', 'Android', 'iOS'] : undefined} />
+			<Card>
+				<AppDownload previewDevicePlatform={props.preview ? 'Web' : undefined} previewProjectPlatforms={props.preview ? ['Web', 'Android', 'iOS'] : undefined} />
+			</Card>
 			<Card>
 				<MostRecentNotification
 					notificationType={notificationType}


### PR DESCRIPTION
## Overview

The decision of whether to use Cards or Sections is somewhat context dependent so for most components (other than, SurveyTaskList for instance; where it might render multiple cards) we don't want to include a card in the component itself.

This fixes up App Download so it's not in a card (was about to add this to the view builder and noticed this)

This also adds customizable text / title to this component

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner