### PR TITLE
Reload after connecting to an external account

### DIFF
--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -78,7 +78,16 @@ export default function (props: ConnectDeviceProps) {
 	}
 
 	function connectToDevice() {
-		MyDataHelps.connectExternalAccount(props.providerID, { openNewWindow: true });
+		MyDataHelps.connectExternalAccount(props.providerID, { openNewWindow: true })
+			.then(function() {
+				MyDataHelps.getExternalAccounts().then(function (accounts) {
+					accounts.forEach((account) => {
+						if (account.provider.id === props.providerID) {
+							setDeviceExternalAccount(account);
+						}
+					});
+				});
+			});
 	}
 
 	useEffect(() => {

--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -80,13 +80,7 @@ export default function (props: ConnectDeviceProps) {
 	function connectToDevice() {
 		MyDataHelps.connectExternalAccount(props.providerID, { openNewWindow: true })
 			.then(function() {
-				MyDataHelps.getExternalAccounts().then(function (accounts) {
-					accounts.forEach((account) => {
-						if (account.provider.id === props.providerID) {
-							setDeviceExternalAccount(account);
-						}
-					});
-				});
+        initialize();
 			});
 	}
 

--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -80,7 +80,7 @@ export default function (props: ConnectDeviceProps) {
 	function connectToDevice() {
 		MyDataHelps.connectExternalAccount(props.providerID, { openNewWindow: true })
 			.then(function() {
-        initialize();
+				initialize();
 			});
 	}
 

--- a/src/components/container/ExternalAccountList/ExternalAccountList.tsx
+++ b/src/components/container/ExternalAccountList/ExternalAccountList.tsx
@@ -48,7 +48,10 @@ export default function (props: ExternalAccountListProps) {
     }
 
     function reconnectAccount(account: ExternalAccount) {
-        MyDataHelps.connectExternalAccount(account.provider.id, {openNewWindow: true});
+        MyDataHelps.connectExternalAccount(account.provider.id, {openNewWindow: true})
+            .then(function() {
+                loadExternalAccounts();
+            });
     }
 
     useEffect(() => {

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -103,6 +103,8 @@ export default function (props: ProviderSearchProps) {
                     if (props.onProviderConnected) {
                         props.onProviderConnected(provider);
                     }
+
+                    return loadExternalAccounts();
                 });
         }
     }


### PR DESCRIPTION
## Overview

Reload states after a participant successfully connects their external account.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner