### PR TITLE
Fix data gaps on Bar Chart

### DIFF
--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -196,7 +196,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
             var nextExpectedPoint = add(currentPoint, props.expectedDataInterval);
             if (nextExpectedPoint < nextPoint) {
                 var nullValue = {
-                    timestamp: props.data[i].timestamp + 1
+                    timestamp: nextExpectedPoint.getTime()
                 }
                 dataToDisplay.push(nullValue);
             }

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -188,14 +188,14 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
     let dataToDisplay: Record<string, any>[] | undefined;
     if (props.data && props.expectedDataInterval) {
         dataToDisplay = [];
-        for (var i = 0; i < props.data.length - 1; ++i) {
+        for (let i = 0; i < props.data.length - 1; ++i) {
             dataToDisplay.push(props.data[i]);
 
             var currentPoint = new Date(props.data[i].timestamp);
             var nextPoint = new Date(props.data[i + 1].timestamp);
             var nextExpectedPoint = add(currentPoint, props.expectedDataInterval);
             if (nextExpectedPoint < nextPoint) {
-                var nullValue = {
+                let nullValue = {
                     timestamp: nextExpectedPoint.getTime()
                 }
                 dataToDisplay.push(nullValue);


### PR DESCRIPTION
## Overview

This chunk of code is necessary to show data gaps in charts that have an expected cadence of data.  For line charts this was working fine, but for Bar Charts, putting the null data point at a millisecond time interval was screwing up Rechart's math on how wide it could make each bar.  Because it wants to make each bar the same width, having two data points 1 millisecond apart made it make every bar extremely small.  This correction puts the null data point at the timestamp where we thought we *should* find data (i.e. 1 day later instead of 1 millisecond).  While the other option was to simply skip this code for Bar Charts, this solution seemed more appropriate as I think it's clearer what the intent of the code is anyway.

This is what the live view Story looks like for the account's data that flagged this issue:
![image](https://github.com/CareEvolution/MyDataHelpsUI/assets/5473619/4b95d85d-86ab-477a-8865-a9d3b57a7d89)


## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timestamp accuracy in the TimeSeriesChart, ensuring more reliable data display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->