### PR TITLE
Add support for applying an alpha value to resolved colors.

### DIFF
--- a/src/components/presentational/CalendarDay/CalendarDay.stories.tsx
+++ b/src/components/presentational/CalendarDay/CalendarDay.stories.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import CalendarDay, { CalendarDayProps, CalendarDayStateConfiguration } from './CalendarDay';
 import { Calendar, Card, DateRangeContext, DateRangeCoordinator, Layout } from '../../presentational';
 import { add, formatISO, isSameDay, parseISO } from 'date-fns';
+import { resolveColor } from "../../../helpers/colors";
 
 export default {
     title: 'Presentational/CalendarDay',
@@ -38,7 +39,7 @@ const commonProps = {
                 background: '#35A6A0'
             },
             streak: true,
-            streakColor: 'rgba(53,166,160,0.4)'
+            streakColor: resolveColor('light', '#35A6A0', 0.4)
         }
     },
     onClick: () => {
@@ -194,14 +195,14 @@ function CalendarDayInCalendar() {
                 color: '#000'
             },
             streak: true,
-            streakColor: 'rgba(248,106,92,0.4)'
+            streakColor: resolveColor('light', '#F86A5C', 0.4)
         },
         'state2': {
             style: {
                 background: '#35A6A0'
             },
             streak: true,
-            streakColor: 'rgba(53,166,160,0.4)'
+            streakColor: resolveColor('light', '#35A6A0', 0.4)
         },
         'state3': {
             style: {

--- a/src/helpers/colors.ts
+++ b/src/helpers/colors.ts
@@ -1,14 +1,29 @@
 export type ColorDefinition = string | { lightMode?: string, darkMode?: string }
 
-export function resolveColor(colorScheme: "light" | "dark", colorDefinition?: ColorDefinition): string | undefined {
-    if (!colorDefinition) {
-        return undefined;
-    }
-    if (typeof colorDefinition === 'string' || colorDefinition instanceof String) {
-        return colorDefinition as string;
-    }
-    if (colorScheme === "dark" && colorDefinition.darkMode) {
-        return colorDefinition.darkMode;
-    }
-    return colorDefinition.lightMode || colorDefinition.darkMode;
+function resolveColorInner(colorScheme: 'light' | 'dark', colorDefinition?: ColorDefinition): string | undefined {
+	if (!colorDefinition) {
+		return undefined;
+	}
+	if (typeof colorDefinition === 'string' || colorDefinition instanceof String) {
+		return colorDefinition as string;
+	}
+	if (colorScheme === 'dark' && colorDefinition.darkMode) {
+		return colorDefinition.darkMode;
+	}
+	return colorDefinition.lightMode || colorDefinition.darkMode;
+}
+
+function addAlpha(hexColor: string, alpha: number): string | undefined {
+	if (alpha < 0 || alpha > 1) {
+		return hexColor;
+	}
+	return `${hexColor}${Math.floor(alpha * 255).toString(16).padStart(2, '0')}`;
+}
+
+export function resolveColor(colorScheme: 'light' | 'dark', colorDefinition?: ColorDefinition, alpha?: number): string | undefined {
+	let resolvedColor = resolveColorInner(colorScheme, colorDefinition);
+	if (resolvedColor && alpha) {
+		resolvedColor = addAlpha(resolvedColor, alpha);
+	}
+	return resolvedColor;
 }


### PR DESCRIPTION
## Overview

This branch updates the `resolveColor` helper function to accept an optional alpha value to be applied to resolved colors.

I have updated the `CalendarDay` streak highlighting stories to demostrate how this can be utilized.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No new security risks.  This change just allows for applying optional alpha transparency to resolved colors.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.