### PR TITLE
Fix relative activity showing 0s

### DIFF
--- a/src/components/container/RelativeActivity/RelativeActivity.tsx
+++ b/src/components/container/RelativeActivity/RelativeActivity.tsx
@@ -42,7 +42,7 @@ export default function (props: RelativeActivityProps) {
             let transformedResults: { [key: string]: RelativeActivityQueryResult } = {};
             dataTypes.forEach(dataType => {
                 if (results[dataType.dailyDataType]?.[getDayKey(date)]?.value) {
-                    transformedResults[dataType.dailyDataType] = results[dataType.dailyDataType][getDayKey(date!)];
+                    transformedResults[dataType.dailyDataType] = results[dataType.dailyDataType][getDayKey(date)];
                 }
             });
             return transformedResults;
@@ -59,7 +59,7 @@ export default function (props: RelativeActivityProps) {
 
         //prevent requests from returning back out of order, since some of these can be long running
         let requestID = ++currentRequestID;
-        queryRelativeActivity(date!, date!, dataTypes, !!props.previewState).then(results => {
+        queryRelativeActivity(date, date, dataTypes, !!props.previewState).then(results => {
             if (requestID == currentRequestID) {
                 setResults(transformResults(results));
             }


### PR DESCRIPTION
## Overview

Fixes a minor regression where the "relative activity" component was not properly filtering out 0 / empty values.  Also in my testing I saw the potential for requests to return out of order here; followed a similar pattern to providerSearch to prevent this from happening. 

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner