### PR TITLE
Add an AsthmaControlCalendar component.

### DIFF
--- a/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.css
+++ b/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.css
@@ -1,0 +1,50 @@
+.mdhui-asthma-control-calendar-log-entry-components {
+    display: grid;
+    grid-template-columns: max-content max-content max-content auto;
+    grid-column-gap: 8px;
+    align-items: center;
+    padding: 0 16px 16px;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component {
+    display: grid;
+    grid-template-columns: max-content auto;
+    align-items: center;
+    height: 24px;
+    line-height: 24px;
+    border-radius: 12px;
+    font-size: 0.8em;
+    padding: 0 8px;
+    color: #000;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component-symptoms {
+    background: #f9debf;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component-impacts {
+    background: #e6d6fa;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component-triggers {
+    background: #bfbfbf;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component-icon {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin-right: 4px;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component-symptoms .mdhui-asthma-control-calendar-log-entry-component-icon {
+    background: #E87C00;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component-impacts .mdhui-asthma-control-calendar-log-entry-component-icon {
+    background: #9D5BED;
+}
+
+.mdhui-asthma-control-calendar-log-entry-component-triggers .mdhui-asthma-control-calendar-log-entry-component-icon {
+    background: #000000;
+}

--- a/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.previewData.ts
+++ b/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.previewData.ts
@@ -1,0 +1,43 @@
+import { AsthmaLogEntry, AsthmaSymptomLevel } from '../../model';
+import { dateToAsthmaLogEntryIdentifier } from '../../helpers';
+import { add } from 'date-fns';
+
+export type AsthmaControlCalendarPreviewState = 'no logs' | 'some logs';
+
+export interface AsthmaControlCalendarPreviewData {
+    logEntries: AsthmaLogEntry[];
+}
+
+const createLogEntry = (daysAgo: number, symptomLevel: AsthmaSymptomLevel): AsthmaLogEntry => {
+    return {
+        identifier: dateToAsthmaLogEntryIdentifier(add(new Date(), {days: -daysAgo})),
+        symptomLevel: symptomLevel,
+        symptoms: [],
+        impacts: [],
+        triggers: []
+    }
+};
+
+export const previewData: Record<AsthmaControlCalendarPreviewState, AsthmaControlCalendarPreviewData> = {
+    'no logs': {
+        logEntries: []
+    },
+    'some logs': {
+        logEntries: [
+            createLogEntry(20, 'none'),
+            {...createLogEntry(19, 'mild'), impacts: ['Limit your daily activity']},
+            createLogEntry(17, 'none'),
+            createLogEntry(16, 'none'),
+            createLogEntry(15, 'none'),
+            createLogEntry(8, 'none'),
+            createLogEntry(7, 'none'),
+            createLogEntry(6, 'none'),
+            createLogEntry(5, 'none'),
+            createLogEntry(4, 'none'),
+            createLogEntry(3, 'none'),
+            createLogEntry(2, 'mild'),
+            {...createLogEntry(1, 'mild'), symptoms: ['Difficulty breathing'], impacts: ['Limit your daily activity'], triggers: ['Smoke']},
+            {...createLogEntry(0, 'mild'), impacts: ['Limit your daily activity']}
+        ]
+    }
+};

--- a/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.stories.tsx
+++ b/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.stories.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import AsthmaControlCalendar, { AsthmaControlCalendarProps } from './AsthmaControlCalendar';
+import { Card, DateRangeCoordinator, Layout } from '../../../presentational';
+
+export default {
+    title: 'Asthma/Components/AsthmaControlCalendar',
+    component: AsthmaControlCalendar,
+    parameters: {layout: 'fullscreen'}
+};
+
+interface AsthmaControlCalendarStoryArgs extends AsthmaControlCalendarProps {
+    colorScheme: 'auto' | 'light' | 'dark';
+    onCard: boolean;
+}
+
+const render = (args: AsthmaControlCalendarStoryArgs) => {
+    return <Layout colorScheme={args.colorScheme}>
+        {args.onCard &&
+            <Card>
+                <DateRangeCoordinator intervalType="Month">
+                    <AsthmaControlCalendar {...args} />
+                </DateRangeCoordinator>
+            </Card>
+        }
+
+        {!args.onCard &&
+            <DateRangeCoordinator intervalType="Month">
+                <AsthmaControlCalendar {...args} />
+            </DateRangeCoordinator>
+        }
+    </Layout>;
+};
+
+export const Default = {
+    args: {
+        colorScheme: 'auto',
+        previewState: 'no logs',
+        variant: 'compact',
+        onCard: false
+    },
+    argTypes: {
+        colorScheme: {
+            name: 'color scheme',
+            control: 'radio',
+            options: ['auto', 'light', 'dark']
+        },
+        previewState: {
+            name: 'state',
+            control: 'radio',
+            options: ['no logs', 'some logs']
+        },
+        variant: {
+            control: 'radio',
+            options: ['compact', 'verbose']
+        },
+        onCard: {
+            name: 'on card',
+            if: {arg: 'variant', 'eq': 'compact'}
+        }
+    },
+    render: render
+};

--- a/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.tsx
+++ b/src/components/asthma/components/AsthmaControlCalendar/AsthmaControlCalendar.tsx
@@ -1,0 +1,157 @@
+import React, { useContext, useState } from 'react';
+import './AsthmaControlCalendar.css';
+import { add, differenceInDays, format, formatISO, isAfter, isBefore, isSameDay, parseISO, startOfMonth, startOfToday } from 'date-fns';
+import { AsthmaLogEntry } from '../../model';
+import { useInitializeView } from '../../../../helpers/Initialization';
+import { asthmaDataService, computeAsthmaControlState, dateToAsthmaLogEntryIdentifier, getAsthmaSymptomLevelText } from '../../helpers';
+import { AsthmaControlCalendarPreviewState, previewData } from './AsthmaControlCalendar.previewData';
+import { Action, Calendar, CalendarDay, CalendarDayStateConfiguration, Card, DateRangeContext, Section } from '../../../presentational';
+import MyDataHelps from '@careevolution/mydatahelps-js';
+import language from '../../../../helpers/language';
+
+export type AsthmaControlCalendarVariant = 'compact' | 'verbose';
+
+export interface AsthmaControlCalendarProps {
+    previewState?: AsthmaControlCalendarPreviewState;
+    dayViewUrl: string;
+    intervalStart?: Date;
+    variant?: AsthmaControlCalendarVariant;
+    innerRef?: React.Ref<HTMLDivElement>;
+}
+
+export default function (props: AsthmaControlCalendarProps) {
+    const dateRangeContext = useContext(DateRangeContext);
+
+    const [logEntries, setLogEntries] = useState<AsthmaLogEntry[]>([]);
+
+    useInitializeView(() => {
+        if (props.previewState) {
+            setLogEntries(previewData[props.previewState].logEntries);
+            return;
+        }
+        asthmaDataService.loadLogEntries().then(logEntries => {
+            setLogEntries(logEntries);
+        });
+    }, [], [props.previewState]);
+
+    const stateConfiguration: CalendarDayStateConfiguration = {
+        'not-determined': {
+            style: {
+                background: '#000',
+                color: '#fff'
+            },
+            streak: true,
+            streakColor: '#DBDBDB'
+        },
+        'not-controlled': {
+            style: {
+                background: '#F86A5C',
+                color: '#fff'
+            },
+            streak: true,
+            streakColor: '#FCCCC7'
+        },
+        'controlled': {
+            style: {
+                background: '#35A6A0',
+                color: '#fff'
+            },
+            streak: true,
+            streakColor: '#CCE9E7'
+        }
+    };
+
+    const computeStateForDay = (date: Date): string => {
+        let status = computeAsthmaControlState(logEntries, date).status;
+        if (status === 'not-determined') {
+            return 'not-determined';
+        } else if (status === 'not-controlled') {
+            return 'not-controlled';
+        } else if (status === 'controlled') {
+            return 'controlled';
+        } else if (isSameDay(date, new Date())) {
+            return 'today';
+        } else if (isAfter(date, new Date())) {
+            return 'future';
+        } else {
+            return 'no-data';
+        }
+    };
+
+    const onDayClicked = (date: Date): void => {
+        if (props.previewState || isAfter(date, new Date())) return;
+        MyDataHelps.openApplication(props.dayViewUrl + '?date=' + formatISO(date, {representation: 'date'}), {modal: true});
+    };
+
+    const renderDay = (year: number, month: number, day?: number): React.JSX.Element => {
+        return <CalendarDay
+            year={year}
+            month={month}
+            day={day}
+            stateConfiguration={stateConfiguration}
+            computeStateForDay={computeStateForDay}
+            onClick={onDayClicked}
+        />;
+    };
+
+    let intervalStart = dateRangeContext?.intervalStart ?? props.intervalStart ?? startOfMonth(new Date());
+
+    const getLogEntries = () => {
+        if (logEntries.length === 0) {
+            return null;
+        }
+
+        let today = startOfToday();
+        let logEntryLookup: Record<string, AsthmaLogEntry | undefined> = {};
+
+        let earliestLogEntry = [...logEntries].sort((e1, e2) => e1.identifier.localeCompare(e2.identifier))[0];
+        let earliestDate = parseISO(earliestLogEntry.identifier);
+        for (let i = 0; i <= differenceInDays(today, earliestDate); i++) {
+            let targetDate = add(earliestDate, {days: i});
+            if (!isBefore(targetDate, intervalStart) && isBefore(targetDate, add(intervalStart, {months: 1}))) {
+                logEntryLookup[dateToAsthmaLogEntryIdentifier(targetDate)] = logEntries.find(e => e.identifier === dateToAsthmaLogEntryIdentifier(targetDate));
+            }
+        }
+
+        return <div className="mdhui-asthma-control-calendar-log-entries">
+            {Object.keys(logEntryLookup).sort().reverse().map((identifier, index) => {
+                let targetDate = parseISO(identifier);
+                let logEntry = logEntryLookup[identifier];
+                return <Card key={index}>
+                    <Action
+                        title={format(targetDate, 'LLLL do')}
+                        subtitle={logEntry ? getAsthmaSymptomLevelText(logEntry.symptomLevel) : differenceInDays(today, targetDate) >= 2 ? language('asthma-control-calendar-daily-entry-missed') : language('asthma-control-calendar-not-logged-yet')}
+                        onClick={() => onDayClicked(targetDate)}
+                    />
+                    {logEntry && ((logEntry.symptoms && logEntry.symptoms.length > 0) || (logEntry.impacts && logEntry.impacts.length > 0) || (logEntry.triggers && logEntry.triggers.length > 0)) &&
+                        <div className="mdhui-asthma-control-calendar-log-entry-components">
+                            {logEntry.symptoms && logEntry.symptoms.length > 0 &&
+                                <LogEntryComponent className="mdhui-asthma-control-calendar-log-entry-component-symptoms" label={language('asthma-control-calendar-log-entries-symptoms-label')}/>
+                            }
+                            {logEntry.impacts && logEntry.impacts.length > 0 &&
+                                <LogEntryComponent className="mdhui-asthma-control-calendar-log-entry-component-impacts" label={language('asthma-control-calendar-log-entries-impacts-label')}/>
+                            }
+                            {logEntry.triggers && logEntry.triggers.length > 0 &&
+                                <LogEntryComponent className="mdhui-asthma-control-calendar-log-entry-component-triggers" label={language('asthma-control-calendar-log-entries-triggers-label')}/>
+                            }
+                        </div>
+                    }
+                </Card>;
+            })}
+        </div>;
+    };
+
+    return <div>
+        <Section noTopMargin={true} style={{boxShadow: 'none', marginBottom: '0'}}>
+            <Calendar innerRef={props.innerRef} className="mdhui-asthma-control-calendar" year={intervalStart.getFullYear()} month={intervalStart.getMonth()} dayRenderer={renderDay}/>
+        </Section>
+        {props.variant === 'verbose' && getLogEntries()}
+    </div>;
+};
+
+function LogEntryComponent(props: { className: string, label: string }) {
+    return <div className={['mdhui-asthma-control-calendar-log-entry-component', props.className].join(' ')}>
+        <div className="mdhui-asthma-control-calendar-log-entry-component-icon"/>
+        <div className="mdhui-asthma-control-calendar-log-entry-component-label">{props.label}</div>
+    </div>;
+}

--- a/src/components/asthma/components/AsthmaControlCalendar/index.ts
+++ b/src/components/asthma/components/AsthmaControlCalendar/index.ts
@@ -1,0 +1,2 @@
+export { default, AsthmaControlCalendarVariant } from './AsthmaControlCalendar';
+export { AsthmaControlCalendarPreviewState } from './AsthmaControlCalendar.previewData';

--- a/src/components/asthma/components/index.ts
+++ b/src/components/asthma/components/index.ts
@@ -1,0 +1,1 @@
+export { default as AsthmaControlCalendar, AsthmaControlCalendarPreviewState, AsthmaControlCalendarVariant } from './AsthmaControlCalendar';

--- a/src/components/asthma/helpers/asthma-data.ts
+++ b/src/components/asthma/helpers/asthma-data.ts
@@ -1,0 +1,25 @@
+import MyDataHelps, { DeviceDataPointQuery } from '@careevolution/mydatahelps-js';
+import { AsthmaLogEntry } from '../model';
+
+export interface AsthmaDataService {
+    loadLogEntries(fromDate?: Date, toDate?: Date): Promise<AsthmaLogEntry[]>;
+}
+
+const service: AsthmaDataService = {
+    loadLogEntries: async function (fromDate?: Date, toDate?: Date): Promise<AsthmaLogEntry[]> {
+        let params: DeviceDataPointQuery = {
+            namespace: 'Project',
+            type: ['Asthma-LogEntry']
+        };
+        if (fromDate) {
+            params.observedAfter = fromDate.toISOString();
+        }
+        if (toDate) {
+            params.observedBefore = toDate.toISOString();
+        }
+        let result = await MyDataHelps.queryDeviceData(params);
+        return result.deviceDataPoints.map(dp => JSON.parse(dp.value) as AsthmaLogEntry);
+    }
+};
+
+export default service;

--- a/src/components/asthma/helpers/asthma-functions.ts
+++ b/src/components/asthma/helpers/asthma-functions.ts
@@ -1,0 +1,82 @@
+import { add, formatISO } from 'date-fns';
+import { AsthmaControlState, AsthmaControlStatus, AsthmaLogEntry, AsthmaSymptomLevel } from '../model';
+import language from '../../../helpers/language';
+
+export const dateToAsthmaLogEntryIdentifier = (date: Date): string => {
+    return formatISO(date, {representation: 'date'});
+};
+
+const computePast7Dates = (date: Date): Date[] => {
+    let dates: Date[] = [];
+    for (let x = 0; x < 7; x++) {
+        dates.push(add(new Date(date), {days: -x}))
+    }
+    return dates;
+};
+
+const filterLogEntries = (logEntries: AsthmaLogEntry[], dates: Date[]) => {
+    let identifiers = dates.map(dateToAsthmaLogEntryIdentifier);
+    return logEntries.filter(e => identifiers.includes(e.identifier));
+};
+
+export const computeAsthmaControlState = (logEntries: AsthmaLogEntry[], date: Date): AsthmaControlState => {
+    let logEntry = logEntries.find(e => e.identifier === dateToAsthmaLogEntryIdentifier(date));
+
+    if (logEntry) {
+        let past7Dates = computePast7Dates(date);
+        let past7LogEntries = filterLogEntries(logEntries, past7Dates);
+
+        let symptomDaysPast7 = past7LogEntries.reduce((sum, entry) => {
+            return sum + (entry.symptomLevel !== 'none' ? 1 : 0);
+        }, 0);
+
+        let nighttimeAwakeningDaysPast7 = past7LogEntries.reduce((sum, entry) => {
+            return sum + (entry.impacts.includes('Wake up at night') ? 1 : 0);
+        }, 0);
+
+        let limitedActivityDaysPast7 = past7LogEntries.reduce((sum, entry) => {
+            return sum + (entry.impacts.includes('Limit your daily activity') ? 1 : 0);
+        }, 0);
+
+        let inhalerUseDaysPast7 = past7LogEntries.reduce((sum, entry) => {
+            return sum + (entry.impacts.includes('Use your rescue inhaler') ? 1 : 0);
+        }, 0);
+
+        let loggedDaysPast7 = past7LogEntries.length;
+
+        let status: AsthmaControlStatus;
+        if (nighttimeAwakeningDaysPast7 > 0 ||
+            limitedActivityDaysPast7 > 0 ||
+            inhalerUseDaysPast7 >= 3 ||
+            symptomDaysPast7 >= 3) {
+            status = 'not-controlled';
+        } else if (loggedDaysPast7 >= 1 &&
+            nighttimeAwakeningDaysPast7 == 0 &&
+            limitedActivityDaysPast7 == 0 &&
+            inhalerUseDaysPast7 == 0 &&
+            symptomDaysPast7 == 0) {
+            status = 'controlled';
+        } else if (loggedDaysPast7 >= 3 && loggedDaysPast7 - symptomDaysPast7 >= 2) {
+            status = 'controlled';
+        } else {
+            status = 'not-determined';
+        }
+
+        return {
+            status: status,
+            symptomDaysPast7: symptomDaysPast7,
+            nighttimeAwakeningDaysPast7: nighttimeAwakeningDaysPast7,
+            limitedActivityDaysPast7: limitedActivityDaysPast7,
+            inhalerUseDaysPast7: inhalerUseDaysPast7
+        };
+    }
+
+    return {status: 'no-data'};
+};
+
+export const getAsthmaSymptomLevelText = (symptomLevel: AsthmaSymptomLevel): string => {
+    if (symptomLevel === 'mild') return language('asthma-symptom-level-mild');
+    if (symptomLevel === 'moderate') return language('asthma-symptom-level-moderate');
+    if (symptomLevel === 'severe') return language('asthma-symptom-level-severe');
+    return language('asthma-symptom-level-none');
+};

--- a/src/components/asthma/helpers/index.ts
+++ b/src/components/asthma/helpers/index.ts
@@ -1,0 +1,2 @@
+export { default as asthmaDataService } from './asthma-data';
+export * from './asthma-functions';

--- a/src/components/asthma/index.ts
+++ b/src/components/asthma/index.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * from './helpers';
+export * from './model';

--- a/src/components/asthma/model/index.ts
+++ b/src/components/asthma/model/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/components/asthma/model/types.ts
+++ b/src/components/asthma/model/types.ts
@@ -1,0 +1,19 @@
+export type AsthmaControlStatus = 'no-data' | 'not-controlled' | 'controlled' | 'not-determined';
+
+export interface AsthmaControlState {
+    status: AsthmaControlStatus;
+    symptomDaysPast7?: number;
+    nighttimeAwakeningDaysPast7?: number;
+    limitedActivityDaysPast7?: number;
+    inhalerUseDaysPast7?: number;
+}
+
+export type AsthmaSymptomLevel = 'none' | 'mild' | 'moderate' | 'severe';
+
+export interface AsthmaLogEntry {
+    identifier: string;
+    symptomLevel: AsthmaSymptomLevel;
+    symptoms: string[];
+    impacts: string[];
+    triggers: string[];
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
-﻿export * from './presentational';
+﻿export * from './asthma'
+export * from './presentational';
 export * from './container';
 export * from './symptom-shark';
 export * from './view';

--- a/src/components/presentational/CalendarDay/CalendarDay.css
+++ b/src/components/presentational/CalendarDay/CalendarDay.css
@@ -28,7 +28,7 @@
 
 .mdhui-calendar-day-value {
     position: relative;
-    background: #DBDBDB;
+    background: var(--mdhui-border-color-2);
     height: 40px;
     width: 40px;
     line-height: 40px;
@@ -43,13 +43,13 @@
 .mdhui-calendar-day-today .mdhui-calendar-day-value {
     background: #369CFF;
     color: #fff;
-    border: 2px solid #fff;
+    border: 2px solid var(--mdhui-background-color-0);
     margin-top: -12px;
 }
 
 .mdhui-calendar-day-future .mdhui-calendar-day-value {
-    background: #fff;
-    color: #DBDBDB;
-    border: 2px solid #DBDBDB;
+    background: var(--mdhui-background-color-0);
+    color: var(--mdhui-text-color-4);
+    border: 2px solid var(--mdhui-border-color-2);
     margin-top: -12px;
 }

--- a/src/helpers/strings-en.ts
+++ b/src/helpers/strings-en.ts
@@ -162,7 +162,16 @@
     "inbox-view-resources-title": "Resources",
     "inbox-view-recently-completed-title": "Recent",
     "inbox-view-recently-completed-empty-text": "You have no recently completed items in your inbox.",
-    "inbox-view-history-button-text": "View inbox history"
+    "inbox-view-history-button-text": "View inbox history",
+    "asthma-symptom-level-none": "No symptoms",
+    "asthma-symptom-level-mild": "Mild symptoms",
+    "asthma-symptom-level-moderate": "Moderate symptoms",
+    "asthma-symptom-level-severe": "Severe symptoms",
+    "asthma-control-calendar-daily-entry-missed": "Daily entry missed",
+    "asthma-control-calendar-not-logged-yet": "Not logged yet",
+    "asthma-control-calendar-log-entries-symptoms-label": "Symptoms",
+    "asthma-control-calendar-log-entries-impacts-label": "Impacts",
+    "asthma-control-calendar-log-entries-triggers-label": "Triggers"
 };
 
 export default strings;

--- a/src/helpers/strings-es.ts
+++ b/src/helpers/strings-es.ts
@@ -158,7 +158,16 @@
     "inbox-view-resources-title": "Recursos",
     "inbox-view-recently-completed-title": "Reciente",
     "inbox-view-recently-completed-empty-text": "No tienes elementos recientemente completados en tu bandeja de entrada.",
-    "inbox-view-history-button-text": "Ver historial de bandeja de entrada"
+    "inbox-view-history-button-text": "Ver historial de bandeja de entrada",
+    "asthma-symptom-level-none": "Sin síntomas",
+    "asthma-symptom-level-mild": "Síntomas leves",
+    "asthma-symptom-level-moderate": "Síntomas moderados",
+    "asthma-symptom-level-severe": "Síntomas graves",
+    "asthma-control-calendar-daily-entry-missed": "Entrada diaria omitida",
+    "asthma-control-calendar-not-logged-yet": "No ingresado todavía",
+    "asthma-control-calendar-log-entries-symptoms-label": "Síntomas",
+    "asthma-control-calendar-log-entries-impacts-label": "Impactos",
+    "asthma-control-calendar-log-entries-triggers-label": "Disparadores"
 };
 
 export default strings;


### PR DESCRIPTION
## Overview

This will be the first of several asthma related component PRs I'll be submitting over the coming days.  I decided to split them up to both make my "final polish" exercises a bit easier and to keep the file count down to a reasonable level for each review.

This branch adds a new `AsthmaControlCalendar` component that I will be using in a number of places to expose asthma control feedback to participants.  It has two modes, compact and verbose.  Compact is just the calendar.  Verbose includes a list of days below it with further information about logged symptoms, impacts, and triggers for each day.

<img src="https://github.com/CareEvolution/MyDataHelpsUI/assets/5408603/5a8d95c8-6b79-453d-9a85-6ccf1408fe29" width="350" />&nbsp;<img src="https://github.com/CareEvolution/MyDataHelpsUI/assets/5408603/63bd5699-5bc8-41ab-9bf8-39ba7183e9fa" width="350" />

I also had to make a couple of small tweaks to the `CalendarDay` component to get it to render more reasonably in dark mode.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [x] MyDataHelps iOS app
- [x] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
