### PR TITLE
Add Day navigation to the DateRangeNavigator and DateRangeCoordinator

### DIFF
--- a/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.stories.tsx
+++ b/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.stories.tsx
@@ -71,6 +71,16 @@ let children = <Card><DailyDataChart title="Steps"
 		return Promise.resolve(data);
 	}} /></Card>;
 
+export const day = {
+	args: {
+		variant: "rounded",
+		initialIntervalStart: new Date(),
+		intervalType: "Day",
+		children: <Card></Card>
+	},
+	render: render
+};
+
 export const month = {
 	args: {
 		variant: "rounded",

--- a/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.tsx
+++ b/src/components/presentational/DateRangeCoordinator/DateRangeCoordinator.tsx
@@ -5,7 +5,7 @@ import { WeekStartsOn, getMonthStart, getWeekStart } from "../../../helpers/get-
 
 export interface DateRangeCoordinatorProps {
     initialIntervalStart?: Date;
-    intervalType: "Week" | "Month";
+    intervalType: "Day" | "Week" | "Month";
     weekStartsOn?: WeekStartsOn;
     variant?: "default" | "rounded";
     children: React.ReactNode;
@@ -14,7 +14,7 @@ export interface DateRangeCoordinatorProps {
 }
 
 export interface DateRangeContext {
-    intervalType: "Week" | "Month";
+    intervalType: "Day" | "Week" | "Month";
     intervalStart: Date;
 }
 

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.stories.tsx
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.stories.tsx
@@ -17,6 +17,13 @@ const Template: ComponentStory<typeof DateRangeNavigator> = (args: DateRangeNavi
 	</Layout>;
 
 var currentDate = new Date();
+export const Day = Template.bind({});
+Day.args = {
+	intervalStart: new Date(),
+	intervalType: "Day"
+}
+
+
 export const Month = Template.bind({});
 Month.args = {
 	intervalStart: new Date(currentDate.getFullYear(), currentDate.getMonth(), 1, 0, 0, 0, 0),

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
@@ -11,7 +11,7 @@ import { enUS, es } from 'date-fns/locale';
 import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
 
 export interface DateRangeNavigatorProps {
-	intervalType: "Week" | "Month";
+	intervalType: "Day" | "Week" | "Month";
 	intervalStart: Date;
 	variant?: "default" | "rounded";
 	onIntervalChange(newIntervalStart: Date, newIntervalEnd: Date): void;
@@ -21,7 +21,7 @@ export interface DateRangeNavigatorProps {
 }
 
 export default function (props: DateRangeNavigatorProps) {
-	var duration: Duration = props.intervalType == "Month" ? { months: 1 } : { weeks: 1 };
+	var duration: Duration = props.intervalType == "Month" ? { months: 1 } : props.intervalType == "Day" ? { days: 1 } : { weeks: 1 };
 
 	var nextInterval = function () {
 		var newIntervalStart = add(props.intervalStart, duration);
@@ -70,10 +70,15 @@ export default function (props: DateRangeNavigatorProps) {
 						{getMonthName()} {props.intervalStart.getFullYear()}
 					</div>
 				}
-				{(props.intervalType == "Week" || props.intervalStart.getDate() != 1) &&
+				{(props.intervalType == "Week" || (props.intervalType == "Month" && props.intervalStart.getDate() != 1)) &&
 					<div>
 						{format(props.intervalStart, "MM/dd/yyyy")}&nbsp;-&nbsp;
 						{format(sub(intervalEnd, { days: 1 }), "MM/dd/yyyy")}
+					</div>
+				}
+				{(props.intervalType == "Day") &&
+					<div>
+						{format(props.intervalStart, "MM/dd/yyyy")}
 					</div>
 				}
 				{!isCurrentInterval &&

--- a/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
+++ b/src/components/presentational/DateRangeNavigator/DateRangeNavigator.tsx
@@ -1,7 +1,7 @@
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import '@fortawesome/fontawesome-svg-core/styles.css';
-import { format, sub } from 'date-fns';
+import { format, isToday, sub } from 'date-fns';
 import React from 'react';
 import UnstyledButton from '../UnstyledButton';
 import "./DateRangeNavigator.css"
@@ -9,6 +9,7 @@ import MyDataHelps from "@careevolution/mydatahelps-js"
 import add from 'date-fns/add'
 import { enUS, es } from 'date-fns/locale';
 import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
+import language from '../../../helpers/language';
 
 export interface DateRangeNavigatorProps {
 	intervalType: "Day" | "Week" | "Month";
@@ -78,7 +79,7 @@ export default function (props: DateRangeNavigatorProps) {
 				}
 				{(props.intervalType == "Day") &&
 					<div>
-						{format(props.intervalStart, "MM/dd/yyyy")}
+						{isToday(props.intervalStart) ? language("today") : format(props.intervalStart, "MM/dd/yyyy")}
 					</div>
 				}
 				{!isCurrentInterval &&


### PR DESCRIPTION
## Overview

Add Day navigation to the DateRangeNavigator and DateRangeCoordinator

## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner