### PR TITLE
Add AppleHealth & Google Fit data to the Blood Pressure Visualization

### DIFF
--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.stories.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.stories.tsx
@@ -56,7 +56,7 @@ export const NoData = {
 export const Live = {
 	args: {
 		surveyDataSource: {
-			surveyName: "Blood Pressure Readings - OPTIONAL",
+			surveyName: "BloodPressure",
 			dateResultIdentifier: "Date of BP",
 			systolicResultIdentifier: "Systolic BP",
 			diastolicResultIdentifier: "Diastolic BP"

--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.stories.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.stories.tsx
@@ -60,7 +60,8 @@ export const Live = {
 			dateResultIdentifier: "Date of BP",
 			systolicResultIdentifier: "Systolic BP",
 			diastolicResultIdentifier: "Diastolic BP"
-		}
+		},
+		deviceDataSource: ["AppleHealth", "GoogleFit"]
 	},
 	render: render
 };

--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -4,29 +4,21 @@ import React from "react";
 import { DateRangeContext, LoadingIndicator } from "../../presentational";
 import DumbbellChart from "../../presentational/DumbbellChart";
 import { Dumbbell, ClosedInterval, Axis, DataPoint, DumbbellClass } from "../../presentational/DumbbellChart/DumbbellChart";
-import { addDays, format, isEqual, parseISO, startOfDay } from "date-fns";
+import { addDays, format, startOfDay } from "date-fns";
 import language from "../../../helpers/language";
 import { previewBloodPressureDataPoint } from "./BloodPressureVisualization.previewdata";
 import { WeekStartsOn, getWeekStart } from "../../../helpers/get-interval-start";
 import { useInitializeView } from "../../../helpers/Initialization";
-import { BloodPressureDataPoint, bloodPressureDataProvider, SurveyBloodPressureDataParameters } from "../../../helpers/blood-pressure-data-providers";
-
+import { BloodPressureDataPoint, SurveyBloodPressureDataParameters, bloodPressureDataProvider } from "../../../helpers/blood-pressure-data-providers";
 
 enum Category { "Low", "Normal", "Elevated", "Stage 1", "Stage 2", "Crisis", "Unknown" };
-export type BloodPressurePreviewState = "Default" | "NoData" | "Loading";
+export type BloodPressurePreviewState = "Default" | "Survey" | "Device" | "NoData" | "Loading";
 
 export interface BloodPressureVisualizationProps {
     previewState?: BloodPressurePreviewState,
-    surveyDataSource: SurveyBloodPressureDataParameters,
+    surveyDataSource?: SurveyBloodPressureDataParameters,
     weekStartsOn?: WeekStartsOn,
     innerRef?: React.Ref<HTMLDivElement>
-};
-
-interface BloodPressureDumbbell {
-    date: Date,
-    dumbbell: Dumbbell,
-    averageSystolic: number,
-    averageDiastolic: number
 };
 
 interface BloodPressureMetrics {
@@ -49,173 +41,38 @@ export default function (props: BloodPressureVisualizationProps) {
     const _maxSystolic = 250;
     const yInterval: ClosedInterval = { values: [_minDiastolic, _maxSystolic] };
     const axis: Axis = { yRange: yInterval, yIncrement: 50, xIncrement: (80 / 7) };
-    const [bloodPressureData, setDataForGraph] = useState<Map<string, BloodPressureDumbbell> | undefined>(undefined);
+    const [bloodPressureData, setIntervalData] = useState<Map<string, BloodPressureDataPoint[]> | undefined>(undefined);
     const dateRangeContext = useContext(DateRangeContext);
 
-    let intervalStart = dateRangeContext?.intervalStart ?? startOfDay(getWeekStart(props.weekStartsOn ?? "Monday"));
+    let intervalStart = dateRangeContext?.intervalStart ?? getWeekStart(props.weekStartsOn ?? "Monday");
+    intervalStart = startOfDay(intervalStart);
 
     async function initialize() {
         if (props.previewState !== "Loading") {
             if (["Default", "NoData"].includes(props.previewState ?? "")) {
                 const params = (props.previewState === "Default") ? previewBloodPressureDataPoint : [];
-                transformToGraphData(params);
+                setIntervalData(groupDataPointsByDate(params));
             }
             else {
                 bloodPressureDataProvider(props.surveyDataSource).then((bloodPressureDataPoints: BloodPressureDataPoint[]) => {
-                    transformToGraphData(bloodPressureDataPoints);
+                    setIntervalData(groupDataPointsByDate(bloodPressureDataPoints));
                 });
             }
         }
     }
 
-    function transformToGraphData(bloodPressureDataPoints: BloodPressureDataPoint[]) {
-        const bpByDayMap = createDumbbellsPerDay(bloodPressureDataPoints);
-        setDataForGraph(bpByDayMap);
-    }
-
-    function createDumbbellsPerDay(bpDataPoints: BloodPressureDataPoint[]) {
-        var dbs: Map<string, BloodPressureDumbbell> = new Map<string, BloodPressureDumbbell>;
-
+    function groupDataPointsByDate(bpDataPoints: BloodPressureDataPoint[]) {
         var bpByDate: Map<string, BloodPressureDataPoint[]> = new Map<string, BloodPressureDataPoint[]>();
         bpDataPoints.forEach((bpDataPoint) => {
-            var exists = bpByDate.get(bpDataPoint.date.toString());
+            const dateKey = bpDataPoint.date.toString();
+            var exists = bpByDate.get(dateKey);
             if (exists) {
                 exists.push(bpDataPoint);
             } else {
-                bpByDate.set(bpDataPoint.date.toString(), [bpDataPoint]);
+                bpByDate.set(dateKey, [bpDataPoint]);
             }
         });
-
-        bpByDate.forEach((bpDate, key, map) => {
-            const keyDate = new Date(key);
-            const systolicEntriesForDate = bpDate.map(e => e.systolic);
-            const systolicInterval = buildInterval(systolicEntriesForDate);
-            const systolicAverage = systolicEntriesForDate.reduce((a, b) => a + b) / systolicEntriesForDate.length;
-            const diastolicEntriesForDate = bpDate.map(e => e.diastolic);
-            const diastolicInterval = buildInterval(diastolicEntriesForDate);
-            const diastolicAverage = diastolicEntriesForDate.reduce((a, b) => a + b) / diastolicEntriesForDate.length;
-            const dataPoint: DataPoint = { dataSet1: diastolicInterval, dataSet2: systolicInterval };
-            var db: Dumbbell = { dataPoint: dataPoint, xValue: format(keyDate, "MM/dd"), class: assignClass(systolicAverage, diastolicAverage) };
-            dbs.set(key, { date: keyDate, dumbbell: db, averageSystolic: systolicAverage, averageDiastolic: diastolicAverage });
-        });
-
-        return dbs;
-    }
-
-    function pageWeeklyData(startOfWeek: Date) {
-        const weekData: Dumbbell[] = [];
-        if (bloodPressureData) {
-            for (let i = 0; i < 7; i++) {
-                var currentDate = startOfDay(addDays(startOfWeek, i));
-                var dataForDay = bloodPressureData.get(currentDate.toString());
-                if (!dataForDay) {
-                    weekData.push({ xValue: format(currentDate, "MM/dd") });
-                }
-                else {
-                    weekData.push(dataForDay.dumbbell);
-                }
-            }
-        }
-
-        return <DumbbellChart dumbbells={weekData} axis={axis} ></DumbbellChart>;
-    }
-
-    function pageWeeklyMetrics(startOfWeek: Date) {
-        const metrics = getWeeklyAggregates(startOfWeek);
-
-        return <div className="mdhui-blood-pressure-metrics">
-            <div className="mdhui-blood-pressure-metrics-rows">
-                {buildDetailBlock(language("systolic-average"), metrics.averageSystolicAlert, metrics.averageSystolicAlertClass, metrics.averageSystolic)}
-                {buildDetailBlock(language("diastolic-average"), metrics.averageDiastolicAlert, metrics.averageDiastolicAlertClass, metrics.averageDiastolic)}
-            </div>
-            <div className="mdhui-blood-pressure-metrics-rows">
-                {buildDetailBlock(language("highest-systolic"), metrics.maxSystolicAlert, metrics.maxSystolicAlertClass, metrics.maxSystolic)}
-                {buildDetailBlock(language("lowest-diastolic"), metrics.minDiastolicAlert, metrics.minDiastolicAlertClass, metrics.minDiastolic)}
-            </div>
-        </div>;
-    }
-
-    function getWeeklyAggregates(startOfWeek: Date) {
-
-        const start = startOfDay(startOfWeek);
-        const end = startOfDay(addDays(startOfWeek, 6));
-        let bpMetrics: BloodPressureMetrics = {
-            averageDiastolicAlertClass: "",
-            averageSystolicAlertClass: "",
-            minDiastolicAlertClass: "",
-            maxSystolicAlertClass: ""
-        };
-
-        if (!bloodPressureData) {
-            return bpMetrics;
-        }
-
-        var dataForDateRange: BloodPressureDumbbell[] = [];
-        for (var d = start; d <= end; d.setDate(d.getDate() + 1)) {
-            const exists = bloodPressureData.get(startOfDay(d).toString());
-            if (exists && exists.dumbbell.dataPoint) {
-                dataForDateRange.push(exists);
-            }
-        }
-
-        if (dataForDateRange.length === 0) {
-            return bpMetrics;
-        }
-
-        let diastolicReadings = dataForDateRange.map(db => db.averageDiastolic);
-        let diastolicWeeklyAvg = diastolicReadings.reduce((a, b) => a + b) / diastolicReadings.length;
-        diastolicWeeklyAvg = Math.round(diastolicWeeklyAvg);
-        let diastolicWeeklyAvgAlert = getDiastolicCategory(diastolicWeeklyAvg);
-
-        let systolicReadings = dataForDateRange.map(db => db.averageSystolic);
-        let systolicWeeklyAvg = systolicReadings.reduce((a, b) => a + b) / systolicReadings.length;
-        systolicWeeklyAvg = Math.round(systolicWeeklyAvg);
-        let systolicWeeklyAvgAlert = getSystolicCategory(systolicWeeklyAvg);
-
-        bpMetrics.averageSystolic = systolicWeeklyAvg;
-        bpMetrics.averageSystolicAlert = Category[systolicWeeklyAvgAlert];
-        bpMetrics.averageSystolicAlertClass = systolicWeeklyAvgAlert == Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
-        bpMetrics.averageDiastolic = diastolicWeeklyAvg;
-        bpMetrics.averageDiastolicAlert = Category[diastolicWeeklyAvgAlert];
-        bpMetrics.averageDiastolicAlertClass = diastolicWeeklyAvgAlert == Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
-
-
-        var weekDataEntryDataPoints = dataForDateRange.map(e => e.dumbbell.dataPoint);
-        let diastolicLows = weekDataEntryDataPoints.filter(db => !isNaN(Number(db?.dataSet1.values[0]))).map(db => Number(db?.dataSet1.values[0]));
-        let diastolicLow = Math.min(...diastolicLows);
-        bpMetrics.minDiastolic = Math.round(diastolicLow);
-        let cat = getDiastolicCategory(diastolicLow);
-        bpMetrics.minDiastolicAlert = Category[cat];
-        bpMetrics.minDiastolicAlertClass = cat === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
-
-        let systolicHighs = weekDataEntryDataPoints.filter(db => !isNaN(Number(db?.dataSet2.values[1]))).map(db => Number(db?.dataSet2.values[1]));
-        let systolicHigh = Math.max(...systolicHighs);
-        bpMetrics.maxSystolic = Math.round(systolicHigh);
-        cat = getSystolicCategory(systolicHigh);
-        bpMetrics.maxSystolicAlert = Category[cat];
-        bpMetrics.maxSystolicAlertClass = cat === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
-
-        return bpMetrics;
-    }
-
-    function buildDetailBlock(description: string, alert?: string, alertClass?: string, value?: number) {
-        return <div className="mdhui-blood-pressure-metrics-block">
-            <div className="mdhui-blood-pressure-metric-value">{value ?? "--"} <span className="mdhui-blood-pressure-units">mm HG</span></div>
-            <div className="mdhui-blood-pressure-metric-description">{description}</div>
-            <div className={alertClass}>{alert ?? "No data yet"}</div>
-        </div>
-    }
-
-    function buildInterval(entries: number[]) {
-        const min = Math.min(...entries);
-        const closedInterval: ClosedInterval = { values: [min] };
-
-        var max = min;
-        if (entries.length > 1) {
-            max = Math.max(...entries);
-        }
-        closedInterval.values.push(max);
-        return closedInterval;
+        return bpByDate;
     }
 
     function assignClass(avgSystolic: number, avgDiastolic: number) {
@@ -282,17 +139,128 @@ export default function (props: BloodPressureVisualizationProps) {
         return Category.Unknown;
     }
 
+    function buildMetrics(data: BloodPressureDataPoint[]) {
+        const metrics = buildAggregates(data);
+
+        return <div className="mdhui-blood-pressure-metrics">
+            <div className="mdhui-blood-pressure-metrics-rows">
+                {buildDetailBlock(language("systolic-average"), metrics.averageSystolicAlert, metrics.averageSystolicAlertClass, metrics.averageSystolic)}
+                {buildDetailBlock(language("diastolic-average"), metrics.averageDiastolicAlert, metrics.averageDiastolicAlertClass, metrics.averageDiastolic)}
+            </div>
+            <div className="mdhui-blood-pressure-metrics-rows">
+                {buildDetailBlock(language("highest-systolic"), metrics.maxSystolicAlert, metrics.maxSystolicAlertClass, metrics.maxSystolic)}
+                {buildDetailBlock(language("lowest-diastolic"), metrics.minDiastolicAlert, metrics.minDiastolicAlertClass, metrics.minDiastolic)}
+            </div>
+        </div>;
+    }
+
+    function buildAggregates(data: BloodPressureDataPoint[]) {
+
+        let bpMetrics: BloodPressureMetrics = {
+            averageDiastolicAlertClass: "",
+            averageSystolicAlertClass: "",
+            minDiastolicAlertClass: "",
+            maxSystolicAlertClass: ""
+        };
+
+        if (!data || data.length === 0) {
+            return bpMetrics;
+        }
+
+        let diastolicReadings = data.map(db => db.diastolic);
+        let diastolicWeeklyAvg = diastolicReadings.reduce((a, b) => a + b) / diastolicReadings.length;
+        diastolicWeeklyAvg = Math.round(diastolicWeeklyAvg);
+        let diastolicWeeklyAvgAlert = getDiastolicCategory(diastolicWeeklyAvg);
+
+        let systolicReadings = data.map(db => db.systolic);
+        let systolicWeeklyAvg = systolicReadings.reduce((a, b) => a + b) / systolicReadings.length;
+        systolicWeeklyAvg = Math.round(systolicWeeklyAvg);
+        let systolicWeeklyAvgAlert = getSystolicCategory(systolicWeeklyAvg);
+
+        bpMetrics.averageSystolic = systolicWeeklyAvg;
+        bpMetrics.averageSystolicAlert = Category[systolicWeeklyAvgAlert];
+        bpMetrics.averageSystolicAlertClass = systolicWeeklyAvgAlert === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
+        bpMetrics.averageDiastolic = diastolicWeeklyAvg;
+        bpMetrics.averageDiastolicAlert = Category[diastolicWeeklyAvgAlert];
+        bpMetrics.averageDiastolicAlertClass = diastolicWeeklyAvgAlert === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
+
+        let diastolicLow = Math.min(...diastolicReadings);
+        bpMetrics.minDiastolic = Math.round(diastolicLow);
+        let cat = getDiastolicCategory(diastolicLow);
+        bpMetrics.minDiastolicAlert = Category[cat];
+        bpMetrics.minDiastolicAlertClass = cat === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
+
+        let systolicHigh = Math.max(...systolicReadings);
+        bpMetrics.maxSystolic = Math.round(systolicHigh);
+        cat = getSystolicCategory(systolicHigh);
+        bpMetrics.maxSystolicAlert = Category[cat];
+        bpMetrics.maxSystolicAlertClass = cat === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
+
+        return bpMetrics;
+    }
+
+    function buildDetailBlock(description: string, alert?: string, alertClass?: string, value?: number) {
+        return <div className="mdhui-blood-pressure-metrics-block">
+            <div className="mdhui-blood-pressure-metric-value">{value ?? "--"} <span className="mdhui-blood-pressure-units">mm HG</span></div>
+            <div className="mdhui-blood-pressure-metric-description">{description}</div>
+            <div className={alertClass}>{alert ?? "No data yet"}</div>
+        </div>
+    }
+
+    function buildInterval(entries: number[]) {
+        const min = Math.min(...entries);
+        const closedInterval: ClosedInterval = { values: [min] };
+
+        var max = min;
+        if (entries.length > 1) {
+            max = Math.max(...entries);
+        }
+        closedInterval.values.push(max);
+        return closedInterval;
+    }
+
+    function createDumbbellsPerDay(date: Date, bpDataPoints: BloodPressureDataPoint[]) {
+        const systolicEntriesForDate = bpDataPoints.map(e => e.systolic);
+        const systolicInterval = buildInterval(systolicEntriesForDate);
+        const systolicAverage = systolicEntriesForDate.reduce((a, b) => a + b) / systolicEntriesForDate.length;
+        const diastolicEntriesForDate = bpDataPoints.map(e => e.diastolic);
+        const diastolicInterval = buildInterval(diastolicEntriesForDate);
+        const diastolicAverage = diastolicEntriesForDate.reduce((a, b) => a + b) / diastolicEntriesForDate.length;
+        const dataPoint: DataPoint = { dataSet1: diastolicInterval, dataSet2: systolicInterval };
+        var db: Dumbbell = { dataPoint: dataPoint, xValue: format(date, "MM/dd"), class: assignClass(systolicAverage, diastolicAverage) };
+        return db;
+    }
+
+    function buildVisualization(start : Date){
+        const intervalEnd = addDays(start, 6);
+        var bpDataForMetrics: BloodPressureDataPoint[] = [];
+        const weekData: Dumbbell[] = [];
+        for (let i = start; i <= intervalEnd; i.setDate(i.getDate() + 1)) {
+            var currentDate = startOfDay(i);
+            var dataForDay = bloodPressureData?.get(currentDate.toString()) ?? [];
+            if (dataForDay.length > 0) {
+                bpDataForMetrics.push(...dataForDay);
+                weekData.push(createDumbbellsPerDay(currentDate, dataForDay));
+            } else {
+                weekData.push({ xValue: format(currentDate, "MM/dd") });
+            }
+        }
+
+        const metrics = buildMetrics(bpDataForMetrics);
+        return (
+            <div ref={props.innerRef}>
+                <DumbbellChart dumbbells={weekData} axis={axis} ></DumbbellChart>
+                {metrics}
+            </div>
+        );
+    }
+
     useInitializeView(initialize, [], [props.previewState, props.weekStartsOn]);
 
     if (!bloodPressureData) {
         return <LoadingIndicator innerRef={props.innerRef} />;
     }
     else {
-        return (
-            <div ref={props.innerRef}>
-                {pageWeeklyData(intervalStart)}
-                {pageWeeklyMetrics(intervalStart)}
-            </div>
-        );
+        return buildVisualization(intervalStart);
     }
 }

--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -12,7 +12,7 @@ import { useInitializeView } from "../../../helpers/Initialization";
 import { BloodPressureDataPoint, SurveyBloodPressureDataParameters, bloodPressureDataProvider } from "../../../helpers/blood-pressure-data-providers";
 
 enum Category { "Low", "Normal", "Elevated", "Stage 1", "Stage 2", "Crisis", "Unknown" };
-export type BloodPressurePreviewState = "Default" | "Survey" | "Device" | "NoData" | "Loading";
+export type BloodPressurePreviewState = "Default" | "NoData" | "Loading";
 
 export interface BloodPressureVisualizationProps {
     previewState?: BloodPressurePreviewState,

--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -41,7 +41,7 @@ export default function (props: BloodPressureVisualizationProps) {
     const _maxSystolic = 250;
     const yInterval: ClosedInterval = { values: [_minDiastolic, _maxSystolic] };
     const axis: Axis = { yRange: yInterval, yIncrement: 50, xIncrement: (80 / 7) };
-    const [bloodPressureData, setIntervalData] = useState<Map<string, BloodPressureDataPoint[]> | undefined>(undefined);
+    const [bloodPressureData, setData] = useState<Map<string, BloodPressureDataPoint[]> | undefined>(undefined);
     const dateRangeContext = useContext(DateRangeContext);
 
     let intervalStart = dateRangeContext?.intervalStart ?? getWeekStart(props.weekStartsOn ?? "Monday");
@@ -51,11 +51,11 @@ export default function (props: BloodPressureVisualizationProps) {
         if (props.previewState !== "Loading") {
             if (["Default", "NoData"].includes(props.previewState ?? "")) {
                 const params = (props.previewState === "Default") ? previewBloodPressureDataPoint : [];
-                setIntervalData(groupDataPointsByDate(params));
+                setData(groupDataPointsByDate(params));
             }
             else {
                 bloodPressureDataProvider(props.surveyDataSource).then((bloodPressureDataPoints: BloodPressureDataPoint[]) => {
-                    setIntervalData(groupDataPointsByDate(bloodPressureDataPoints));
+                    setData(groupDataPointsByDate(bloodPressureDataPoints));
                 });
             }
         }
@@ -231,7 +231,7 @@ export default function (props: BloodPressureVisualizationProps) {
         return db;
     }
 
-    function buildVisualization(start : Date){
+    function buildVisualization(start: Date) {
         const intervalEnd = addDays(start, 6);
         var bpDataForMetrics: BloodPressureDataPoint[] = [];
         const weekData: Dumbbell[] = [];

--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -42,7 +42,7 @@ export default function (props: BloodPressureVisualizationProps) {
     const _maxSystolic = 250;
     const yInterval: ClosedInterval = { values: [_minDiastolic, _maxSystolic] };
     const axis: Axis = { yRange: yInterval, yIncrement: 50, xIncrement: (80 / 7) };
-    const [bloodPressureData, setData] = useState<Map<string, BloodPressureDataPoint[]> | undefined>(undefined);
+    const [bloodPressureData, setBloodPressureDataData] = useState<Map<string, BloodPressureDataPoint[]> | undefined>(undefined);
     const dateRangeContext = useContext(DateRangeContext);
 
     let intervalStart = dateRangeContext?.intervalStart ?? getWeekStart(props.weekStartsOn ?? "Monday");
@@ -52,11 +52,11 @@ export default function (props: BloodPressureVisualizationProps) {
         if (props.previewState !== "Loading") {
             if (["Default", "NoData"].includes(props.previewState ?? "")) {
                 const params = (props.previewState === "Default") ? previewBloodPressureDataPoint : [];
-                setData(groupDataPointsByDate(params));
+                setBloodPressureDataData(groupDataPointsByDate(params));
             }
             else {
                 bloodPressureDataProvider(props.surveyDataSource, props.deviceDataSource).then((bloodPressureDataPoints: BloodPressureDataPoint[]) => {
-                    setData(groupDataPointsByDate(bloodPressureDataPoints));
+                    setBloodPressureDataData(groupDataPointsByDate(bloodPressureDataPoints));
                 });
             }
         }

--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -9,7 +9,7 @@ import language from "../../../helpers/language";
 import { previewBloodPressureDataPoint } from "./BloodPressureVisualization.previewdata";
 import { WeekStartsOn, getWeekStart } from "../../../helpers/get-interval-start";
 import { useInitializeView } from "../../../helpers/Initialization";
-import { BloodPressureDataPoint, SurveyBloodPressureDataParameters, bloodPressureDataProvider } from "../../../helpers/blood-pressure-data-providers";
+import { BloodPressureDataPoint, BloodPressureDeviceDataSource, SurveyBloodPressureDataParameters, bloodPressureDataProvider } from "../../../helpers/blood-pressure-data-providers";
 
 enum Category { "Low", "Normal", "Elevated", "Stage 1", "Stage 2", "Crisis", "Unknown" };
 export type BloodPressurePreviewState = "Default" | "NoData" | "Loading";
@@ -18,6 +18,7 @@ export interface BloodPressureVisualizationProps {
     previewState?: BloodPressurePreviewState,
     surveyDataSource?: SurveyBloodPressureDataParameters,
     weekStartsOn?: WeekStartsOn,
+    deviceDataSource?: BloodPressureDeviceDataSource[],
     innerRef?: React.Ref<HTMLDivElement>
 };
 
@@ -54,7 +55,7 @@ export default function (props: BloodPressureVisualizationProps) {
                 setData(groupDataPointsByDate(params));
             }
             else {
-                bloodPressureDataProvider(props.surveyDataSource).then((bloodPressureDataPoints: BloodPressureDataPoint[]) => {
+                bloodPressureDataProvider(props.surveyDataSource, props.deviceDataSource).then((bloodPressureDataPoints: BloodPressureDataPoint[]) => {
                     setData(groupDataPointsByDate(bloodPressureDataPoints));
                 });
             }

--- a/src/helpers/blood-pressure-data-providers/combined-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/combined-blood-pressure-data-provider.ts
@@ -1,0 +1,28 @@
+import MyDataHelps from "@careevolution/mydatahelps-js"
+import { BloodPressureDataPoint, SurveyBloodPressureDataParameters } from "."
+import surveyBloodPressureDataProvider from "./survey-blood-pressure-data-provider"
+import deviceDataBloodPressureDataProvider from "./device-blood-pressure-data-provider"
+
+export default async function (surveyDataSource?: SurveyBloodPressureDataParameters): Promise<BloodPressureDataPoint[]> {
+    let providers: Promise<BloodPressureDataPoint[]>[] = [];
+
+    return MyDataHelps.getDataCollectionSettings().then((settings) => {
+
+        if (surveyDataSource) {
+            providers.push(surveyBloodPressureDataProvider(surveyDataSource));
+        }
+        
+        if (!surveyDataSource || !surveyDataSource.hideDeviceData) {
+            providers.push(deviceDataBloodPressureDataProvider("AppleHealth", "BloodPressureSystolic", "BloodPressureDiastolic"));
+            providers.push(deviceDataBloodPressureDataProvider("GoogleFit", "blood_pressure_systolic", "blood_pressure_diastolic"));
+        }
+
+        if (!providers.length) {
+            return [];
+        }
+
+        return Promise.all(providers).then((values) => {
+            return values.reduce((acc, val) => acc.concat(val), []);
+        });
+    });
+}

--- a/src/helpers/blood-pressure-data-providers/combined-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/combined-blood-pressure-data-provider.ts
@@ -4,15 +4,15 @@ import deviceDataBloodPressureDataProvider from "./device-blood-pressure-data-pr
 
 export type BloodPressureDeviceDataSource = 'AppleHealth' | 'GoogleFit';
 
-export default async function (surveyDataSource?: SurveyBloodPressureDataParameters, bloodPressureDeviceDataSource?: BloodPressureDeviceDataSource[]): Promise<BloodPressureDataPoint[]> {
+export default async function (surveyDataSource?: SurveyBloodPressureDataParameters, bloodPressureDeviceDataSources?: BloodPressureDeviceDataSource[]): Promise<BloodPressureDataPoint[]> {
     let providers: Promise<BloodPressureDataPoint[]>[] = [];
 
     if (surveyDataSource) {
         providers.push(surveyBloodPressureDataProvider(surveyDataSource));
     }
 
-    if (bloodPressureDeviceDataSource) {
-        bloodPressureDeviceDataSource.forEach((source) => {
+    if (bloodPressureDeviceDataSources) {
+        bloodPressureDeviceDataSources.forEach((source) => {
             if (source === 'AppleHealth') {
                 providers.push(deviceDataBloodPressureDataProvider("AppleHealth", "BloodPressureSystolic", "BloodPressureDiastolic"));
             } else if (source === 'GoogleFit') {

--- a/src/helpers/blood-pressure-data-providers/combined-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/combined-blood-pressure-data-provider.ts
@@ -11,7 +11,7 @@ export default async function (surveyDataSource?: SurveyBloodPressureDataParamet
         if (surveyDataSource) {
             providers.push(surveyBloodPressureDataProvider(surveyDataSource));
         }
-        
+
         if (!surveyDataSource || !surveyDataSource.hideDeviceData) {
             providers.push(deviceDataBloodPressureDataProvider("AppleHealth", "BloodPressureSystolic", "BloodPressureDiastolic"));
             providers.push(deviceDataBloodPressureDataProvider("GoogleFit", "blood_pressure_systolic", "blood_pressure_diastolic"));

--- a/src/helpers/blood-pressure-data-providers/device-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/device-blood-pressure-data-provider.ts
@@ -3,9 +3,9 @@ import queryAllDeviceData from "../daily-data-providers/query-all-device-data";
 import { BloodPressureDataPoint } from ".";
 import { parseISO, startOfDay } from "date-fns";
 
-export default async function (namespace: DeviceDataNamespace, bloodPressureSystolic : string, bloodPressureDiastolic : string): Promise<BloodPressureDataPoint[]> {
+export default async function (namespace: DeviceDataNamespace, bloodPressureSystolic: string, bloodPressureDiastolic: string): Promise<BloodPressureDataPoint[]> {
 
-    function collateAppleHealthResults(dataPoints: DeviceDataPoint[]): BloodPressureDataPoint[] {
+    function collateResults(dataPoints: DeviceDataPoint[]): BloodPressureDataPoint[] {
         let bpDataPointsByObservationDateTime: Map<string, BloodPressureDataPoint> = new Map<string, BloodPressureDataPoint>();
 
         dataPoints.forEach((dataPoint) => {
@@ -35,5 +35,5 @@ export default async function (namespace: DeviceDataNamespace, bloodPressureSyst
         type: [bloodPressureSystolic, bloodPressureDiastolic]
     });
 
-    return collateAppleHealthResults(dataPoints);
+    return collateResults(dataPoints);
 }

--- a/src/helpers/blood-pressure-data-providers/device-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/device-blood-pressure-data-provider.ts
@@ -1,0 +1,39 @@
+import { DeviceDataNamespace, DeviceDataPoint } from "@careevolution/mydatahelps-js";
+import queryAllDeviceData from "../daily-data-providers/query-all-device-data";
+import { BloodPressureDataPoint } from ".";
+import { parseISO, startOfDay } from "date-fns";
+
+export default async function (namespace: DeviceDataNamespace, bloodPressureSystolic : string, bloodPressureDiastolic : string): Promise<BloodPressureDataPoint[]> {
+
+    function collateAppleHealthResults(dataPoints: DeviceDataPoint[]): BloodPressureDataPoint[] {
+        let bpDataPointsByObservationDateTime: Map<string, BloodPressureDataPoint> = new Map<string, BloodPressureDataPoint>();
+
+        dataPoints.forEach((dataPoint) => {
+            if (dataPoint.observationDate && !isNaN(Number(dataPoint.value))) {
+                var bpDate = parseISO(dataPoint.observationDate);
+                var bpDateIdentifier = bpDate.toDateString();
+                var exists = bpDataPointsByObservationDateTime.get(bpDateIdentifier);
+                var bp: BloodPressureDataPoint = exists ?? { date: startOfDay(bpDate), systolic: 0, diastolic: 0 };
+                buildBpDataPoint(dataPoint, bp);
+                bpDataPointsByObservationDateTime.set(bpDateIdentifier, bp);
+            }
+        });
+
+        return Array.from(bpDataPointsByObservationDateTime.values());
+    }
+
+    function buildBpDataPoint(dataPoint: DeviceDataPoint, bpDataPoint: BloodPressureDataPoint) {
+        if (dataPoint.type === bloodPressureSystolic) {
+            bpDataPoint.systolic = Number(dataPoint.value);
+        } else if (dataPoint.type === bloodPressureDiastolic) {
+            bpDataPoint.diastolic = Number(dataPoint.value);
+        }
+    }
+
+    const dataPoints = await queryAllDeviceData({
+        namespace: namespace,
+        type: [bloodPressureSystolic, bloodPressureDiastolic]
+    });
+
+    return collateAppleHealthResults(dataPoints);
+}

--- a/src/helpers/blood-pressure-data-providers/device-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/device-blood-pressure-data-provider.ts
@@ -7,19 +7,22 @@ export default async function (namespace: DeviceDataNamespace, bloodPressureSyst
 
     function collateResults(dataPoints: DeviceDataPoint[]): BloodPressureDataPoint[] {
         let bpDataPointsByObservationDateTime: Map<string, BloodPressureDataPoint> = new Map<string, BloodPressureDataPoint>();
+        let complete: BloodPressureDataPoint[] = [];
 
         dataPoints.forEach((dataPoint) => {
             if (dataPoint.observationDate && !isNaN(Number(dataPoint.value))) {
                 var bpDate = parseISO(dataPoint.observationDate);
-                var bpDateIdentifier = bpDate.toDateString();
-                var exists = bpDataPointsByObservationDateTime.get(bpDateIdentifier);
+                var exists = bpDataPointsByObservationDateTime.get(dataPoint.observationDate);
                 var bp: BloodPressureDataPoint = exists ?? { date: startOfDay(bpDate), systolic: 0, diastolic: 0 };
                 buildBpDataPoint(dataPoint, bp);
-                bpDataPointsByObservationDateTime.set(bpDateIdentifier, bp);
+                bpDataPointsByObservationDateTime.set(dataPoint.observationDate, bp);
+                if (bp.systolic !== 0 && bp.diastolic !== 0) {
+                    complete.push(bp);
+                }
             }
         });
 
-        return Array.from(bpDataPointsByObservationDateTime.values());
+        return complete;
     }
 
     function buildBpDataPoint(dataPoint: DeviceDataPoint, bpDataPoint: BloodPressureDataPoint) {

--- a/src/helpers/blood-pressure-data-providers/index.ts
+++ b/src/helpers/blood-pressure-data-providers/index.ts
@@ -1,3 +1,3 @@
-﻿export { default as bloodPressureDataProvider } from "./survey-blood-pressure-data-provider"
+﻿export { default as bloodPressureDataProvider } from "./combined-blood-pressure-data-provider"
 export { SurveyBloodPressureDataParameters as SurveyBloodPressureDataParameters } from "./survey-blood-pressure-data-provider"
 export { BloodPressureDataPoint as BloodPressureDataPoint } from "./survey-blood-pressure-data-provider"

--- a/src/helpers/blood-pressure-data-providers/index.ts
+++ b/src/helpers/blood-pressure-data-providers/index.ts
@@ -1,4 +1,3 @@
-﻿export { default as bloodPressureDataProvider } from "./combined-blood-pressure-data-provider"
+﻿export { default as bloodPressureDataProvider, BloodPressureDeviceDataSource as BloodPressureDeviceDataSource } from "./combined-blood-pressure-data-provider"
 export { SurveyBloodPressureDataParameters as SurveyBloodPressureDataParameters } from "./survey-blood-pressure-data-provider"
 export { BloodPressureDataPoint as BloodPressureDataPoint } from "./survey-blood-pressure-data-provider"
-export { BloodPressureDeviceDataSource as BloodPressureDeviceDataSource } from "./combined-blood-pressure-data-provider"

--- a/src/helpers/blood-pressure-data-providers/index.ts
+++ b/src/helpers/blood-pressure-data-providers/index.ts
@@ -1,3 +1,4 @@
 ﻿export { default as bloodPressureDataProvider } from "./combined-blood-pressure-data-provider"
 export { SurveyBloodPressureDataParameters as SurveyBloodPressureDataParameters } from "./survey-blood-pressure-data-provider"
 export { BloodPressureDataPoint as BloodPressureDataPoint } from "./survey-blood-pressure-data-provider"
+export { BloodPressureDeviceDataSource as BloodPressureDeviceDataSource } from "./combined-blood-pressure-data-provider"

--- a/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
@@ -5,8 +5,7 @@ export interface SurveyBloodPressureDataParameters {
     surveyName: string,
     dateResultIdentifier: string,
     systolicResultIdentifier: string,
-    diastolicResultIdentifier: string,
-    hideDeviceData?: boolean
+    diastolicResultIdentifier: string
 }
 
 export interface BloodPressureDataPoint {

--- a/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
@@ -1,5 +1,5 @@
 import MyDataHelps, { Guid, SurveyAnswer, SurveyAnswersPage, SurveyAnswersQuery } from "@careevolution/mydatahelps-js";
-import { addDays, parseISO, startOfDay } from "date-fns";
+import { parseISO, startOfDay } from "date-fns";
 
 export interface SurveyBloodPressureDataParameters {
     surveyName: string,

--- a/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
@@ -1,11 +1,12 @@
 import MyDataHelps, { Guid, SurveyAnswer, SurveyAnswersPage, SurveyAnswersQuery } from "@careevolution/mydatahelps-js";
-import { format, isDate, parseISO, startOfDay, toDate } from "date-fns";
+import { addDays, parseISO, startOfDay } from "date-fns";
 
 export interface SurveyBloodPressureDataParameters {
     surveyName: string,
     dateResultIdentifier: string,
     systolicResultIdentifier: string,
-    diastolicResultIdentifier: string
+    diastolicResultIdentifier: string,
+    hideDeviceData?: boolean
 }
 
 export interface BloodPressureDataPoint {
@@ -15,7 +16,7 @@ export interface BloodPressureDataPoint {
 };
 
 export default async function (props: SurveyBloodPressureDataParameters): Promise<BloodPressureDataPoint[]> {
-    
+
     function groupSurveyAnswersByResults(answers: SurveyAnswer[]) {
         let bpDataPoints: BloodPressureDataPoint[] = [];
 


### PR DESCRIPTION
## Overview

Add AppleHealth and GoogleFit data to the BloodPressureVisualization.
When a survey data source is specified, give the option to hide AppleHealth & GoogleFit data

## Security

REMINDER: All file contents are public.

- [x ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.
This updates an existing component and gets all ppt data through existing and established MDH js

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ x] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner