### PR TITLE
Prevent duplicate task survey launches.

### DIFF
--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -7,6 +7,7 @@ import { previewCompleteTasks, previewIncompleteTasks } from './SurveyTaskList.p
 import language from '../../../helpers/language'
 import { ColorDefinition, resolveColor } from '../../../helpers/colors'
 import { ButtonVariant } from '../../presentational/Button/Button'
+import { useInitializeView } from '../../../helpers/Initialization';
 
 export interface SurveyTaskListProps {
 	status: SurveyTaskStatus,
@@ -28,19 +29,30 @@ export type SurveyTaskListListPreviewState = "IncompleteTasks" | "CompleteTasks"
 
 export default function (props: SurveyTaskListProps) {
 	const [loading, setLoading] = useState(true);
-	const [tasks, setTasks] = useState<SurveyTask[] | null>(null);
+	const [tasks, setTasksInner] = useState<SurveyTask[] | null>(null);
+	const [activeSurveys, setActiveSurveys] = useState<string[]>([]);
 	const context = useContext(LayoutContext);
 
-	useEffect(() => {
-		initialize()
-		MyDataHelps.on("applicationDidBecomeVisible", initialize);
-		return () => {
-			MyDataHelps.off("applicationDidBecomeVisible", initialize);
+	const setTasks = (tasks: SurveyTask[]): void => {
+		setTasksInner(tasks);
+		setActiveSurveys([]);
+	};
+
+	useInitializeView(initialize, [], [props.previewState]);
+
+	const isSurveyActive = (task: SurveyTask): boolean => {
+		return activeSurveys.includes(task.surveyName);
+	};
+
+	const onTaskClicked = (task: SurveyTask) => {
+		if (!loading && !isSurveyActive(task)) {
+			setActiveSurveys([...activeSurveys, task.surveyName]);
+			MyDataHelps.startSurvey(task.surveyName);
 		}
-	}, [props.previewState]);
+	};
 
 	function getSurveyTaskElement(task: SurveyTask) {
-		return <SingleSurveyTask buttonColor={props.buttonColor} buttonVariant={props.buttonVariant} key={task.id.toString()} task={task} disableClick={loading} />
+		return <SingleSurveyTask buttonColor={props.buttonColor} buttonVariant={props.buttonVariant} key={task.id.toString()} task={task} onClick={() => onTaskClicked(task)} surveyActive={isSurveyActive(task)}/>
 	}
 
 	function initialize() {

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -45,7 +45,7 @@ export default function (props: SurveyTaskListProps) {
 	};
 
 	const onTaskClicked = (task: SurveyTask) => {
-		if (!loading && !isSurveyActive(task)) {
+		if (!isSurveyActive(task)) {
 			setActiveSurveys([...activeSurveys, task.surveyName]);
 			MyDataHelps.startSurvey(task.surveyName);
 		}

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
@@ -1,87 +1,92 @@
-﻿import React from "react"
-import { ComponentStory, ComponentMeta } from "@storybook/react"
-import SingleSurveyTask, { SingleSurveyTaskProps } from "./SingleSurveyTask"
-import Layout from "../Layout"
+﻿import React from 'react'
+import SingleSurveyTask, { SingleSurveyTaskProps } from './SingleSurveyTask'
+import Layout from '../Layout'
+import { add } from 'date-fns';
+import { SurveyTask } from "@careevolution/mydatahelps-js";
+import Card from '../Card';
 
 export default {
-	title: "Presentational/SingleSurveyTask",
+	title: 'Presentational/SingleSurveyTask',
 	component: SingleSurveyTask,
-	parameters: {
-		layout: 'fullscreen',
-	}
-} as ComponentMeta<typeof SingleSurveyTask>;
+	parameters: {layout: 'fullscreen'}
+};
 
-const Template: ComponentStory<typeof SingleSurveyTask> = (args: SingleSurveyTaskProps) =>
-	<Layout colorScheme="auto">
+const render = (args: SingleSurveyTaskProps) => <Layout colorScheme="auto">
+	<Card>
 		<SingleSurveyTask {...args} />
-	</Layout>;
+	</Card>
+</Layout>;
 
-export const Incomplete = Template.bind({});
-Incomplete.args = {
-	task: {
-		id: "test",
-		status: "incomplete",
-		surveyDisplayName: "Pain Survey",
-		surveyDescription: "5 minutes",
-		surveyName: "PainSurvey",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: false,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier:"1"
+const now = new Date();
+
+const commonTask = {
+	surveyName: 'PainSurvey',
+	surveyDisplayName: 'Pain Survey',
+	surveyDescription: '5 minutes',
+	dueDate: add(new Date(now), {days: 3}).toISOString(),
+} as SurveyTask;
+
+const commonProps = {
+	onClick: () => {
+		console.log('task clicked');
 	}
-}
+} as SingleSurveyTaskProps;
 
-export const Complete = Template.bind({});
-Complete.args = {
-	task: {
-		id: "test",
-		status: "complete",
-		surveyDisplayName: "Pain Survey",
-		surveyDescription: "5 minutes",
-		surveyName: "PainSurvey",
-		endDate: "2022-03-06T20:00:00Z",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: false,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier: "1"
-	}
-}
+export const Incomplete = {
+	args: {
+		...commonProps,
+		task: {
+			...commonTask,
+			status: 'incomplete'
+		}
+	},
+	render: render
+};
 
-export const InProgress = Template.bind({});
-InProgress.args = {
-	task: {
-		id: "test",
-		status: "incomplete",
-		surveyDisplayName: "Pain Survey",
-		surveyDescription: "5 minutes",
-		surveyName: "PainSurvey",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: true,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier: "1"
-	}
-}
+export const IncompleteInProgress = {
+	args: {
+		...commonProps,
+		task: {
+			...commonTask,
+			status: 'incomplete',
+			hasSavedProgress: true
+		}
+	},
+	render: render
+};
 
-export const LongDescription = Template.bind({});
-LongDescription.args = {
-	task: {
-		id: "test",
-		status: "incomplete",
-		surveyDisplayName: "Long Description",
-		surveyDescription: "Here is a really long description that will likely need to wrap.  It should wrap before overlapping the right chevron.",
-		surveyName: "PainSurvey",
-		dueDate: (new Date()).toISOString(),
-		hasSavedProgress: false,
-		insertedDate: "2022-03-06T20:00:00Z",
-		modifiedDate: "2022-03-06T20:00:00Z",
-		surveyID: "1",
-		linkIdentifier:"1"
-	}
-}
+export const IncompleteSurveyActive = {
+	args: {
+		...commonProps,
+		task: {
+			...commonTask,
+			status: 'incomplete'
+		},
+		surveyActive: true
+	},
+	render: render
+};
 
+export const IncompleteWithLongDescription = {
+	args: {
+		...commonProps,
+		task: {
+			...commonTask,
+			status: 'incomplete',
+			surveyDescription: 'Here is a really long description that will likely need to wrap.  It should wrap before overlapping the action indicator.'
+		}
+	},
+	render: render
+};
+
+export const Complete = {
+	args: {
+		...commonProps,
+		task: {
+			...commonTask,
+			status: 'complete',
+			endDate: add(new Date(now), {days: -2}).toISOString(),
+		}
+	},
+	render: render
+};

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -16,11 +16,13 @@ import { ColorDefinition, resolveColor } from '../../../helpers/colors';
 import { ButtonVariant } from '../Button/Button';
 import checkMark from '../../../assets/greenCheck.svg';
 import Action from '../Action';
+import LoadingIndicator from '../LoadingIndicator';
 
 export interface SingleSurveyTaskProps {
 	task: SurveyTask,
 	descriptionIcon?: IconDefinition,
-	disableClick?: boolean
+	onClick: () => void;
+	surveyActive?: boolean;
 	innerRef?: React.Ref<HTMLDivElement>;
 	buttonColor?: ColorDefinition;
 	buttonVariant?: ButtonVariant;
@@ -28,12 +30,6 @@ export interface SingleSurveyTaskProps {
 
 export default function (props: SingleSurveyTaskProps) {
 	const context = useContext(LayoutContext);
-
-	function startSurvey(survey: string) {
-		if (!props.disableClick) {
-			MyDataHelps.startSurvey(survey);
-		}
-	}
 
 	const datesAreOnSameDay = (first: Date, second: Date) =>
 		first.getFullYear() === second.getFullYear() &&
@@ -65,13 +61,13 @@ export default function (props: SingleSurveyTaskProps) {
 	}
 
 	if (props.task.status == 'incomplete') {
-		const indicator = <Button color={resolveColor(context.colorScheme, props.buttonColor)} variant={props.buttonVariant || "light"} onClick={() => { }}>
+		const indicator = props.surveyActive ? <LoadingIndicator/> : <Button color={resolveColor(context.colorScheme, props.buttonColor)} variant={props.buttonVariant || "light"} onClick={() => {}}>
 			{!props.task.hasSavedProgress ? language("start") : language("resume")}
 		</Button>;
 		return (
 			<Action renderAs='div'
 				innerRef={props.innerRef}
-				onClick={() => startSurvey(props.task.surveyName!)}
+				onClick={() => props.onClick()}
 				className="mdhui-single-survey-task incomplete"
 				indicator={indicator}>
 				<div className="survey-name">{props.task.surveyDisplayName}</div>


### PR DESCRIPTION
## Overview

Fixes #139 

Here is another approach at fixing the issue with duplicate task survey launches.  As described previously, there are scenarios where a delay in refreshing the task list can allow a participant to launch a task survey more than once, even when the task has already been completed.

In order for refreshes to work correctly, management of the "active surveys" had to be moved up to the list itself.  This also meant that I had to move the click handling up to the list as well.  The single survey task no longer launches the survey directly. Instead, it has a click handler property and a flag for whether the task's survey is currently active (so that the spinner can be displayed).

The combination of these changes results in the clicked survey task displaying a spinner while the survey is active and then that spinner gets removed (and clicking gets re-enabled) once the task list has had a chance to refresh.

![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/5408603/1f44c786-951c-4ac5-a7c6-2f264db97db4)

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No new security implications.  This change just prevents relaunching of completed task surveys.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
