### PR TITLE
Fix calendar day rendering.

### DIFF
--- a/src/components/presentational/CalendarDay/CalendarDay.css
+++ b/src/components/presentational/CalendarDay/CalendarDay.css
@@ -22,7 +22,12 @@
     background-color: var(--mdhui-calendar-day-streak-color);
 }
 
+.mdhui-calendar-day .mdhui-unstyled-button {
+    margin: 0 auto;
+}
+
 .mdhui-calendar-day-value {
+    position: relative;
     background: #DBDBDB;
     height: 40px;
     width: 40px;

--- a/src/components/presentational/CalendarDay/CalendarDay.tsx
+++ b/src/components/presentational/CalendarDay/CalendarDay.tsx
@@ -72,7 +72,9 @@ export default function (props: CalendarDayProps) {
 
     return <div ref={props.innerRef} className={dayClasses.join(' ')} style={dayStyle}>
         {props.onClick &&
-            <UnstyledButton className="mdhui-calendar-day-value" style={currentDayStateConfiguration?.style} onClick={() => props.onClick!(date)}>{date.getDate()}</UnstyledButton>
+            <UnstyledButton onClick={() => props.onClick!(date)}>
+                <div className="mdhui-calendar-day-value" style={currentDayStateConfiguration?.style}>{date.getDate()}</div>
+            </UnstyledButton>
         }
         {!props.onClick &&
             <div className="mdhui-calendar-day-value" style={currentDayStateConfiguration?.style}>{date.getDate()}</div>


### PR DESCRIPTION
## Overview

This branch fixes calendar day rendering when a click handler is present.  I broke this functionality when I added the `UnstyledButton` as part of this PR: https://github.com/CareEvolution/MyDataHelpsUI/pull/176

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just a small rendering adjustment.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.