### PR TITLE
Validate language before calling setCurrentLanguage

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -31,6 +31,7 @@ export const decorators = [(story, context) => {
 	if (context.globals.language) {
 		myDataHelps.setCurrentLanguage(context.globals.language);
 	} else {
+		// MDH.js does not currently support clearing current language
 		myDataHelps.language = "";
 	}
 	

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -28,8 +28,11 @@ export const globalTypes = {
 export const decorators = [(story, context) => {
 	myDataHelps.setParticipantAccessToken({ "access_token": process.env.PARTICIPANT_ACCESS_TOKEN, "expires_in": 21600, "token_type": "Bearer" }, process.env.PARTICIPANT_ENVIRONMENT_API ? process.env.PARTICIPANT_ENVIRONMENT_API : "https://mydatahelps.org/");
 	
-	if (context.globals.language == "") myDataHelps.language = "";
-	myDataHelps.setCurrentLanguage(context.globals.language);
+	if (context.globals.language) {
+		myDataHelps.setCurrentLanguage(context.globals.language);
+	} else {
+		myDataHelps.language = "";
+	}
 	
 	return story();
 }];


### PR DESCRIPTION
## Overview

Previously, calling setCurrentLanguage with the empty string generates a console warning and fails to clear the language.  

Instead, we manually set MyDataHelps.language to the empty string and do not call setCurrentLanguage.  This allows future calls of MyDataHelps.getCurrentLanguage() to return the browser default language.

## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

No security risks, client side code changes only.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)
- [ ] StoryBook testing only

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner