### PR TITLE
Remove Title from BloodPressure Viz

### DIFF
--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -291,7 +291,6 @@ export default function (props: BloodPressureVisualizationProps) {
     else {
         return (
             <>
-                <Title defaultMargin order={3}>{language("blood-pressure")}</Title>
                 <DateRangeNavigator intervalType="Week" intervalStart={datePagerStartDate} onIntervalChange={pageWeek}></DateRangeNavigator>
                 {pageWeeklyData(datePagerStartDate)}
                 {pageWeeklyMetrics(datePagerStartDate)}

--- a/src/helpers/strings-en.ts
+++ b/src/helpers/strings-en.ts
@@ -144,12 +144,10 @@
     "new-points-next-reward-prefix": "You now need ",
     "new-points-next-reward-suffix": " points to unlock your next reward.",
     "new-points-done-button-text": "Done",
-    "blood-pressure" : "Blood Pressure",
     "systolic-average" : "Systolic Average",
     "diastolic-average" : "Diastolic Average",
     "highest-systolic" : "Highest Systolic",
-    "lowest-diastolic" : "Lowest Diastolic",
-    "log-blood-pressure" : "Log Blood Pressure"
+    "lowest-diastolic" : "Lowest Diastolic"
 };
 
 export default strings;


### PR DESCRIPTION
## Overview

Remove Title from the Blood Pressure Visualization. 

## Security

REMINDER: All file contents are public.

- [x ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner