### PR TITLE
Adjust some out-of-the-box styling on the CalendarDay component.

### DIFF
--- a/src/components/presentational/CalendarDay/CalendarDay.css
+++ b/src/components/presentational/CalendarDay/CalendarDay.css
@@ -1,7 +1,11 @@
+.mdhui-calendar table tr:has(.mdhui-calendar-day) td {
+    height: 40px;
+}
+
 .mdhui-calendar-day {
     display: inline-block;
     width: 100%;
-    height: 30px;
+    height: 22px;
     margin-top: 5px;
     --mdhui-calendar-day-streak-color: #ddd;
 }
@@ -19,13 +23,28 @@
 }
 
 .mdhui-calendar-day-value {
+    background: #DBDBDB;
     height: 40px;
     width: 40px;
     line-height: 40px;
     border-radius: 50%;
     text-align: center;
     vertical-align: middle;
-    margin: -5px auto 0;
+    margin: -10px auto 0;
     font-size: 15px;
     font-weight: bold;
+}
+
+.mdhui-calendar-day-today .mdhui-calendar-day-value {
+    background: #369CFF;
+    color: #fff;
+    border: 2px solid #fff;
+    margin-top: -12px;
+}
+
+.mdhui-calendar-day-future .mdhui-calendar-day-value {
+    background: #fff;
+    color: #DBDBDB;
+    border: 2px solid #DBDBDB;
+    margin-top: -12px;
 }

--- a/src/components/presentational/CalendarDay/CalendarDay.stories.tsx
+++ b/src/components/presentational/CalendarDay/CalendarDay.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import CalendarDay, { CalendarDayProps, CalendarDayStateConfiguration } from './CalendarDay';
 import { Calendar, Card, DateRangeContext, DateRangeCoordinator, Layout } from '../../presentational';
-import { add, formatISO, isSameDay, parseISO } from 'date-fns';
+import { add, formatISO, isBefore, isSameDay, parseISO, startOfDay } from 'date-fns';
 
 export default {
     title: 'Presentational/CalendarDay',
@@ -10,12 +10,14 @@ export default {
 };
 
 const render = (args: CalendarDayProps) => <Layout colorScheme="auto">
-    <div style={{width: '60px', margin: '0 auto'}}>
+    <div style={{width: '60px', margin: '20px auto 0'}}>
         <CalendarDay {...args} />
     </div>
 </Layout>;
 
 const testDate = parseISO('2023-11-29T21:41:43.678Z');
+const now = new Date();
+const tomorrow = startOfDay(add(new Date(now), {days: 1}));
 
 const commonProps = {
     year: testDate.getFullYear(),
@@ -59,6 +61,32 @@ export const Default = {
         ...commonProps,
         computeStateForDay: (date: Date): string => {
             return 'state0';
+        }
+    },
+    render: render
+};
+
+export const Today = {
+    args: {
+        ...commonProps,
+        year: now.getFullYear(),
+        month: now.getMonth(),
+        day: now.getDate(),
+        computeStateForDay: (date: Date): string => {
+            return 'today';
+        }
+    },
+    render: render
+};
+
+export const Future = {
+    args: {
+        ...commonProps,
+        year: tomorrow.getFullYear(),
+        month: tomorrow.getMonth(),
+        day: tomorrow.getDate(),
+        computeStateForDay: (date: Date): string => {
+            return 'future';
         }
     },
     render: render
@@ -172,7 +200,7 @@ export const StreakBothCustomColor = {
     render: render
 };
 
-export const InCalendar = {
+export const InCalendarNoData = {
     render: () => {
         return <Layout colorScheme="auto">
             <Card>
@@ -184,7 +212,19 @@ export const InCalendar = {
     }
 };
 
-function CalendarDayInCalendar() {
+export const InCalendarWithData = {
+    render: () => {
+        return <Layout colorScheme="auto">
+            <Card>
+                <DateRangeCoordinator intervalType="Month">
+                    <CalendarDayInCalendar withData={true}/>
+                </DateRangeCoordinator>
+            </Card>
+        </Layout>
+    }
+};
+
+function CalendarDayInCalendar(props: { withData?: boolean }) {
     let dateRangeContext = useContext(DateRangeContext);
 
     const stateConfiguration: CalendarDayStateConfiguration = {
@@ -218,17 +258,19 @@ function CalendarDayInCalendar() {
     };
 
     const computeStateForDay = (date: Date): string => {
-        if ((date.getDate() >= 5 && date.getDate() <= 13) || date.getDate() === 17) {
-            return 'state1';
-        }
-        if ((date.getDate() >= 2 && date.getDate() <= 4) || (date.getDate() >= 19 && date.getDate() <= 22) || date.getDate() === 16) {
-            return 'state2';
-        }
-        if (date.getDate() >= 24 && date.getDate() <= 25) {
-            return 'state3';
-        }
-        if (date.getDate() >= 26 && date.getDate() <= 27) {
-            return 'state4';
+        if (props.withData && isBefore(date, new Date())) {
+            if ((date.getDate() >= 5 && date.getDate() <= 13) || date.getDate() === 17) {
+                return 'state1';
+            }
+            if ((date.getDate() >= 2 && date.getDate() <= 4) || (date.getDate() >= 19 && date.getDate() <= 22) || date.getDate() === 16) {
+                return 'state2';
+            }
+            if (date.getDate() >= 24 && date.getDate() <= 25) {
+                return 'state3';
+            }
+            if (date.getDate() >= 26 && date.getDate() <= 27) {
+                return 'state4';
+            }
         }
         return 'state5';
     };

--- a/src/components/presentational/CalendarDay/CalendarDay.tsx
+++ b/src/components/presentational/CalendarDay/CalendarDay.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useContext } from 'react';
 import './CalendarDay.css';
 import { LayoutContext } from '../Layout';
 import { ColorDefinition, resolveColor } from '../../../helpers/colors';
-import { add } from 'date-fns';
+import { add, isAfter, isSameDay } from 'date-fns';
 
 export type CalendarDayStateConfiguration = Record<string, { style?: CSSProperties, streak?: boolean, streakColor?: ColorDefinition }>;
 
@@ -47,8 +47,15 @@ export default function (props: CalendarDayProps) {
 
     let currentDayStateConfiguration = props.stateConfiguration[currentDayState];
 
-    let dayClasses = ['mdhui-calendar-day'];
+    let dayClasses: string[] = ['mdhui-calendar-day'];
     let dayStyle: CSSProperties | undefined;
+
+    if (isSameDay(date, new Date())) {
+        dayClasses.push('mdhui-calendar-day-today');
+    } else if (isAfter(date, new Date())) {
+        dayClasses.push('mdhui-calendar-day-future');
+    }
+
     if (currentDayStateConfiguration?.streak) {
         if (currentDayState === previousDayState && currentDayState === nextDayState && canStreakLeft(date) && canStreakRight(date)) {
             dayClasses.push('mdhui-calendar-day-streak-both');


### PR DESCRIPTION
## Overview

This branch adjusts some default styling in the `CalendarDay` component to reduce the amount of boilerplate styling needed in project specific calendar implementations.

![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/5408603/c0b5be32-4aba-46dc-86a9-6216e5a1b68b)

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risks.  Just a styling update.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.