### PR TITLE
Fix baseUrl race condition in providerID helpers

### DIFF
--- a/src/components/view/FitbitView/FitbitView.tsx
+++ b/src/components/view/FitbitView/FitbitView.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
-import { Layout, Card, StatusBarBackground, ConnectFitbit, FitbitDevices, FitbitMonthCharts } from "../.."
+import React, { useEffect, useState } from 'react'
+import { Layout, Card, StatusBarBackground, ConnectFitbit, FitbitDevices, FitbitMonthCharts, LoadingIndicator } from "../.."
 import { ConnectFitbitPreviewState } from "../../container/ConnectFitbit/ConnectFitbit";
 import { ConnectedDevicesPreviewState } from '../../container/ConnectedDevices/ConnectedDevices';
 import { MonthChartsPreviewState } from '../../container/MonthCharts/MonthCharts';
+import MyDataHelps from '@careevolution/mydatahelps-js';
 
 export interface FitbitViewProps {
 	connectPreview?: ConnectFitbitPreviewState,
@@ -12,18 +13,32 @@ export interface FitbitViewProps {
 }
 
 export default function (props: FitbitViewProps) {
+	var [viewIsReady, setViewIsReady] = useState(false);
+	useEffect(() => {
+		MyDataHelps.connect().then(() => {
+			setViewIsReady(true);
+		})
+	}, [])
+
 	return (
 		<Layout colorScheme={props.colorScheme ?? "auto"}>
 			<StatusBarBackground />
-			<Card>
-				<ConnectFitbit previewState={props.connectPreview} disabledBehavior="displayError" />
-			</Card>
-			<Card>
-				<FitbitDevices previewState={props.devicesPreview} />
-			</Card>
-			<Card allowOverflow={true}>
-				<FitbitMonthCharts previewState={props.chartsPreview} />
-			</Card>
+			{viewIsReady &&
+				<>
+					<Card>
+						<ConnectFitbit previewState={props.connectPreview} disabledBehavior="displayError" />
+					</Card>
+					<Card>
+						<FitbitDevices previewState={props.devicesPreview} />
+					</Card>
+					<Card allowOverflow={true}>
+						<FitbitMonthCharts previewState={props.chartsPreview} />
+					</Card>
+				</>
+			}
+			{!viewIsReady &&
+				<LoadingIndicator />
+			}
 		</Layout>
 	)
 }

--- a/src/components/view/GarminView/GarminView.tsx
+++ b/src/components/view/GarminView/GarminView.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Layout, Card, StatusBarBackground, ConnectGarmin, GarminDevices, GarminMonthCharts } from "../.."
 import { ConnectGarminPreviewState } from "../../container/ConnectGarmin/ConnectGarmin";
 import { ConnectedDevicesPreviewState } from '../../container/ConnectedDevices/ConnectedDevices';
 import { MonthChartsPreviewState } from '../../container/MonthCharts/MonthCharts';
+import MyDataHelps from '@careevolution/mydatahelps-js';
 
 export interface GarminViewProps {
 	connectPreview?: ConnectGarminPreviewState,
@@ -12,18 +13,33 @@ export interface GarminViewProps {
 }
 
 export default function (props: GarminViewProps) {
+	var [viewIsReady, setViewIsReady] = useState(false);
+	useEffect(() => {
+		MyDataHelps.connect().then(() => {
+			setViewIsReady(true);
+		})
+	}, [])
+
+
 	return (
 		<Layout>
 			<StatusBarBackground color="var(--main-bg-color)" />
-			<Card>
-				<ConnectGarmin previewState={props.connectPreview} garminProviderID={props.garminProviderID} disabledBehavior="displayError" />
-			</Card>
-			<Card>
-				<GarminDevices previewState={props.devicesPreview} />
-			</Card>
-			<Card allowOverflow={true}>
-				<GarminMonthCharts previewState={props.chartsPreview} />
-			</Card>
+			{viewIsReady &&
+				<>
+					<Card>
+						<ConnectGarmin previewState={props.connectPreview} garminProviderID={props.garminProviderID} disabledBehavior="displayError" />
+					</Card>
+					<Card>
+						<GarminDevices previewState={props.devicesPreview} />
+					</Card>
+					<Card allowOverflow={true}>
+						<GarminMonthCharts previewState={props.chartsPreview} />
+					</Card>
+				</>
+			}
+			{!viewIsReady &&
+				<LoadingIndicator />
+			}
 		</Layout>
 	)
 }


### PR DESCRIPTION
## Overview

There is a race condition with `MyDataHelps.baseUrl` not being set yet when `getFitbitProviderID` or `getGarminProviderID` are called through either the `ConnectFitbit` or `ConnectGarmin` widgets when use on the `FitbitView` or `GarminView`.  This is because no other `MyDataHelps` API call happens before `getFitbitProviderID` or `getGarminProviderID`, so `baseUrl` isn't set because no access token has been parsed yet.

The solution I'm providing here is the most straight forward.  This fix targets the views directly affected by this race condition, which does leave open the possibility for this to crop up again.  I'm certainly open to other ideas for fixing this; the only other idea I had was to push the `connect` call into the providerID getters directly - which would require them to return a `Promise`, which has more downstream effects and a lot more thread pulling than seemed necessary at this point in time.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner