### PR TITLE
Fix an issue with RecentDailyDataBarChart dayTick rendering around month boundaries.

### DIFF
--- a/src/components/container/RecentDailyDataBarChart/RecentDailyDataBarChart.tsx
+++ b/src/components/container/RecentDailyDataBarChart/RecentDailyDataBarChart.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { checkDailyDataAvailability, DailyDataQueryResult, queryDailyData } from '../../../helpers/query-daily-data';
 import { LoadingIndicator, Title } from '../../presentational';
-import { add, format, startOfToday } from 'date-fns';
+import { add, differenceInDays, format, startOfToday } from 'date-fns';
 import getDayKey from '../../../helpers/get-day-key';
 import { AxisDomain } from 'recharts/types/util/types';
 import { Bar, BarChart, CartesianGrid, Cell, LabelList, ResponsiveContainer, XAxis, YAxis } from 'recharts';
@@ -77,7 +77,7 @@ export default function (props: RecentDailyDataBarChartProps) {
     if (currentData) {
         while (currentDate < endDate) {
             let dataDay: any = {
-                day: currentDate.getDate()
+                daysAfterStart: differenceInDays(currentDate, startDate)
             };
             data.push(dataDay);
 
@@ -107,7 +107,8 @@ export default function (props: RecentDailyDataBarChartProps) {
     }
 
     const dayTick = ({x, y, payload}: any) => {
-        let currentDate = add(startDate, {days: payload.value - startDate.getDate()});
+        let daysAfterStart = payload.value;
+        let currentDate = add(startDate, {days: daysAfterStart});
         return <text x={x} y={y + 8} fontSize="11" fontWeight="bold" textAnchor="middle" fill="var(--mdhui-text-color-2)">{format(currentDate, 'M/d')}</text>;
     }
 
@@ -145,7 +146,7 @@ export default function (props: RecentDailyDataBarChartProps) {
                         orientation="right"
                     />
                     <XAxis
-                        dataKey="day"
+                        dataKey="daysAfterStart"
                         tick={dayTick}
                         axisLine={false} minTickGap={0}
                         tickLine={false}


### PR DESCRIPTION
## Overview

The `RecentDailyDataBarChart` has a bug where the day tick labeling is incorrect when crossing month boundaries.  This branch fixes that.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
 
n/a