### PR TITLE
For ConnectEhr, ConnectFitbit, and ConnectGarmin widgets, update hideWhenConnected flag to display connections in error

### DIFF
--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -117,7 +117,7 @@ export default function (props: ConnectDeviceProps) {
 		}
 	}
 
-	if (props.hideWhenConnected && deviceExternalAccount) {
+	if (props.hideWhenConnected && deviceExternalAccount && deviceExternalAccount?.status != "unauthorized") {
 		return null;
 	}
 

--- a/src/components/container/ConnectDevice/ConnectDevice.tsx
+++ b/src/components/container/ConnectDevice/ConnectDevice.tsx
@@ -117,7 +117,7 @@ export default function (props: ConnectDeviceProps) {
 		}
 	}
 
-	if (props.hideWhenConnected && deviceExternalAccount && deviceExternalAccount?.status != "unauthorized") {
+	if (props.hideWhenConnected && deviceExternalAccount && deviceExternalAccount?.status != "unauthorized" && deviceExternalAccount?.status != "error") {
 		return null;
 	}
 

--- a/src/components/container/ConnectEhr/ConnectEhr.stories.tsx
+++ b/src/components/container/ConnectEhr/ConnectEhr.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react"
 import Card from "../../presentational/Card"
 import Layout from "../../presentational/Layout"
 import ConnectEhr, { ConnectEhrProps } from "./ConnectEhr";
+import { truncateByDomain } from "recharts/types/util/ChartUtils";
 
 
 export default {
@@ -81,3 +82,12 @@ export const CustomConnectText = {
     render: render
 };
 
+export const HideConnectedEnabledConnected = {
+    args: { previewState: "enabledConnected", applicationUrl: "preview", hideWhenConnected: true },
+    render: render
+};
+
+export const HideConnectedEnabledNeedsAttention = {
+    args: { previewState: "enabledNeedsAttention", applicationUrl: "preview", hideWhenConnected: true },
+    render: render
+};

--- a/src/components/container/ConnectEhr/ConnectEhr.stories.tsx
+++ b/src/components/container/ConnectEhr/ConnectEhr.stories.tsx
@@ -3,7 +3,6 @@ import { ComponentMeta, ComponentStory } from "@storybook/react"
 import Card from "../../presentational/Card"
 import Layout from "../../presentational/Layout"
 import ConnectEhr, { ConnectEhrProps } from "./ConnectEhr";
-import { truncateByDomain } from "recharts/types/util/ChartUtils";
 
 
 export default {

--- a/src/components/container/ConnectEhr/ConnectEhr.tsx
+++ b/src/components/container/ConnectEhr/ConnectEhr.tsx
@@ -102,7 +102,7 @@ export default function (props: ConnectEhrProps) {
 		return null;
 	}
 
-	if (props.hideWhenConnected && connected) {
+	if (props.hideWhenConnected && connected && !needsAttention) {
 		return null;
 	}
 

--- a/src/components/container/ConnectFitbit/ConnectFitbit.stories.tsx
+++ b/src/components/container/ConnectFitbit/ConnectFitbit.stories.tsx
@@ -39,3 +39,15 @@ NotEnabledHide.args = { previewState: "notEnabled", title: "Fitbit", disabledBeh
 
 export const NotEnabledDisplayError = Template.bind({});
 NotEnabledDisplayError.args = { previewState: "notEnabled", title: "Fitbit", disabledBehavior: "displayError" };
+
+export const HideConnectedFetchComplete = Template.bind({});
+HideConnectedFetchComplete.args = { previewState: "fetchComplete", title: "Fitbit", hideWhenConnected: true };
+
+export const HideConnectedNotConnected = Template.bind({});
+HideConnectedNotConnected.args = { previewState: "notConnected", title: "Fitbit", hideWhenConnected: true };
+
+export const HideConnectedUnauthorized = Template.bind({});
+HideConnectedUnauthorized.args = { previewState: "unauthorized", title: "Fitbit", hideWhenConnected: true };
+
+export const HideConnectedFetchingData = Template.bind({});
+HideConnectedFetchingData.args = { previewState: "fetchingData", title: "Fitbit", hideWhenConnected: true };

--- a/src/components/container/ConnectGarmin/ConnectGarmin.stories.tsx
+++ b/src/components/container/ConnectGarmin/ConnectGarmin.stories.tsx
@@ -39,3 +39,15 @@ NotEnabledHide.args = { previewState: "notEnabled", title: "Garmin", disabledBeh
 
 export const NotEnabledDisplayError = Template.bind({});
 NotEnabledDisplayError.args = { previewState: "notEnabled", title: "Garmin", disabledBehavior: "displayError" };
+
+export const HideConnectedNotConnected = Template.bind({});
+HideConnectedNotConnected.args = { previewState: "notConnected", title: "Garmin", hideWhenConnected: true };
+
+export const HideConnectedUnauthorized = Template.bind({});
+HideConnectedUnauthorized.args = { previewState: "unauthorized", title: "Garmin", hideWhenConnected: true };
+
+export const HideConnectedFetchComplete = Template.bind({});
+HideConnectedFetchComplete.args = { previewState: "fetchComplete", title: "Garmin", hideWhenConnected: true };
+
+export const HideConnectedFetchingData = Template.bind({});
+HideConnectedFetchingData.args = { previewState: "fetchingData", title: "Garmin", hideWhenConnected: true };


### PR DESCRIPTION
## Overview

Addresses: https://github.com/CareEvolution/MyDataHelpsUI/issues/224

Adds stories to the ConnectFitbit, ConnectGarmin, and ConnectEhr to cover cases when the hideWhenConnected flag is set.  Updates the default behavior of "hideWhenConnected" to not hide the widget in the case the connection is in an unauthorized or error state.  This will allow a user to view the widget and be able to reconnect or fix a connection error. 

This change can be see in the `ConnectEhr->Hide Connected Enabled Needs Attention` story, the `Fitbit->Hide Connected Unauthorized` and `Garmin->Hide Connected Unauthorized` stories.  Prior to the code change these would be hidden in the UI.

## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Changes to how existing connections are displayed in the user interface only.  No changes to underlying connection code.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner