### PR TITLE
Update the InboxView to allow for category based filtering.

### DIFF
--- a/src/components/view/InboxView/InboxView.tsx
+++ b/src/components/view/InboxView/InboxView.tsx
@@ -19,6 +19,7 @@ export interface InboxViewProps {
     resourceImageAlignment?: ResourceImageAlignment;
     messageViewerUrl: string;
     historyViewerUrl: string;
+    itemCategory?: string;
 }
 
 export default function (props: InboxViewProps) {
@@ -59,6 +60,7 @@ function InboxViewInner(props: InboxViewProps) {
             messageViewerUrl={props.messageViewerUrl}
             onItemsLoaded={setMessages}
             hideLoadingIndicator={true}
+            category={props.itemCategory}
         />
         <InboxItemList
             previewState={props.previewState === 'default' ? 'incomplete survey' : undefined}
@@ -70,6 +72,7 @@ function InboxViewInner(props: InboxViewProps) {
             onItemsLoaded={setSurveys}
             hideLoadingIndicator={true}
             surveyVariant={props.surveyVariant}
+            category={props.itemCategory}
         />
         <InboxItemList
             previewState={props.previewState === 'default' ? 'incomplete resource' : undefined}
@@ -81,6 +84,7 @@ function InboxViewInner(props: InboxViewProps) {
             onItemsLoaded={setResources}
             hideLoadingIndicator={true}
             resourceImageAlignment={props.resourceImageAlignment}
+            category={props.itemCategory}
         />
         <div className="mdhui-inbox-recently-completed">
             <InboxItemList
@@ -94,6 +98,7 @@ function InboxViewInner(props: InboxViewProps) {
                 showTitleWhenEmpty={true}
                 emptyText={language('inbox-view-recently-completed-empty-text')}
                 syncOnChanges={true}
+                category={props.itemCategory}
             />
             {!loading &&
                 <Card>


### PR DESCRIPTION
## Overview

This branch just adds a pass through property so the `InboxView` can be limited to items with specific categories.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [x] MyDataHelps iOS app
- [x] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation

n/a