### PR TITLE
Add sticky option for date range navigator, fix Symptom Shark Calendar

### DIFF
--- a/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.tsx
+++ b/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.tsx
@@ -10,6 +10,7 @@ export interface DateRangeCoordinatorProps {
     variant?: "default" | "rounded";
     children: React.ReactNode;
     innerRef?: React.Ref<HTMLDivElement>;
+    sticky?: boolean;
 }
 
 export interface DateRangeContext {
@@ -37,6 +38,7 @@ export default function DateRangeNavigatorContext(props: DateRangeCoordinatorPro
 
     return <div ref={props.innerRef}> <DateRangeContext.Provider value={currentContext}>
         <DateRangeNavigator
+            sticky={props.sticky}
             intervalType={props.intervalType}
             intervalStart={currentContext.intervalStart}
             onIntervalChange={(d) => setCurrentContext({ ...currentContext, intervalStart: d })}

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.css
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.css
@@ -16,7 +16,7 @@
     position: sticky;
     position: -webkit-sticky;
     top: 0;
-    padding-top: calc(16px + env(safe-area-inset-top));
+    padding-top: calc(16px + env(safe-area-inset-top, 0px));
 }
 
 .mdhui-date-range-navigator .navigator-button {

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.css
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.css
@@ -7,11 +7,16 @@
     text-align: center;
     font-weight: bold;
     border-bottom: solid 1px var(--mdhui-border-color-0);
-    position: sticky;
-    position: -webkit-sticky;
-    top: env(safe-area-inset-top, 0px);
     background: var(--mdhui-background-color-0);
     z-index: 1;
+    position: relative;
+}
+
+.mdhui-date-range-navigator.mdhui-date-range-navigator-sticky {
+    position: sticky;
+    position: -webkit-sticky;
+    top: 0;
+    padding-top: calc(16px + env(safe-area-inset-top));
 }
 
 .mdhui-date-range-navigator .navigator-button {

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
@@ -17,6 +17,7 @@ export interface DateRangeNavigatorProps {
 	onIntervalChange(newIntervalStart: Date, newIntervalEnd: Date): void;
 	className?: string;
 	innerRef?: React.Ref<HTMLDivElement>;
+	sticky?: boolean;
 }
 
 export default function (props: DateRangeNavigatorProps) {
@@ -50,6 +51,9 @@ export default function (props: DateRangeNavigatorProps) {
 	let classes = ["mdhui-date-range-navigator"]
 	if (props.variant == "rounded") {
 		classes.push("mdhui-date-range-navigator-rounded");
+	}
+	if (props.sticky) {
+		classes.push("mdhui-date-range-navigator-sticky");
 	}
 	if (props.className) {
 		classes.push(props.className);

--- a/src/components/symptom-shark/container/LogToday/LogToday.tsx
+++ b/src/components/symptom-shark/container/LogToday/LogToday.tsx
@@ -9,6 +9,7 @@ import language from '../../../../helpers/language';
 export interface SymptomSharkLogTodayProps {
     previewState?: "withLog" | "noLog";
     innerRef?: React.Ref<HTMLDivElement>;
+    onClick(d: Date): void;
 }
 
 export default function (props: SymptomSharkLogTodayProps) {
@@ -43,5 +44,5 @@ export default function (props: SymptomSharkLogTodayProps) {
         return null;
     }
 
-    return <SymptomSharkLogEntry innerRef={props.innerRef} title={!symptomLogEntry ? language("log-todays-symptoms") : language("todays-log")} date={currentDate} logEntry={symptomLogEntry} configuration={configuration!} />;
+    return <SymptomSharkLogEntry onClick={(d) => props.onClick(d)} innerRef={props.innerRef} title={!symptomLogEntry ? language("log-todays-symptoms") : language("todays-log")} date={currentDate} logEntry={symptomLogEntry} configuration={configuration!} />;
 }

--- a/src/components/symptom-shark/presentational/Calendar/Calendar.tsx
+++ b/src/components/symptom-shark/presentational/Calendar/Calendar.tsx
@@ -19,7 +19,7 @@ export interface SymptomSharkCalendarProps {
 export default function (props: SymptomSharkCalendarProps) {
     let visualizationContext = useContext(SymptomSharkVisualizationContext);
     if (!visualizationContext) {
-        return <TextBlock>Error: Symptom Calendar must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
+        return <TextBlock innerRef={props.innerRef}>Error: Symptom Calendar must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
     }
     let { symptoms, treatments, logEntries } = visualizationContext;
 

--- a/src/components/symptom-shark/presentational/OverallExperienceChart/OverallExperienceChart.tsx
+++ b/src/components/symptom-shark/presentational/OverallExperienceChart/OverallExperienceChart.tsx
@@ -15,7 +15,7 @@ export interface OverallExperienceChartProps {
 export default function (props: OverallExperienceChartProps) {
     let visualizationContext = useContext(SymptomSharkVisualizationContext);
     if (!visualizationContext) {
-        return <TextBlock>Error: Symptom Severity Chart must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
+        return <TextBlock innerRef={props.innerRef}>Error: Symptom Severity Chart must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
     }
     let { logEntries } = visualizationContext;
 

--- a/src/components/symptom-shark/presentational/SymptomSeverityChart/SymptomSeverityChart.tsx
+++ b/src/components/symptom-shark/presentational/SymptomSeverityChart/SymptomSeverityChart.tsx
@@ -16,7 +16,7 @@ export interface SymptomSeverityChartProps {
 export default function (props: SymptomSeverityChartProps) {
     let visualizationContext = useContext(SymptomSharkVisualizationContext);
     if (!visualizationContext) {
-        return <TextBlock>Error: Symptom Severity Chart must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
+        return <TextBlock innerRef={props.innerRef}>Error: Symptom Severity Chart must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
     }
     let { logEntries } = visualizationContext;
 

--- a/src/components/symptom-shark/presentational/SymptomSeveritySummary/SymptomSeveritySummary.tsx
+++ b/src/components/symptom-shark/presentational/SymptomSeveritySummary/SymptomSeveritySummary.tsx
@@ -18,7 +18,7 @@ export interface SymptomSeveritySummaryProps {
 export default function (props: SymptomSeveritySummaryProps) {
     let visualizationContext = useContext(SymptomSharkVisualizationContext);
     if (!visualizationContext) {
-        return <TextBlock>Error: Symptom Severity Summary must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
+        return <TextBlock innerRef={props.innerRef}>Error: Symptom Severity Summary must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
     }
     let { logEntries } = visualizationContext;
 

--- a/src/components/symptom-shark/presentational/SymptomTreatmentHistograms/SymptomTreatmentHistograms.css
+++ b/src/components/symptom-shark/presentational/SymptomTreatmentHistograms/SymptomTreatmentHistograms.css
@@ -1,5 +1,4 @@
 .mdhui-ss-histograms {
-    background: var(--mdhui-background-color-0);
     border-top: solid 1px var(--mdhui-border-color-1);
     border-bottom: solid 1px var(--mdhui-border-color-1);
     box-shadow: var(--mdhui-box-shadow-0);

--- a/src/components/symptom-shark/presentational/SymptomTreatmentHistograms/SymptomTreatmentHistograms.tsx
+++ b/src/components/symptom-shark/presentational/SymptomTreatmentHistograms/SymptomTreatmentHistograms.tsx
@@ -14,7 +14,7 @@ export interface SymptomTreatmentHistogramsProps {
 export default function (props: SymptomTreatmentHistogramsProps) {
     let visualizationContext = useContext(SymptomSharkVisualizationContext);
     if (!visualizationContext) {
-        return <TextBlock>Error: Symptom Treatment Histograms must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
+        return <TextBlock innerRef={props.innerRef}>Error: Symptom Treatment Histograms must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
     }
     let { symptoms, treatments, logEntries } = visualizationContext;
 

--- a/src/components/symptom-shark/view/CalendarView/CalendarView.tsx
+++ b/src/components/symptom-shark/view/CalendarView/CalendarView.tsx
@@ -36,7 +36,7 @@ export default function (props: CalendarViewProps) {
 function CalendarSeverityCharts() {
     let visualizationContext = useContext(SymptomSharkVisualizationContext);
     if (!visualizationContext) {
-        return <TextBlock>Error: Symptom Treatment Histograms must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
+        return <TextBlock>Error: Calendar severity charts must be used inside a Symptom Shark Visualization Coordinator.</TextBlock>
     }
     let { hasFilteredSymptoms, symptoms } = visualizationContext;
 

--- a/src/components/symptom-shark/view/CalendarView/CalendarView.tsx
+++ b/src/components/symptom-shark/view/CalendarView/CalendarView.tsx
@@ -15,7 +15,7 @@ export default function (props: CalendarViewProps) {
 
     return (
         <Layout colorScheme={props.colorScheme ?? "light"}>
-            <DateRangeCoordinator variant='rounded' intervalType='Month'>
+            <DateRangeCoordinator variant='rounded' intervalType='Month' sticky>
                 <SymptomSharkVisualizationCoordinator showFilters previewState={props.previewState}>
                     <Section>
                         <SymptomSharkCalendar onDaySelected={props.onDaySelected} />

--- a/src/components/symptom-shark/view/SymptomDetailView/SymptomDetailView.tsx
+++ b/src/components/symptom-shark/view/SymptomDetailView/SymptomDetailView.tsx
@@ -37,7 +37,7 @@ function SymptomDetailViewInner(props: SymptomDetailViewProps) {
 
     return <>
         <NavigationBar title={symptom.name} showCloseButton={true} />
-        <DateRangeCoordinator sticky initialIntervalStart={initialIntervalStart} intervalType='Month' variant="rounded" >
+        <DateRangeCoordinator initialIntervalStart={initialIntervalStart} intervalType='Month' variant="rounded" >
             <Section noTopMargin>
                 <SymptomSharkSymptomSeveritySummary symptom={symptom} />
             </Section>

--- a/src/components/symptom-shark/view/SymptomDetailView/SymptomDetailView.tsx
+++ b/src/components/symptom-shark/view/SymptomDetailView/SymptomDetailView.tsx
@@ -37,7 +37,7 @@ function SymptomDetailViewInner(props: SymptomDetailViewProps) {
 
     return <>
         <NavigationBar title={symptom.name} showCloseButton={true} />
-        <DateRangeCoordinator initialIntervalStart={initialIntervalStart} intervalType='Month' variant="rounded" >
+        <DateRangeCoordinator sticky initialIntervalStart={initialIntervalStart} intervalType='Month' variant="rounded" >
             <Section noTopMargin>
                 <SymptomSharkSymptomSeveritySummary symptom={symptom} />
             </Section>


### PR DESCRIPTION
## Overview

The symptom shark calendar view currently looks like this - the date range navigator is covering the filter buttons so you can only see a sliver of the bottom of them:
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/1643171/5b0acac9-03b5-4b03-ae4a-18c4513f0881).

Additionally, as you scrolled down, content was scrolling behind the status bar because the "top" was set to the safe area vs. the padding-top

This is a quick fix for this issue - since this is used in the device data pages I couldn't just adjust the margin / padding / top - so this basically makes those non-sticky (which is fine...I think it's a bit awkward they were)

While an existing issue, I would like to refactor this a bit more later to use portals so that there is a single stacked "sticky" context at the top of the page.  Right now this isn't sticky if you already have a navigation bar at the top, for instance (see the symptom detail view for an example).  I think having a portal with a single sticky spot at the top of the page would work though.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [x] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner