### PR TITLE
ConnectDeviceAccount step: set loading flag to false on rejection

### DIFF
--- a/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.tsx
+++ b/src/components/step/ConnectDeviceAccountStepContainer/ConnectDeviceAccountStepContainer.tsx
@@ -39,6 +39,7 @@ export default function (props: ConnectDeviceAccountStepContainerProps) {
     }
 
     async function completeStepIfConnected(deviceType: string) {
+      try {
         const accounts = await MyDataHelps.getExternalAccounts();
 
         const providerID = convertToProviderID(deviceType);
@@ -48,8 +49,9 @@ export default function (props: ConnectDeviceAccountStepContainerProps) {
         if (connected) {
             MyDataHelps.completeStep(providerID);
         }
-
+      } finally {
         setLoading(false);
+      }
     }
 
     useEffect(() => {
@@ -58,10 +60,7 @@ export default function (props: ConnectDeviceAccountStepContainerProps) {
             config: StepConfiguration
         ) {
             if (!config) {
-
-                setLoading(false);
                 completeStepIfConnected(deviceType);
-
                 return; // allows test mode to work
             }
 


### PR DESCRIPTION
## Overview

The loading flag should be set to false when `getExternalAccounts` errors out. This is actually the case when a user accesses this survey step from MDHD. Due to lack of access token, `getExternalAccount` is rejected, which leaves the loading flag forever true.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner