### PR TITLE
Use an unstyled button for clickable calendar days so they are part of the tab traversal.

### DIFF
--- a/src/components/presentational/CalendarDay/CalendarDay.stories.tsx
+++ b/src/components/presentational/CalendarDay/CalendarDay.stories.tsx
@@ -208,7 +208,19 @@ export const InCalendarNoData = {
                     <CalendarDayInCalendar/>
                 </DateRangeCoordinator>
             </Card>
-        </Layout>
+        </Layout>;
+    }
+};
+
+export const InCalendarNoDataWithClickHandler = {
+    render: () => {
+        return <Layout colorScheme="auto">
+            <Card>
+                <DateRangeCoordinator intervalType="Month">
+                    <CalendarDayInCalendar withClickHandler={true}/>
+                </DateRangeCoordinator>
+            </Card>
+        </Layout>;
     }
 };
 
@@ -220,11 +232,23 @@ export const InCalendarWithData = {
                     <CalendarDayInCalendar withData={true}/>
                 </DateRangeCoordinator>
             </Card>
-        </Layout>
+        </Layout>;
     }
 };
 
-function CalendarDayInCalendar(props: { withData?: boolean }) {
+export const InCalendarWithDataWithClickHandler = {
+    render: () => {
+        return <Layout colorScheme="auto">
+            <Card>
+                <DateRangeCoordinator intervalType="Month">
+                    <CalendarDayInCalendar withData={true} withClickHandler={true}/>
+                </DateRangeCoordinator>
+            </Card>
+        </Layout>;
+    }
+};
+
+function CalendarDayInCalendar(props: { withData?: boolean, withClickHandler?: boolean }) {
     let dateRangeContext = useContext(DateRangeContext);
 
     const stateConfiguration: CalendarDayStateConfiguration = {
@@ -286,7 +310,7 @@ function CalendarDayInCalendar(props: { withData?: boolean }) {
             day={day}
             stateConfiguration={stateConfiguration}
             computeStateForDay={computeStateForDay}
-            onClick={onDayClicked}
+            onClick={props.withClickHandler ? onDayClicked : undefined}
         />;
     };
 

--- a/src/components/presentational/CalendarDay/CalendarDay.tsx
+++ b/src/components/presentational/CalendarDay/CalendarDay.tsx
@@ -3,6 +3,7 @@ import './CalendarDay.css';
 import { LayoutContext } from '../Layout';
 import { ColorDefinition, resolveColor } from '../../../helpers/colors';
 import { add, isAfter, isSameDay } from 'date-fns';
+import UnstyledButton from '../UnstyledButton';
 
 export type CalendarDayStateConfiguration = Record<string, { style?: CSSProperties, streak?: boolean, streakColor?: ColorDefinition }>;
 
@@ -12,7 +13,7 @@ export interface CalendarDayProps {
     day?: number;
     stateConfiguration: CalendarDayStateConfiguration;
     computeStateForDay: (date: Date) => string;
-    onClick: (date: Date) => void;
+    onClick?: (date: Date) => void;
     innerRef?: React.Ref<HTMLDivElement>;
 }
 
@@ -69,7 +70,12 @@ export default function (props: CalendarDayProps) {
         }
     }
 
-    return <div ref={props.innerRef} className={dayClasses.join(' ')} style={dayStyle} onClick={() => props.onClick(date)}>
-        <div className="mdhui-calendar-day-value" style={currentDayStateConfiguration?.style}>{date.getDate()}</div>
+    return <div ref={props.innerRef} className={dayClasses.join(' ')} style={dayStyle}>
+        {props.onClick &&
+            <UnstyledButton className="mdhui-calendar-day-value" style={currentDayStateConfiguration?.style} onClick={() => props.onClick!(date)}>{date.getDate()}</UnstyledButton>
+        }
+        {!props.onClick &&
+            <div className="mdhui-calendar-day-value" style={currentDayStateConfiguration?.style}>{date.getDate()}</div>
+        }
     </div>;
 }


### PR DESCRIPTION
## Overview

This branch updates the `CalendarDay` component such that it uses an `UnstyledButton` for clickable days to ensure they are included in the tab traversal of the page.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No new security risks.  Just a rendering update.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.