### PR TITLE
Add innerRef props to SeverityCalendar and BP viz 

### DIFF
--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -287,7 +287,7 @@ export default function (props: BloodPressureVisualizationProps) {
     useInitializeView(initialize, [], [props.previewState]);
 
     if (!bloodPressureData) {
-        return <LoadingIndicator />;
+        return <LoadingIndicator innerRef={props.innerRef}/>;
     }
     else {
         return (

--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -18,7 +18,8 @@ export type BloodPressurePreviewState = "Default" | "NoData" | "Loading";
 export interface BloodPressureVisualizationProps {
     previewState?: BloodPressurePreviewState,
     surveyDataSource: SurveyBloodPressureDataParameters,
-    weekStartsOn?: WeekStartsOn
+    weekStartsOn?: WeekStartsOn,
+    innerRef?: React.Ref<HTMLDivElement>
 };
 
 interface BloodPressureDumbbell {
@@ -290,11 +291,11 @@ export default function (props: BloodPressureVisualizationProps) {
     }
     else {
         return (
-            <>
+            <div ref={props.innerRef}>
                 <DateRangeNavigator intervalType="Week" intervalStart={datePagerStartDate} onIntervalChange={pageWeek}></DateRangeNavigator>
                 {pageWeeklyData(datePagerStartDate)}
                 {pageWeeklyMetrics(datePagerStartDate)}
-            </>
+            </div>
         )
     }
 }

--- a/src/components/container/SeverityCalendar/SeverityCalendar.tsx
+++ b/src/components/container/SeverityCalendar/SeverityCalendar.tsx
@@ -13,7 +13,7 @@ export interface SeverityCalendarProps {
     surveyName: string,
     dateRecordedResultIdentifier?: string,
     severityResultIdentifier: string,
-    severityValueMapper? : (value: string) => string,
+    severityValueMapper?: (value: string) => string,
     intervalStart?: Date,
     previewState?: SeverityCalendarPreviewState,
     innerRef?: React.Ref<HTMLDivElement>
@@ -49,9 +49,9 @@ export default function (props: SeverityCalendarProps) {
 
         var resultByDateMap = new Map<string, SeverityLogEntry>();
         var groupedByResult = groupAnswersByResult(results);
-        const ceSeverityValueMapper = function(severityAnswer : string){
+        const ceSeverityValueMapper = function (severityAnswer: string) {
             let severity = "";
-            if (['mild', 'moderate', 'severe'].includes(severityAnswer.toLowerCase())){
+            if (['mild', 'moderate', 'severe'].includes(severityAnswer.toLowerCase())) {
                 severity = severityAnswer.toLowerCase();
             }
             return severity;
@@ -65,7 +65,7 @@ export default function (props: SeverityCalendarProps) {
                     let dateOfSeverity = parseISO(grouping.dateObservedAnswer ? grouping.dateObservedAnswer.answers[0] : grouping.severityAnswer.date);
                     let key = format(startOfDay(dateOfSeverity), 'MM/dd/yyyy');
                     let exists = resultByDateMap.get(key);
-                    if (exists){
+                    if (exists) {
                         if (grouping.severityAnswer.date > exists.dateEntered) {
                             exists.dateObserved = dateOfSeverity;
                             exists.severity = severity;
@@ -143,7 +143,7 @@ export default function (props: SeverityCalendarProps) {
     useInitializeView(initialize, [], [props.previewState]);
 
     if (!data) {
-        return <LoadingIndicator />;
+        return <LoadingIndicator innerRef={props.innerRef} />;
     } else {
         return <Calendar innerRef={props.innerRef} className="mdhui-simple-calendar" year={intervalStart.getFullYear()} month={intervalStart.getMonth()} dayRenderer={renderDay} />;
     }

--- a/src/components/container/SeverityCalendar/SeverityCalendar.tsx
+++ b/src/components/container/SeverityCalendar/SeverityCalendar.tsx
@@ -16,6 +16,7 @@ export interface SeverityCalendarProps {
     severityValueMapper? : (value: string) => string,
     intervalStart?: Date,
     previewState?: SeverityCalendarPreviewState,
+    innerRef?: React.Ref<HTMLDivElement>
 }
 
 interface SeverityLogEntry {
@@ -144,6 +145,6 @@ export default function (props: SeverityCalendarProps) {
     if (!data) {
         return <LoadingIndicator />;
     } else {
-        return <Calendar className="mdhui-simple-calendar" year={intervalStart.getFullYear()} month={intervalStart.getMonth()} dayRenderer={renderDay} />;
+        return <Calendar innerRef={props.innerRef} className="mdhui-simple-calendar" year={intervalStart.getFullYear()} month={intervalStart.getMonth()} dayRenderer={renderDay} />;
     }
 } 


### PR DESCRIPTION
## Overview

InnerRef properties were added to the Severity Calendar and BP Viz. These properties are needed to get references to components

## Security

REMINDER: All file contents are public.

- [x ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner