### PR TITLE
Prevent duplicate task survey launches.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.1-Issue139.1",
+  "version": "2.9.1-Issue139.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.9.1-Issue139.1",
+      "version": "2.9.1-Issue139.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.0",
+  "version": "2.9.1-Issue139.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.9.0",
+      "version": "2.9.1-Issue139.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.1-Issue139.2",
+  "version": "2.9.1-Issue139.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.9.1-Issue139.2",
+      "version": "2.9.1-Issue139.3",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.1-Issue139.0",
+  "version": "2.9.1-Issue139.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.9.1-Issue139.0",
+      "version": "2.9.1-Issue139.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.1-Issue139.2",
+  "version": "2.9.1-Issue139.3",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.0",
+  "version": "2.9.1-Issue139.0",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.1-Issue139.1",
+  "version": "2.9.1-Issue139.2",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.9.1-Issue139.0",
+  "version": "2.9.1-Issue139.1",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -7,6 +7,7 @@ import { previewCompleteTasks, previewIncompleteTasks } from './SurveyTaskList.p
 import language from '../../../helpers/language'
 import { ColorDefinition, resolveColor } from '../../../helpers/colors'
 import { ButtonVariant } from '../../presentational/Button/Button'
+import { useInitializeView } from '../../../helpers/Initialization';
 
 export interface SurveyTaskListProps {
 	status: SurveyTaskStatus,
@@ -31,13 +32,7 @@ export default function (props: SurveyTaskListProps) {
 	const [tasks, setTasks] = useState<SurveyTask[] | null>(null);
 	const context = useContext(LayoutContext);
 
-	useEffect(() => {
-		initialize()
-		MyDataHelps.on("applicationDidBecomeVisible", initialize);
-		return () => {
-			MyDataHelps.off("applicationDidBecomeVisible", initialize);
-		}
-	}, [props.previewState]);
+	useInitializeView(initialize, ['surveyDidFinish'], [props.previewState])
 
 	function getSurveyTaskElement(task: SurveyTask) {
 		return <SingleSurveyTask buttonColor={props.buttonColor} buttonVariant={props.buttonVariant} key={task.id.toString()} task={task} disableClick={loading} />

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -7,7 +7,6 @@ import { previewCompleteTasks, previewIncompleteTasks } from './SurveyTaskList.p
 import language from '../../../helpers/language'
 import { ColorDefinition, resolveColor } from '../../../helpers/colors'
 import { ButtonVariant } from '../../presentational/Button/Button'
-import { useInitializeView } from '../../../helpers/Initialization';
 
 export interface SurveyTaskListProps {
 	status: SurveyTaskStatus,
@@ -32,7 +31,13 @@ export default function (props: SurveyTaskListProps) {
 	const [tasks, setTasks] = useState<SurveyTask[] | null>(null);
 	const context = useContext(LayoutContext);
 
-	useInitializeView(initialize, ['surveyDidFinish'], [props.previewState])
+	useEffect(() => {
+		initialize()
+		MyDataHelps.on("applicationDidBecomeVisible", initialize);
+		return () => {
+			MyDataHelps.off("applicationDidBecomeVisible", initialize);
+		}
+	}, [props.previewState]);
 
 	function getSurveyTaskElement(task: SurveyTask) {
 		return <SingleSurveyTask buttonColor={props.buttonColor} buttonVariant={props.buttonVariant} key={task.id.toString()} task={task} disableClick={loading} />

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
@@ -1,87 +1,75 @@
-﻿import React from "react"
-import { ComponentStory, ComponentMeta } from "@storybook/react"
-import SingleSurveyTask, { SingleSurveyTaskProps } from "./SingleSurveyTask"
-import Layout from "../Layout"
+﻿import React from 'react'
+import SingleSurveyTask, { SingleSurveyTaskProps } from './SingleSurveyTask'
+import Layout from '../Layout'
+import { add } from 'date-fns';
 
 export default {
-	title: "Presentational/SingleSurveyTask",
+	title: 'Presentational/SingleSurveyTask',
 	component: SingleSurveyTask,
-	parameters: {
-		layout: 'fullscreen',
-	}
-} as ComponentMeta<typeof SingleSurveyTask>;
+	parameters: {layout: 'fullscreen'}
+};
 
-const Template: ComponentStory<typeof SingleSurveyTask> = (args: SingleSurveyTaskProps) =>
-	<Layout colorScheme="auto">
-		<SingleSurveyTask {...args} />
-	</Layout>;
+const render = (args: SingleSurveyTaskProps) => <Layout colorScheme="auto"><SingleSurveyTask {...args} /></Layout>
 
-export const Incomplete = Template.bind({});
-Incomplete.args = {
-	task: {
-		id: "test",
-		status: "incomplete",
-		surveyDisplayName: "Pain Survey",
-		surveyDescription: "5 minutes",
-		surveyName: "PainSurvey",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: false,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier:"1"
-	}
+const now = new Date();
+
+const commonTask = {
+	surveyName: 'PainSurvey',
+	surveyDisplayName: 'Pain Survey',
+	surveyDescription: '5 minutes',
+	dueDate: add(new Date(now), {days: 3}).toISOString(),
 }
 
-export const Complete = Template.bind({});
-Complete.args = {
-	task: {
-		id: "test",
-		status: "complete",
-		surveyDisplayName: "Pain Survey",
-		surveyDescription: "5 minutes",
-		surveyName: "PainSurvey",
-		endDate: "2022-03-06T20:00:00Z",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: false,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier: "1"
-	}
-}
+export const Incomplete = {
+	args: {
+		task: {
+			...commonTask,
+			status: 'incomplete'
+		}
+	},
+	render: render
+};
 
-export const InProgress = Template.bind({});
-InProgress.args = {
-	task: {
-		id: "test",
-		status: "incomplete",
-		surveyDisplayName: "Pain Survey",
-		surveyDescription: "5 minutes",
-		surveyName: "PainSurvey",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: true,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier: "1"
-	}
-}
+export const IncompleteInProgress = {
+	args: {
+		task: {
+			...commonTask,
+			status: 'incomplete',
+			hasSavedProgress: true
+		}
+	},
+	render: render
+};
 
-export const LongDescription = Template.bind({});
-LongDescription.args = {
-	task: {
-		id: "test",
-		status: "incomplete",
-		surveyDisplayName: "Long Description",
-		surveyDescription: "Here is a really long description that will likely need to wrap.  It should wrap before overlapping the right chevron.",
-		surveyName: "PainSurvey",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: false,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier:"1"
-	}
-}
+export const IncompleteAlreadyClicked = {
+	args: {
+		previewState: 'hasBeenClicked',
+		task: {
+			...commonTask,
+			status: 'incomplete'
+		}
+	},
+	render: render
+};
 
+export const IncompleteWithLongDescription = {
+	args: {
+		task: {
+			...commonTask,
+			status: 'incomplete',
+			surveyDescription: 'Here is a really long description that will likely need to wrap.  It should wrap before overlapping the action indicator.'
+		}
+	},
+	render: render
+};
+
+export const Complete = {
+	args: {
+		task: {
+			...commonTask,
+			status: 'complete',
+			endDate: add(new Date(now), {days: -2}).toISOString(),
+		}
+	},
+	render: render
+};

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import "./SingleSurveyTask.css"
 import MyDataHelps, { SurveyTask } from "@careevolution/mydatahelps-js"
 import { IconDefinition } from '@fortawesome/fontawesome-common-types';
@@ -16,8 +16,12 @@ import { ColorDefinition, resolveColor } from '../../../helpers/colors';
 import { ButtonVariant } from '../Button/Button';
 import checkMark from '../../../assets/greenCheck.svg';
 import Action from '../Action';
+import LoadingIndicator from '../LoadingIndicator';
+
+export type SingleSurveyTaskPreviewState = 'hasBeenClicked';
 
 export interface SingleSurveyTaskProps {
+	previewState?: SingleSurveyTaskPreviewState,
 	task: SurveyTask,
 	descriptionIcon?: IconDefinition,
 	disableClick?: boolean
@@ -28,9 +32,15 @@ export interface SingleSurveyTaskProps {
 
 export default function (props: SingleSurveyTaskProps) {
 	const context = useContext(LayoutContext);
+	const [hasBeenClicked, setHasBeenClicked] = useState<boolean>(false);
+
+	useEffect(() => {
+		setHasBeenClicked(props.previewState === 'hasBeenClicked');
+	}, []);
 
 	function startSurvey(survey: string) {
-		if (!props.disableClick) {
+		if (!props.disableClick && !hasBeenClicked) {
+			setHasBeenClicked(true);
 			MyDataHelps.startSurvey(survey);
 		}
 	}
@@ -65,7 +75,7 @@ export default function (props: SingleSurveyTaskProps) {
 	}
 
 	if (props.task.status == 'incomplete') {
-		const indicator = <Button color={resolveColor(context.colorScheme, props.buttonColor)} variant={props.buttonVariant || "light"} onClick={() => { }}>
+		const indicator = hasBeenClicked ? <LoadingIndicator/> : <Button color={resolveColor(context.colorScheme, props.buttonColor)} variant={props.buttonVariant || "light"} onClick={() => {}}>
 			{!props.task.hasSavedProgress ? language("start") : language("resume")}
 		</Button>;
 		return (


### PR DESCRIPTION
## Overview

Fixes #139

This update is meant to prevent duplicate survey launches for tasks which have not yet had a chance to be cleared from the task list.  This can happen if there is some latency between the completion of a survey task and the refreshing of the task list.  This change effectively makes the `SingleSurveyTask` a single use widget.  That is to say, once it has been clicked, it will not be clickable again until the survey task list has been refreshed.  This should already happen any time a survey gets completed or canceled.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No new security risks.  This update just prevents double launching of a survey task.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
