### PR TITLE
Fix an issue with the top padding of navigation bar children.

### DIFF
--- a/src/components/asthma/views/AsthmaActivityView/AsthmaActivityView.tsx
+++ b/src/components/asthma/views/AsthmaActivityView/AsthmaActivityView.tsx
@@ -35,8 +35,8 @@ export default function (props: AsthmaActivityViewProps) {
     });
 
     return <Layout colorScheme={props.colorScheme ?? 'auto'} bodyBackgroundColor="var(--mdhui-background-color-0)">
-        <NavigationBar showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
-            <Title order={1} style={{paddingTop: '32px'}}>{language('asthma-activity-view-title')}</Title>
+        <NavigationBar variant="compressed" showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
+            <Title order={1}>{language('asthma-activity-view-title')}</Title>
         </NavigationBar>
         <RecentDailyDataBarChart
             previewState={props.previewState === 'default' ? 'loaded with data' : undefined}

--- a/src/components/asthma/views/AsthmaAirQualityView/AsthmaAirQualityView.tsx
+++ b/src/components/asthma/views/AsthmaAirQualityView/AsthmaAirQualityView.tsx
@@ -21,8 +21,8 @@ export default function (props: AsthmaAirQualityViewProps) {
     }
 
     return <Layout colorScheme={props.colorScheme ?? 'auto'} bodyBackgroundColor="var(--mdhui-background-color-0)">
-        <NavigationBar showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
-            <Title order={1} style={{paddingTop: '32px'}}>{language('asthma-air-quality-view-title')}</Title>
+        <NavigationBar variant="compressed" showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
+            <Title order={1}>{language('asthma-air-quality-view-title')}</Title>
         </NavigationBar>
         {(!props.alert || props.alert === 'HomeAirQuality') &&
             <RecentDailyDataBarChart

--- a/src/components/asthma/views/AsthmaDayView/AsthmaDayView.tsx
+++ b/src/components/asthma/views/AsthmaDayView/AsthmaDayView.tsx
@@ -19,8 +19,8 @@ export interface AsthmaDayViewProps {
 
 export default function (props: AsthmaDayViewProps) {
     return <Layout colorScheme={props.colorScheme ?? 'auto'}>
-        <NavigationBar showCloseButton={true}>
-            <Title order={2} style={{paddingTop: '32px'}}>
+        <NavigationBar variant="compressed" showCloseButton={true}>
+            <Title order={2}>
                 {format(props.date, 'PPP')}
             </Title>
         </NavigationBar>

--- a/src/components/asthma/views/AsthmaHeartAndLungsView/AsthmaHeartAndLungsView.tsx
+++ b/src/components/asthma/views/AsthmaHeartAndLungsView/AsthmaHeartAndLungsView.tsx
@@ -52,8 +52,8 @@ export default function (props: AsthmaHeartAndLungsViewProps) {
     });
 
     return <Layout colorScheme={props.colorScheme ?? 'auto'} bodyBackgroundColor="var(--mdhui-background-color-0)">
-        <NavigationBar showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
-            <Title order={1} style={{paddingTop: '32px'}}>{language('asthma-heart-and-lungs-view-title')}</Title>
+        <NavigationBar variant="compressed" showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
+            <Title order={1}>{language('asthma-heart-and-lungs-view-title')}</Title>
         </NavigationBar>
         {(!props.alert || props.alert === 'DaytimeRestingHeartRate') &&
             <RecentDailyDataBarChart

--- a/src/components/asthma/views/AsthmaProviderReportView/AsthmaProviderReportView.tsx
+++ b/src/components/asthma/views/AsthmaProviderReportView/AsthmaProviderReportView.tsx
@@ -9,8 +9,8 @@ export interface AsthmaProviderReportViewProps {
 
 export default function (props: AsthmaProviderReportViewProps) {
     return <Layout colorScheme="light">
-        <NavigationBar showCloseButton={true}>
-            <Title order={1} style={{paddingTop: '32px'}}>Provider Report</Title>
+        <NavigationBar variant="compressed" showCloseButton={true}>
+            <Title order={1}>Provider Report</Title>
         </NavigationBar>
         <AsthmaProviderReport
             previewState={props.previewState}

--- a/src/components/asthma/views/AsthmaSleepView/AsthmaSleepView.tsx
+++ b/src/components/asthma/views/AsthmaSleepView/AsthmaSleepView.tsx
@@ -35,8 +35,8 @@ export default function (props: AsthmaSleepViewProps) {
     });
 
     return <Layout colorScheme={props.colorScheme ?? 'auto'} bodyBackgroundColor="var(--mdhui-background-color-0)">
-        <NavigationBar showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
-            <Title order={1} style={{paddingTop: '32px'}}>{language('asthma-sleep-view-title')}</Title>
+        <NavigationBar variant="compressed" showCloseButton={true} backgroundColor="var(--mdhui-background-color-0)">
+            <Title order={1}>{language('asthma-sleep-view-title')}</Title>
         </NavigationBar>
         <RecentDailyDataBarChart
             previewState={props.previewState === 'default' ? 'loaded with data' : undefined}

--- a/src/components/presentational/NavigationBar/NavigationBar.css
+++ b/src/components/presentational/NavigationBar/NavigationBar.css
@@ -63,3 +63,11 @@
 .mdhui-navigation-bar .close-button {
     right: 16px;
 }
+
+.mdhui-navigation-bar .children {
+    padding-top: calc(56px + env(safe-area-inset-top, 0px));
+}
+
+.mdhui-navigation-bar.mdhui-navigation-bar-compressed .children {
+    padding-top: calc(32px + env(safe-area-inset-top, 0px));
+}

--- a/src/components/presentational/NavigationBar/NavigationBar.tsx
+++ b/src/components/presentational/NavigationBar/NavigationBar.tsx
@@ -97,7 +97,11 @@ export default function (props: NavigationBarProps) {
 					{props.closeButtonText ? props.closeButtonText : language('close')}
 				</div>
 			}
-			{props.children}
+			{props.children &&
+				<div className="children">
+					{props.children}
+				</div>
+			}
 		</div>
 	);
 }

--- a/src/components/view/ResourceListView/ResourceListView.tsx
+++ b/src/components/view/ResourceListView/ResourceListView.tsx
@@ -21,8 +21,8 @@ export default function (props: ResourceListViewProps) {
     };
 
     return <Layout colorScheme={props.colorScheme ?? 'auto'}>
-        <NavigationBar showCloseButton={true}>
-            <Title order={1} style={{paddingTop: '32px'}}>{props.title}</Title>
+        <NavigationBar variant="compressed" showCloseButton={true}>
+            <Title order={1}>{props.title}</Title>
         </NavigationBar>
         <ResourceList
             previewState={props.previewState}


### PR DESCRIPTION
## Overview

Fixes an issue with top padding of navigation bar children that I introduced a while back when updating the navigation bar.

https://github.com/CareEvolution/MyDataHelpsUI/commit/17a361cabb9f41e56c49c8cc0e240ef9e97e78a4#r140349783

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just adjusting some CSS padding within the Navigation Bar component.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
