### PR TITLE
Add a discrete scale component.

### DIFF
--- a/src/components/presentational/DiscreteScale/DiscreteScale.css
+++ b/src/components/presentational/DiscreteScale/DiscreteScale.css
@@ -29,7 +29,15 @@
 .mdhui-discrete-scale-ticks-section-button.mdhui-unstyled-button {
     position: absolute;
     top: -20px;
-    left: -11px;
+    left: calc(-100% + 9px);
+    height: 20px;
+    width: 100%;
+}
+
+.mdhui-discrete-scale-ticks-section-marker {
+    position: absolute;
+    top: 0;
+    right: 0;
     height: 20px;
     width: 20px;
     border-radius: 10px;

--- a/src/components/presentational/DiscreteScale/DiscreteScale.css
+++ b/src/components/presentational/DiscreteScale/DiscreteScale.css
@@ -29,15 +29,12 @@
 .mdhui-discrete-scale-ticks-section-button.mdhui-unstyled-button {
     position: absolute;
     top: -20px;
-    left: -50%;
     height: 20px;
-    width: 100%;
 }
 
 .mdhui-discrete-scale-ticks-section-marker {
     position: absolute;
     top: 0;
-    left: calc(50% - 11px);
     height: 20px;
     width: 20px;
     border-radius: 10px;

--- a/src/components/presentational/DiscreteScale/DiscreteScale.css
+++ b/src/components/presentational/DiscreteScale/DiscreteScale.css
@@ -1,0 +1,48 @@
+.mdhui-discrete-scale {
+    padding: 16px;
+}
+
+.mdhui-discrete-scale-slider {
+    height: 10px;
+    border: 1px solid var(--mdhui-border-color-2);
+    border-radius: 5px;
+    margin-bottom: 4px;
+}
+
+.mdhui-discrete-scale-ticks {
+    padding: 0 8px;
+    display: grid;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.mdhui-discrete-scale-ticks-section {
+    position: relative;
+    height: 5px;
+    border-right: 2px solid var(--mdhui-border-color-1);
+}
+
+.mdhui-discrete-scale-ticks-section:first-child {
+    border-left: 2px solid var(--mdhui-border-color-1);
+}
+
+.mdhui-discrete-scale-ticks-section-button.mdhui-unstyled-button {
+    position: absolute;
+    top: -20px;
+    left: -11px;
+    height: 20px;
+    width: 20px;
+    border-radius: 10px;
+}
+
+.mdhui-discrete-scale-labels {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+    font-size: 0.8em;
+    color: var(--mdhui-text-color-2);
+}
+
+.mdhui-discrete-scale-labels-max {
+    text-align: right;
+}

--- a/src/components/presentational/DiscreteScale/DiscreteScale.stories.tsx
+++ b/src/components/presentational/DiscreteScale/DiscreteScale.stories.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import DiscreteScale, { DiscreteScaleProps } from './DiscreteScale';
+import { Layout } from '../../presentational';
+
+export default {
+    title: 'Presentational/DiscreteScale',
+    component: DiscreteScale,
+    parameters: { layout: 'fullscreen' }
+};
+
+interface DiscreteScaleStoryArgs extends DiscreteScaleProps {
+    colorScheme: 'auto' | 'light' | 'dark';
+}
+
+const render = (args: DiscreteScaleStoryArgs) => {
+    const [value, setValue] = useState<number>(3);
+
+    return <Layout colorScheme={args.colorScheme}>
+        <DiscreteScale {...args} value={value} onChange={setValue} />
+        <div style={{ padding: '16px 0', textAlign: 'center' }}>The current value is {value}.</div>
+    </Layout>;
+};
+
+export const Default = {
+    args: {
+        colorScheme: 'auto',
+        sliderColor: '#51d521',
+        tickCount: 11,
+        minLabel: 'Min Label',
+        maxLabel: 'Max Label'
+    },
+    argTypes: {
+        colorScheme: {
+            name: 'color scheme',
+            control: 'radio',
+            options: ['auto', 'light', 'dark']
+        },
+        sliderColor: {
+            name: 'slider color',
+            control: 'color'
+        },
+        tickCount: {
+            name: 'tick count',
+            control: {
+                type: 'number',
+                min: 2,
+                max: 21
+            }
+        },
+        minLabel: {
+            name: 'minimum value label'
+        },
+        maxLabel: {
+            name: 'maximum value label'
+        }
+    },
+    render: render
+};
+

--- a/src/components/presentational/DiscreteScale/DiscreteScale.tsx
+++ b/src/components/presentational/DiscreteScale/DiscreteScale.tsx
@@ -51,11 +51,16 @@ export default function (props: DiscreteScaleProps) {
                     <UnstyledButton
                         className="mdhui-discrete-scale-ticks-section-button"
                         onClick={() => onClick(value)}
+                        style={{
+                            left: index === 0 ? '-10px' : '-50%',
+                            width: index === 0 ? 'calc(50% + 10px)' : '100%'
+                        }}
                     >
                         <div
                             className="mdhui-discrete-scale-ticks-section-marker"
                             style={{
                                 background: value === selectedValue ? sliderColor : 'transparent',
+                                left: index === 0 ? '-1px' : 'calc(50% - 11px)'
                             }}
                         >&nbsp;</div>
                     </UnstyledButton>
@@ -64,13 +69,15 @@ export default function (props: DiscreteScaleProps) {
                             className="mdhui-discrete-scale-ticks-section-button"
                             onClick={() => onClick(value + 1)}
                             style={{
-                                left: 'calc(50% + 2px)'
+                                left: 'calc(50% + 2px)',
+                                width: 'calc(50% + 10px)'
                             }}
                         >
                             <div
                                 className="mdhui-discrete-scale-ticks-section-marker"
                                 style={{
                                     background: value + 1 === selectedValue ? sliderColor : 'transparent',
+                                    right: '1px'
                                 }}
                             >&nbsp;</div>
                         </UnstyledButton>

--- a/src/components/presentational/DiscreteScale/DiscreteScale.tsx
+++ b/src/components/presentational/DiscreteScale/DiscreteScale.tsx
@@ -1,0 +1,76 @@
+import React, { CSSProperties, useContext } from 'react';
+import { ColorDefinition, resolveColor } from '../../../helpers';
+import { LayoutContext } from '../Layout';
+import './DiscreteScale.css';
+import UnstyledButton from "../UnstyledButton";
+
+export interface DiscreteScaleProps {
+    tickCount: number;
+    minLabel?: string;
+    maxLabel?: string;
+    value?: number;
+    onChange?: (value: number) => void;
+    sliderColor?: ColorDefinition;
+    innerRef?: React.RefObject<HTMLDivElement>;
+}
+
+export default function (props: DiscreteScaleProps) {
+    const layoutContext = useContext(LayoutContext);
+
+    const values = [...Array(props.tickCount).keys()];
+
+    let selectedValue = props.value ?? 0;
+    if (selectedValue < 0) selectedValue = 0;
+    if (selectedValue >= props.tickCount) selectedValue = props.tickCount - 1;
+
+    let sliderColor = props.sliderColor ? resolveColor(layoutContext.colorScheme, props.sliderColor) : 'var(--mdhui-color-primary)';
+    let sliderStop = `calc((((100% - 16px) / ${(props.tickCount - 1)}) * ${selectedValue}) + 8px)`;
+    let sliderStyle = {
+        background: `linear-gradient(to right, ${sliderColor} 0%, ${sliderColor} ${sliderStop}, var(--mdhui-background-color-2) ${sliderStop}, var(--mdhui-background-color-2) 100%)`
+    } as CSSProperties;
+
+    let ticksStyle = {
+        gridTemplateColumns: values.slice(0, -1).map(v => '1fr').join(' ')
+    } as CSSProperties;
+
+    let buttonStyle = {
+        background: sliderColor
+    } as CSSProperties;
+
+    const onClick = (value: number) => {
+        if (props.onChange) {
+            props.onChange(value);
+        }
+    };
+
+    return <div className="mdhui-discrete-scale" ref={props.innerRef}>
+        <div className="mdhui-discrete-scale-slider" style={sliderStyle}>&nbsp;</div>
+        <div className="mdhui-discrete-scale-ticks" style={ticksStyle}>
+            {values.slice(0, -1).map((value, index) => {
+                return <div key={index} className="mdhui-discrete-scale-ticks-section">
+                    <UnstyledButton
+                        className="mdhui-discrete-scale-ticks-section-button"
+                        onClick={() => onClick(value)}
+                        style={{
+                            background: value === selectedValue ? sliderColor : 'transparent'
+                        }}
+                    >&nbsp;</UnstyledButton>
+                    {index === props.tickCount - 2 &&
+                        <UnstyledButton
+                            className="mdhui-discrete-scale-ticks-section-button"
+                            onClick={() => onClick(value + 1)}
+                            style={{
+                                background: value + 1 === selectedValue ? sliderColor : 'transparent',
+                                left: `calc(100% - 9px)`
+                            }}
+                        >&nbsp;</UnstyledButton>
+                    }
+                </div>;
+            })}
+        </div>
+        <div className="mdhui-discrete-scale-labels">
+            <div className="mdhui-discrete-scale-labels-min">{props.minLabel}</div>
+            <div className="mdhui-discrete-scale-labels-max">{props.maxLabel}</div>
+        </div>
+    </div>;
+}

--- a/src/components/presentational/DiscreteScale/DiscreteScale.tsx
+++ b/src/components/presentational/DiscreteScale/DiscreteScale.tsx
@@ -52,18 +52,32 @@ export default function (props: DiscreteScaleProps) {
                         className="mdhui-discrete-scale-ticks-section-button"
                         onClick={() => onClick(value)}
                         style={{
-                            background: value === selectedValue ? sliderColor : 'transparent'
+                            left: index === 0 ? '-11px' : undefined,
+                            width: index === 0 ? '20px' : undefined
                         }}
-                    >&nbsp;</UnstyledButton>
+                    >
+                        <div
+                            className="mdhui-discrete-scale-ticks-section-marker"
+                            style={{
+                                background: value === selectedValue ? sliderColor : 'transparent',
+                            }}
+                        >&nbsp;</div>
+                    </UnstyledButton>
                     {index === props.tickCount - 2 &&
                         <UnstyledButton
                             className="mdhui-discrete-scale-ticks-section-button"
                             onClick={() => onClick(value + 1)}
                             style={{
-                                background: value + 1 === selectedValue ? sliderColor : 'transparent',
-                                left: `calc(100% - 9px)`
+                                left: '10px'
                             }}
-                        >&nbsp;</UnstyledButton>
+                        >
+                            <div
+                                className="mdhui-discrete-scale-ticks-section-marker"
+                                style={{
+                                    background: value + 1 === selectedValue ? sliderColor : 'transparent',
+                                }}
+                            >&nbsp;</div>
+                        </UnstyledButton>
                     }
                 </div>;
             })}

--- a/src/components/presentational/DiscreteScale/index.ts
+++ b/src/components/presentational/DiscreteScale/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DiscreteScale';

--- a/src/components/presentational/index.ts
+++ b/src/components/presentational/index.ts
@@ -10,6 +10,7 @@ export { default as DateRangeCoordinator, DateRangeContext } from "./DateRangeCo
 export { default as DateRangeNavigator } from "./DateRangeNavigator"
 export { default as DateRangeTitle } from "./DateRangeTitle"
 export { default as DayTrackerSymbol } from "./DayTrackerSymbol"
+export { default as DiscreteScale } from "./DiscreteScale"
 export { default as DumbbellChart } from "./DumbbellChart"
 export { default as Face } from "./Face"
 export { default as Histogram } from "./Histogram"


### PR DESCRIPTION
## Overview

This branch adds a discrete scale input component.

![discrete_scale](https://github.com/CareEvolution/MyDataHelpsUI/assets/5408603/8718f8e4-6a2c-4fb3-96d1-fe2e213f5433)

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  This PR just adds a new input widget.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `DiscreteScale` component that allows users to interact with a discrete scale and select values.
  - Added styling for the `DiscreteScale` component for improved visual consistency.
  - Created a configurable story to showcase the `DiscreteScale` component with customizable properties like color scheme, slider color, tick count, and labels.

- **Documentation**
  - Updated export declarations to include the new `DiscreteScale` component in the presentational components index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->