### PR TITLE
BP Viz - do not require a date result id

### DIFF
--- a/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
+++ b/src/helpers/blood-pressure-data-providers/survey-blood-pressure-data-provider.ts
@@ -3,7 +3,7 @@ import { parseISO, startOfDay } from "date-fns";
 
 export interface SurveyBloodPressureDataParameters {
     surveyName: string,
-    dateResultIdentifier: string,
+    dateResultIdentifier?: string,
     systolicResultIdentifier: string,
     diastolicResultIdentifier: string
 }
@@ -23,8 +23,13 @@ export default async function (props: SurveyBloodPressureDataParameters): Promis
             let resultIds = [...new Set(answers.map(a => a.surveyResultID))];
             resultIds.forEach((resultId) => {
                 var resultsForSubmission = answers.filter(a => a.surveyResultID == resultId);
-                var bpLogDateResults = resultsForSubmission.find(r => r.resultIdentifier == props.dateResultIdentifier);
-                var bpLogDate = bpLogDateResults && bpLogDateResults.answers ? bpLogDateResults.answers[0] : "";
+                var bpLogDate = "";
+                if (props.dateResultIdentifier){
+                    var bpLogDateResults = resultsForSubmission.find(r => r.resultIdentifier == props.dateResultIdentifier);
+                    bpLogDate = bpLogDateResults && bpLogDateResults.answers ? bpLogDateResults.answers[0] : "";
+                } else {
+                    bpLogDate = resultsForSubmission[0].date;
+                }
                 var bpSystolicResults = resultsForSubmission.find(r => r.resultIdentifier == props.systolicResultIdentifier);
                 var bpSystolic = bpSystolicResults && bpSystolicResults.answers ? bpSystolicResults.answers[0] : "";
                 var bpDiastolicResults = resultsForSubmission.find(r => r.resultIdentifier == props.diastolicResultIdentifier);
@@ -73,7 +78,9 @@ export default async function (props: SurveyBloodPressureDataParameters): Promis
         return MyDataHelps.querySurveyAnswers(queryParameters);
     }
 
-    const resultFilter = [props.dateResultIdentifier, props.systolicResultIdentifier, props.diastolicResultIdentifier];
+    const resultFilter = props.dateResultIdentifier ? 
+        [props.dateResultIdentifier, props.systolicResultIdentifier, props.diastolicResultIdentifier] : 
+        [props.systolicResultIdentifier, props.diastolicResultIdentifier];
     const surveyAnswers = await getSurveyAnswers();
     var sortedAnswers = (surveyAnswers).sort((a, b) => {
         if (parseISO(a.date) > parseISO(b.date)) { return -1; }


### PR DESCRIPTION
## Overview

BP Visualization - support survey data without requiring result id for the date observed. When a result id for the date observed is not supplied, the date the answers were recorded will be used. 

## Security

REMINDER: All file contents are public.

- [x ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner