### PR TITLE
Add Spanish translations for Device Data Month Chart

### DIFF
--- a/src/components/container/DeviceDataMonthChart/DeviceDataMonthChart.tsx
+++ b/src/components/container/DeviceDataMonthChart/DeviceDataMonthChart.tsx
@@ -8,6 +8,7 @@ import { LoadingIndicator } from '../../presentational'
 import { getPreviewData } from './DeviceDataMonthChart.previewdata'
 import { queryDailyData, checkDailyDataAvailability, DailyDataQueryResult } from '../../../helpers/query-daily-data'
 import getDayKey from '../../../helpers/get-day-key'
+import language from "../../../helpers/language"
 
 export interface DeviceDataMonthChartProps {
 	lines: DeviceDataChartLine[],
@@ -223,7 +224,7 @@ export default function (props: DeviceDataMonthChartProps) {
 			}
 			{!loading && average != null &&
 				<div className="average">
-					Daily Average: <span className="average-value">{average}</span>
+					{language("device-data-month-chart-daily-average")}: <span className="average-value">{average}</span>
 				</div>
 			}
 			<div style={{ clear: "both" }}></div>
@@ -231,7 +232,7 @@ export default function (props: DeviceDataMonthChartProps) {
 				{(!graphHasData || loading) &&
 					<div>
 						{!graphHasData && !loading &&
-							<div className="no-data-label">No Data</div>
+							<div className="no-data-label">{language("device-data-month-chart-no-data")}</div>
 						}
 						{loading &&
 							<LoadingIndicator />

--- a/src/helpers/strings-en.ts
+++ b/src/helpers/strings-en.ts
@@ -314,6 +314,8 @@
     "asthma-log-entry-editor-view-impacts-title": "Impacts",
     "asthma-log-entry-editor-view-triggers-title": "Triggers",
     "blood-type": "Blood Type",
+    "device-data-month-chart-no-data": "No Data",
+    "device-data-month-chart-daily-average": "Daily Average",
 };
 
 export default strings;

--- a/src/helpers/strings-es.ts
+++ b/src/helpers/strings-es.ts
@@ -178,6 +178,8 @@
     "asthma-control-calendar-log-entries-impacts-label": "Impactos",
     "asthma-control-calendar-log-entries-triggers-label": "Disparadores",
     "blood-type": "Tipo de sangre",
+    "device-data-month-chart-no-data": "Sin Datos",
+    "device-data-month-chart-daily-average": "Promedio Diario",
 };
 
 export default strings;


### PR DESCRIPTION
## Overview

Added two Spanish translations for the Device Data Month Chart.  Addresses: https://github.com/CareEvolution/MyDataHelpsUI/issues/221

Translations are from google translate:
`No Data` => `Sin Datos`
`Daily Average` => `Promedio Diario`

![ddmcLanguage](https://github.com/CareEvolution/MyDataHelpsUI/assets/4119723/d53cca09-1771-4066-a478-b1468d698cf4)

Note:  The titles, `"Resting Heart Rate"` and `"Steps"`, are passed in and should be localized prior to invoking this widget.


## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

Updates only for the UI, and only for language display.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

Tested via Storybook, by changing browser language to Spanish.

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Not Applicable 

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner