### PR TITLE
Fix: Blood Pressure Visualization bottom right cube should show Min Systolic

### DIFF
--- a/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
+++ b/src/components/container/BloodPressureVisualization/BloodPressureVisualization.tsx
@@ -32,15 +32,15 @@ interface BloodPressureMetrics {
     maxSystolic?: number,
     maxSystolicAlert?: string,
     maxSystolicAlertClass: string,
-    minDiastolic?: number,
-    minDiastolicAlert?: string,
-    minDiastolicAlertClass: string
+    minSystolic?: number,
+    minSystolicAlert?: string,
+    minSystolicAlertClass: string
 }
 
 export default function (props: BloodPressureVisualizationProps) {
-    const _minDiastolic = 0;
+    const _minSystolic = 0;
     const _maxSystolic = 250;
-    const yInterval: ClosedInterval = { values: [_minDiastolic, _maxSystolic] };
+    const yInterval: ClosedInterval = { values: [_minSystolic, _maxSystolic] };
     const axis: Axis = { yRange: yInterval, yIncrement: 50, xIncrement: (80 / 7) };
     const [bloodPressureData, setBloodPressureDataData] = useState<Map<string, BloodPressureDataPoint[]> | undefined>(undefined);
     const dateRangeContext = useContext(DateRangeContext);
@@ -150,7 +150,7 @@ export default function (props: BloodPressureVisualizationProps) {
             </div>
             <div className="mdhui-blood-pressure-metrics-rows">
                 {buildDetailBlock(language("highest-systolic"), metrics.maxSystolicAlert, metrics.maxSystolicAlertClass, metrics.maxSystolic)}
-                {buildDetailBlock(language("lowest-diastolic"), metrics.minDiastolicAlert, metrics.minDiastolicAlertClass, metrics.minDiastolic)}
+                {buildDetailBlock(language("lowest-systolic"), metrics.minSystolicAlert, metrics.minSystolicAlertClass, metrics.minSystolic)}
             </div>
         </div>;
     }
@@ -160,7 +160,7 @@ export default function (props: BloodPressureVisualizationProps) {
         let bpMetrics: BloodPressureMetrics = {
             averageDiastolicAlertClass: "",
             averageSystolicAlertClass: "",
-            minDiastolicAlertClass: "",
+            minSystolicAlertClass: "",
             maxSystolicAlertClass: ""
         };
 
@@ -185,17 +185,17 @@ export default function (props: BloodPressureVisualizationProps) {
         bpMetrics.averageDiastolicAlert = Category[diastolicWeeklyAvgAlert];
         bpMetrics.averageDiastolicAlertClass = diastolicWeeklyAvgAlert === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
 
-        let diastolicLow = Math.min(...diastolicReadings);
-        bpMetrics.minDiastolic = Math.round(diastolicLow);
-        let cat = getDiastolicCategory(diastolicLow);
-        bpMetrics.minDiastolicAlert = Category[cat];
-        bpMetrics.minDiastolicAlertClass = cat === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
-
         let systolicHigh = Math.max(...systolicReadings);
         bpMetrics.maxSystolic = Math.round(systolicHigh);
-        cat = getSystolicCategory(systolicHigh);
+        let cat = getSystolicCategory(systolicHigh);
         bpMetrics.maxSystolicAlert = Category[cat];
         bpMetrics.maxSystolicAlertClass = cat === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
+
+        let systolicLow = Math.min(...systolicReadings);
+        bpMetrics.minSystolic = Math.round(systolicLow);
+        cat = getSystolicCategory(systolicLow);
+        bpMetrics.minSystolicAlert = Category[cat];
+        bpMetrics.minSystolicAlertClass = cat === Category.Normal ? "mdhui-blood-pressure-metric-normal" : "mdhui-blood-pressure-metric-not-normal";
 
         return bpMetrics;
     }

--- a/src/helpers/strings-de.ts
+++ b/src/helpers/strings-de.ts
@@ -149,7 +149,6 @@ let strings: { [key: string]: string } = {
     "systolic-average": "Durchschnittlicher systolischer Blutdruck",
     "diastolic-average": "Durchschnittlicher diastolischer Blutdruck",
     "highest-systolic": "Höchster systolischer Blutdruck",
-    "lowest-diastolic": "Niedrigster diastolischer Blutdruck",
     "resource-default-button-text": "Öffnen",
     "inbox-message-completed-status": "ANGEGUCKT",
     "inbox-resource-completed-status": "ANGEGUCKT",

--- a/src/helpers/strings-en.ts
+++ b/src/helpers/strings-en.ts
@@ -149,7 +149,7 @@
     "systolic-average": "Systolic Average",
     "diastolic-average": "Diastolic Average",
     "highest-systolic": "Highest Systolic",
-    "lowest-diastolic": "Lowest Diastolic",
+    "lowest-systolic": "Lowest Systolic",
     "resource-default-button-text": "Open",
     "inbox-message-completed-status": "VIEWED",
     "inbox-resource-completed-status": "VIEWED",

--- a/src/helpers/strings-es.ts
+++ b/src/helpers/strings-es.ts
@@ -317,7 +317,11 @@
     "device-data-month-chart-no-data": "Sin Datos",
     "device-data-month-chart-daily-average": "Promedio Diario",
     "device-data-month-chart-minutes": "Minutos",
-    "device-data-month-chart-sleep": "Dormir"
+    "device-data-month-chart-sleep": "Dormir",
+    "systolic-average": "Promedio Sistólico",
+    "diastolic-average": "Promedio Diastólico",
+    "highest-systolic": "Sistólica más Alta",
+    "lowest-systolic": "Sistólica más Baja",
 };
 
 export default strings;

--- a/src/helpers/strings-fr.ts
+++ b/src/helpers/strings-fr.ts
@@ -149,7 +149,6 @@ let strings: { [key: string]: string } = {
     "systolic-average": "Moyenne systolique",
     "diastolic-average": "Moyenne diastolique",
     "highest-systolic": "Systolique le plus élevé",
-    "lowest-diastolic": "Diastolique le plus bas",
     "resource-default-button-text": "Ouvrir",
     "inbox-message-completed-status": "VU",
     "inbox-resource-completed-status": "VU",

--- a/src/helpers/strings-it.ts
+++ b/src/helpers/strings-it.ts
@@ -149,7 +149,6 @@ let strings: { [key: string]: string } = {
     "systolic-average": "Media sistolica",
     "diastolic-average": "Media diastolica",
     "highest-systolic": "Sistolica più alta",
-    "lowest-diastolic": "Diastolica più bassa",
     "resource-default-button-text": "Apri",
     "inbox-message-completed-status": "VISTO",
     "inbox-resource-completed-status": "VISTO",

--- a/src/helpers/strings-nl.ts
+++ b/src/helpers/strings-nl.ts
@@ -149,7 +149,6 @@ let strings: { [key: string]: string } = {
     "systolic-average": "Gemiddelde systolische waarde",
     "diastolic-average": "Gemiddelde diastolische waarde",
     "highest-systolic": "Hoogste systolische waarde",
-    "lowest-diastolic": "Laagste diastolische waarde",
     "resource-default-button-text": "Openen",
     "inbox-message-completed-status": "BEKEKEN",
     "inbox-resource-completed-status": "BEKEKEN",

--- a/src/helpers/strings-pl.ts
+++ b/src/helpers/strings-pl.ts
@@ -149,7 +149,6 @@ let strings: { [key: string]: string } = {
     "systolic-average": "Średnie ciśnienie skurczowe",
     "diastolic-average": "Średnie ciśnienie rozkurczowe",
     "highest-systolic": "Najwyższe ciśnienie skurczowe",
-    "lowest-diastolic": "Najniższe ciśnienie rozkurczowe",
     "resource-default-button-text": "Otwórz",
     "inbox-message-completed-status": "WIDZIANE",
     "inbox-resource-completed-status": "WIDZIANE",

--- a/src/helpers/strings-pt.ts
+++ b/src/helpers/strings-pt.ts
@@ -149,7 +149,6 @@ let strings: { [key: string]: string } = {
     "systolic-average": "Média sistólica",
     "diastolic-average": "Média diastólica",
     "highest-systolic": "Sistólica mais alta",
-    "lowest-diastolic": "Diastólica mais baixa",
     "resource-default-button-text": "Abrir",
     "inbox-message-completed-status": "VISTO",
     "inbox-resource-completed-status": "VISTO",


### PR DESCRIPTION
## Overview

Create a blood pressure survey and submit the following multiple entries for a single day  (systolic/diastolic)
1. 80/60
2. 120/80
3. 40/40
4. 20/40

Current Behavior
The bottom right cube shows Lowest Diastolic with a value of 40
All other aggregate values are correct

Expected Behavior
The bottom right cube shows the Lowest Systolic with a value of 20
All other aggregate values are correct

## Security

REMINDER: All file contents are public.

- [x ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers
@felideon 

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner