### PR TITLE
Celebration Step - Fix confetti on iOS

### DIFF
--- a/src/components/step/CelebrationStep/CelebrationStep.tsx
+++ b/src/components/step/CelebrationStep/CelebrationStep.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import MyDataHelps from '@careevolution/mydatahelps-js';
 import StepLayout from '../StepLayout'
 import StepTitle from '../StepTitle';
@@ -20,10 +20,22 @@ export interface CelebrationStepProps {
 }
 
 export default function (props: CelebrationStepProps) {
-    startConfetti();
-    window.setTimeout(function () {
-        stopConfetti();
-    }, 1200);
+    function runConfetti() {
+        if (window.innerWidth === 0 || window.innerHeight === 0) {
+            window.setTimeout(runConfetti, 50);
+            return;
+        }
+
+        startConfetti();
+        window.setTimeout(function () {
+            stopConfetti();
+        }, 1200);
+    }
+
+    useEffect(() => {
+        runConfetti();
+    }, []);
+
     return (
       <StepLayout>
           <StepImageIcon srcUrl={props.iconUrl} />


### PR DESCRIPTION
## Overview

The MDH iOS app has slightly different handling of WebViewSteps that are defined directly in a template versus ones that are specified by an external URL.  In both cases they are "preloaded" before the step actually comes in to view.  For the Celebration Step, this means that it gets an initial call to `startConfetti` when the size of the `window` is zero.  This generates all of the confetti particles in one spot, so that even when `startConfetti` is called again when the step is viewed, and the window is the right size, they start at 0,0.

I played with a few options for this, but ultimately due to timing issues, the only reliable fix was to wait to start any confetti until the window has a valid width and height.  I've tested this fix on iOS, Android, and Web and it appears to work correctly on all three platforms.

## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner