### PR TITLE
Asthma: Auto launch logging one time after post enrollment activities have been completed.

### DIFF
--- a/src/components/asthma/helpers/asthma-data.ts
+++ b/src/components/asthma/helpers/asthma-data.ts
@@ -251,6 +251,8 @@ export interface AsthmaDataService {
 
     loadSurveyAnswers(surveyName: string | string[], fromDate?: Date): Promise<SurveyAnswer[]>;
 
+    checkSurveyAnswerExists(surveyName: string | string[]): Promise<boolean>;
+
     loadAsthmaActionPlan(): Promise<AsthmaActionPlan | undefined>;
 }
 
@@ -363,6 +365,10 @@ const service: AsthmaDataService = {
             query.insertedAfter = formatISO(fromDate);
         }
         return queryAllSurveyAnswers(query);
+    },
+    checkSurveyAnswerExists: function (surveyName: string | string[]): Promise<boolean> {
+        let query: SurveyAnswersQuery = {surveyName: surveyName, limit: 1};
+        return MyDataHelps.querySurveyAnswers(query).then(result => !!result.surveyAnswers.length);
     },
     loadAsthmaActionPlan: async function (): Promise<AsthmaActionPlan | undefined> {
         let result = await MyDataHelps.invokeCustomApi('Asthma.ActionPlan', 'GET', '', true);


### PR DESCRIPTION
## Overview

This branch updates the Asthma post enrollment survey trigger component to additionally auto-launch the today logging survey one time if all other post enrollment surveys have been completed and no logs have yet been recorded.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just auto-launching the logging survey that is already available to the user when specific conditions are met.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

n/a