### PR TITLE
RestingHeartRate - add garmin

### DIFF
--- a/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.stories.tsx
+++ b/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.stories.tsx
@@ -39,3 +39,33 @@ SampleData.args = {
   month: 3,
   showPreviewData: "WithData",
 };
+
+export const Combined = Template.bind({});
+Combined.args = {
+  month: new Date().getMonth(),
+  year: new Date().getFullYear(),
+  showPreviewData: "Combined",
+};
+
+export const AppleHealth = Template.bind({});
+AppleHealth.args = {
+  month: new Date().getMonth(),
+  year: new Date().getFullYear(),
+  showPreviewData: "AppleHealth",
+};
+
+export const Fitbit = Template.bind({});
+Fitbit.args = {
+  month: new Date().getMonth(),
+  year: new Date().getFullYear(),
+  showPreviewData: "Fitbit",
+};
+
+export const Garmin = Template.bind({});
+Garmin.args = {
+  month: new Date().getMonth(),
+  year: new Date().getFullYear(),
+  showPreviewData: "Garmin",
+};
+
+

--- a/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.stories.tsx
+++ b/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.stories.tsx
@@ -23,6 +23,13 @@ export const Default = Template.bind({});
 Default.args = {
   month: new Date().getMonth(),
   year: new Date().getFullYear(),
+  showPreviewData: "WithData",
+};
+
+export const NoData = Template.bind({});
+NoData.args = {
+  month: new Date().getMonth(),
+  year: new Date().getFullYear(),
   showPreviewData: "NoData",
 };
 
@@ -33,20 +40,13 @@ Loading.args = {
   showPreviewData: "Loading",
 };
 
-export const SampleData = Template.bind({});
-SampleData.args = {
-  year: 2022,
-  month: 3,
-  showPreviewData: "WithData",
-};
-
 export const Live = Template.bind({});
 Live.args = {
   month: new Date().getMonth(),
   year: new Date().getFullYear(),
-  showPreviewData: "Live",
   dataTypeSource: "Combined"
 };
+
 Live.argTypes = {
   dataTypeSource: {
     name: 'dataTypeSource',

--- a/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.stories.tsx
+++ b/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.stories.tsx
@@ -40,32 +40,18 @@ SampleData.args = {
   showPreviewData: "WithData",
 };
 
-export const Combined = Template.bind({});
-Combined.args = {
+export const Live = Template.bind({});
+Live.args = {
   month: new Date().getMonth(),
   year: new Date().getFullYear(),
-  showPreviewData: "Combined",
+  showPreviewData: "Live",
+  dataTypeSource: "Combined"
 };
-
-export const AppleHealth = Template.bind({});
-AppleHealth.args = {
-  month: new Date().getMonth(),
-  year: new Date().getFullYear(),
-  showPreviewData: "AppleHealth",
+Live.argTypes = {
+  dataTypeSource: {
+    name: 'dataTypeSource',
+    control: 'radio',
+    options: ["Combined", "AppleHealth", "Fitbit", "Garmin"],
+    defaultValue: "Combined"
+  }
 };
-
-export const Fitbit = Template.bind({});
-Fitbit.args = {
-  month: new Date().getMonth(),
-  year: new Date().getFullYear(),
-  showPreviewData: "Fitbit",
-};
-
-export const Garmin = Template.bind({});
-Garmin.args = {
-  month: new Date().getMonth(),
-  year: new Date().getFullYear(),
-  showPreviewData: "Garmin",
-};
-
-

--- a/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
+++ b/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
@@ -10,7 +10,7 @@ import { queryDailyData, DailyDataType } from '../../../helpers/query-daily-data
 
 type HeartRateMap = { [key: string]: number };
 
-export type RestingHeartRateCalendarPreviewState = "WithData" | "NoData" | "Loading";
+export type RestingHeartRateCalendarPreviewState = "WithData" | "NoData" | "Loading" | "Combined" | "AppleHealth" | "Fitbit" | "Garmin";
 
 export interface RestingHeartRateCalendarProps {
 	month: number,
@@ -26,8 +26,14 @@ export default function (props: RestingHeartRateCalendarProps) {
 	var monthStart = new Date(props.year, props.month, 1, 0, 0, 0, 0);
 	var monthEnd = add(monthStart, { months: 1 });
 
-	function getRestingHeartRates() {
-		return queryDailyData(DailyDataType.RestingHeartRate, monthStart, monthEnd).then(function (result) {
+	function getRestingHeartRates(dataType?: RestingHeartRateCalendarPreviewState) {
+		var dailyDataType: DailyDataType = DailyDataType.RestingHeartRate;
+		
+		if (dataType == "AppleHealth") dailyDataType = DailyDataType.AppleHealthRestingHeartRate;
+		if (dataType == "Fitbit") dailyDataType = DailyDataType.FitbitRestingHeartRate;
+		if (dataType == "Garmin") dailyDataType = DailyDataType.GarminRestingHeartRate;
+		
+		return queryDailyData(dailyDataType, monthStart, monthEnd).then(function (result) {
 			setHeartRates(result);
 		});
 	}
@@ -54,21 +60,23 @@ export default function (props: RestingHeartRateCalendarProps) {
 	}
 
 	function initialize() {
-		if (props.showPreviewData) {
-			if (props.showPreviewData === "Loading") {
-				setLoading(true);
-			}
-			else if (props.showPreviewData === "WithData") {
-				var previewData = getPreviewData("FitbitRestingHeartRates", props.year, props.month);
-				if (previewData) {
-					setHeartRates(previewData);
-				}
-			}
+		if (props.showPreviewData === "NoData") {
+			return;
 		}
-		else {
+		if (props.showPreviewData === "Loading") {
 			setLoading(true);
-			getRestingHeartRates().then(() => setLoading(false));
+			return;
 		}
+		if (props.showPreviewData === "WithData") {
+			var previewData = getPreviewData("FitbitRestingHeartRates", props.year, props.month);
+			if (previewData) {
+				setHeartRates(previewData);
+			}
+			return;
+		}
+
+		setLoading(true);
+		getRestingHeartRates(props.showPreviewData).then(() => setLoading(false));
 	}
 
 	useEffect(() => {

--- a/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
+++ b/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
@@ -10,7 +10,7 @@ import { queryDailyData, DailyDataType } from '../../../helpers/query-daily-data
 
 type HeartRateMap = { [key: string]: number };
 
-export type RestingHeartRateCalendarPreviewState = "WithData" | "NoData" | "Loading" | "Live";
+export type RestingHeartRateCalendarPreviewState = "WithData" | "NoData" | "Loading";
 export type RestingHeartRateDataSource = "Combined" | "AppleHealth" | "Fitbit" | "Garmin";
 
 export interface RestingHeartRateCalendarProps {

--- a/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
+++ b/src/components/container/RestingHeartRateCalendar/RestingHeartRateCalendar.tsx
@@ -10,12 +10,14 @@ import { queryDailyData, DailyDataType } from '../../../helpers/query-daily-data
 
 type HeartRateMap = { [key: string]: number };
 
-export type RestingHeartRateCalendarPreviewState = "WithData" | "NoData" | "Loading" | "Combined" | "AppleHealth" | "Fitbit" | "Garmin";
+export type RestingHeartRateCalendarPreviewState = "WithData" | "NoData" | "Loading" | "Live";
+export type RestingHeartRateDataSource = "Combined" | "AppleHealth" | "Fitbit" | "Garmin";
 
 export interface RestingHeartRateCalendarProps {
 	month: number,
 	year: number,
 	showPreviewData: RestingHeartRateCalendarPreviewState
+	dataTypeSource?: RestingHeartRateDataSource
 	innerRef?: React.Ref<HTMLDivElement>
 }
 
@@ -26,12 +28,12 @@ export default function (props: RestingHeartRateCalendarProps) {
 	var monthStart = new Date(props.year, props.month, 1, 0, 0, 0, 0);
 	var monthEnd = add(monthStart, { months: 1 });
 
-	function getRestingHeartRates(dataType?: RestingHeartRateCalendarPreviewState) {
+	function getRestingHeartRates(dataTypeSource?: RestingHeartRateDataSource) {
 		var dailyDataType: DailyDataType = DailyDataType.RestingHeartRate;
 		
-		if (dataType == "AppleHealth") dailyDataType = DailyDataType.AppleHealthRestingHeartRate;
-		if (dataType == "Fitbit") dailyDataType = DailyDataType.FitbitRestingHeartRate;
-		if (dataType == "Garmin") dailyDataType = DailyDataType.GarminRestingHeartRate;
+		if (dataTypeSource == "AppleHealth") dailyDataType = DailyDataType.AppleHealthRestingHeartRate;
+		if (dataTypeSource == "Fitbit") dailyDataType = DailyDataType.FitbitRestingHeartRate;
+		if (dataTypeSource == "Garmin") dailyDataType = DailyDataType.GarminRestingHeartRate;
 		
 		return queryDailyData(dailyDataType, monthStart, monthEnd).then(function (result) {
 			setHeartRates(result);
@@ -76,7 +78,7 @@ export default function (props: RestingHeartRateCalendarProps) {
 		}
 
 		setLoading(true);
-		getRestingHeartRates(props.showPreviewData).then(() => setLoading(false));
+		getRestingHeartRates(props.dataTypeSource).then(() => setLoading(false));
 	}
 
 	useEffect(() => {

--- a/src/helpers/daily-data-providers/apple-health-sleep.ts
+++ b/src/helpers/daily-data-providers/apple-health-sleep.ts
@@ -73,7 +73,14 @@ function calculateSleepTime(ranges: DateRange[]) {
 	return totalTime;
 }
 
-function coreSleep(startDate: Date, endDate: Date, value: "Asleep" | "InBed") {
+type SleepType = "Asleep" | "InBed" | "AsleepCore" | "AsleepREM" | "AsleepDeep";
+
+function coreSleep(startDate: Date, endDate: Date, value: SleepType) {
+	var val: SleepType[] = [ value ];
+	return coreSleepMultiValue(startDate, endDate, val);
+}
+
+function coreSleepMultiValue(startDate: Date, endDate: Date, value: SleepType[]) {
 	return queryAllDeviceData({
 		namespace: "AppleHealth",
 		type: "SleepAnalysisInterval",
@@ -85,7 +92,7 @@ function coreSleep(startDate: Date, endDate: Date, value: "Asleep" | "InBed") {
 
 		ddp.forEach((d) => {
 			if (!d.observationDate || !d.startDate) { return; }
-			if (d.value != value) { return; }
+			if (!value.find(x => x /* as string */ == d.value) ) { return; }
 			var ranges = splitSleepSampleIntoRanges(d);
 			for (var i = 0; i < ranges.length; i++) {
 				var anchorDate = add(ranges[i].startDate, { hours: 6 });
@@ -116,4 +123,20 @@ export function asleepTime(startDate: Date, endDate: Date) {
 
 export function inBedTime(startDate: Date, endDate: Date) {
 	return coreSleep(startDate, endDate, "InBed");
+}
+
+export function asleepCoreTime(startDate: Date, endDate: Date) {
+	return coreSleep(startDate, endDate, "AsleepCore");
+}
+
+export function asleepRemTime(startDate: Date, endDate: Date) {
+	return coreSleep(startDate, endDate, "AsleepREM");
+}
+
+export function asleepDeepTime(startDate: Date, endDate: Date) {
+	return coreSleep(startDate, endDate, "AsleepDeep");
+}
+
+export function asleepAnyTime(startDate: Date, endDate: Date) {
+	return coreSleepMultiValue(startDate, endDate, [ "AsleepCore", "AsleepREM", "AsleepDeep" ]);
 }

--- a/src/helpers/daily-data-providers/apple-health-sleep.ts
+++ b/src/helpers/daily-data-providers/apple-health-sleep.ts
@@ -73,14 +73,7 @@ function calculateSleepTime(ranges: DateRange[]) {
 	return totalTime;
 }
 
-type SleepType = "Asleep" | "InBed" | "AsleepCore" | "AsleepREM" | "AsleepDeep";
-
-function coreSleep(startDate: Date, endDate: Date, value: SleepType) {
-	var val: SleepType[] = [ value ];
-	return coreSleepMultiValue(startDate, endDate, val);
-}
-
-function coreSleepMultiValue(startDate: Date, endDate: Date, value: SleepType[]) {
+function coreSleep(startDate: Date, endDate: Date, value: "Asleep" | "InBed") {
 	return queryAllDeviceData({
 		namespace: "AppleHealth",
 		type: "SleepAnalysisInterval",
@@ -92,7 +85,7 @@ function coreSleepMultiValue(startDate: Date, endDate: Date, value: SleepType[])
 
 		ddp.forEach((d) => {
 			if (!d.observationDate || !d.startDate) { return; }
-			if (!value.find(x => x /* as string */ == d.value) ) { return; }
+			if (d.value != value) { return; }
 			var ranges = splitSleepSampleIntoRanges(d);
 			for (var i = 0; i < ranges.length; i++) {
 				var anchorDate = add(ranges[i].startDate, { hours: 6 });
@@ -123,20 +116,4 @@ export function asleepTime(startDate: Date, endDate: Date) {
 
 export function inBedTime(startDate: Date, endDate: Date) {
 	return coreSleep(startDate, endDate, "InBed");
-}
-
-export function asleepCoreTime(startDate: Date, endDate: Date) {
-	return coreSleep(startDate, endDate, "AsleepCore");
-}
-
-export function asleepRemTime(startDate: Date, endDate: Date) {
-	return coreSleep(startDate, endDate, "AsleepREM");
-}
-
-export function asleepDeepTime(startDate: Date, endDate: Date) {
-	return coreSleep(startDate, endDate, "AsleepDeep");
-}
-
-export function asleepAnyTime(startDate: Date, endDate: Date) {
-	return coreSleepMultiValue(startDate, endDate, [ "AsleepCore", "AsleepREM", "AsleepDeep" ]);
 }

--- a/src/helpers/daily-data-providers/combined-resting-heart-rate.ts
+++ b/src/helpers/daily-data-providers/combined-resting-heart-rate.ts
@@ -32,7 +32,7 @@ export default function (startDate: Date, endDate: Date) {
 					}
 				});
 				if (heartRates.length > 0) {
-					data[dayKey] = heartRates.reduce((a,b) => a+b) / heartRates.length; // rounding?
+					data[dayKey] = Math.round( heartRates.reduce((a,b) => a+b) / heartRates.length );
 				}
 				startDate = add(startDate, { days: 1 });
 			}


### PR DESCRIPTION
## Overview

Updates the combined RestingHeartRate data provider to look at Garmin data, as well as AppleHealth and Fitbit.  It will then average and round the combined results for each day.  ~~Added stories to the Resting Heart Rate Calendar container for each three individual data sources as well as the combined data source.~~  Added a "Live" story that defaults to the Combined datasource, with options to selected a specific datasource.

Addresses https://github.com/CareEvolution/MyDataHelpsUI/issues/101

Test data for these screenshots was: no AppleHealth rhr data, fitbit data for one day, and garmin data for two days.

![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/4119723/3b202bca-43ea-47d0-8f63-a96bf8749375)
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/4119723/8f7dad63-9701-4028-a661-dfa4cdec998c)
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/4119723/d39d6137-56cb-4fc4-92a6-423309fa6d34)
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/4119723/d518a4e7-a74e-4fdd-bccd-995c555a52ba)


## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

No security risks, UI changes only.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)
- [x]  Tested via MDH-UI website only

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner