### PR TITLE
Look up daily data type definitions from the dynamic collection.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.21.1",
+  "version": "2.21.2-FixDailyDataTypeDefinitionLookup.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.21.1",
+      "version": "2.21.2-FixDailyDataTypeDefinitionLookup.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.21.1",
+  "version": "2.21.2-FixDailyDataTypeDefinitionLookup.0",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/helpers/query-daily-data.tsx
+++ b/src/helpers/query-daily-data.tsx
@@ -86,11 +86,8 @@ export function getAllDailyDataTypes() {
 	return Array.from(dailyDataTypes.values());
 }
 
-let definitionLookup = new Map(
-	allTypeDefinitions.map((typeDefinition) => [typeDefinition.type, typeDefinition])
-);
 export function getDailyDataTypeDefinition(dataType: string): DailyDataTypeDefinition {
-	return definitionLookup.get(dataType)!;
+	return dailyDataTypes.get(dataType)!;
 }
 
 allTypeDefinitions.forEach(function (typeDefinition) {


### PR DESCRIPTION
## Overview

I ran into this issue while trying to use the `DailyDataChart` with a non-standard daily data provider.

I think the type definition lookup needs to use the dynamic collection of types, which gets updated by registrations, rather than the hard coded list of standard types.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  This just corrects a bug to allow for custom daily data providers to be used, which was the original intent.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance of daily data type definitions lookup by using direct access from a set instead of a map.

- **Chores**
  - Incremented version from "2.21.1" to "2.21.2-FixDailyDataTypeDefinitionLookup.0".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->