### PR TITLE
Fix Standalone View Report Detail Preview State

### DIFF
--- a/src/components/view/StandaloneHealthAndWellnessView/StandaloneHealthAndWellnessView.tsx
+++ b/src/components/view/StandaloneHealthAndWellnessView/StandaloneHealthAndWellnessView.tsx
@@ -180,7 +180,7 @@ export default function (props: StandaloneHealthAndWellnessViewProps) {
         }
 
         if (view.key == "ReportDetail") {
-            return <ReportView previewState={"html"} reportId={view.properties?.reportId} />
+            return <ReportView previewState={props.previewState ? "html" : undefined} reportId={view.properties?.reportId} />
         }
 
         if (view.key == "ExternalAccounts") {

--- a/src/components/view/StandaloneHealthAndWellnessView/StandaloneHealthAndWellnessView.tsx
+++ b/src/components/view/StandaloneHealthAndWellnessView/StandaloneHealthAndWellnessView.tsx
@@ -180,7 +180,7 @@ export default function (props: StandaloneHealthAndWellnessViewProps) {
         }
 
         if (view.key == "ReportDetail") {
-            return <ReportView previewState={props.previewState ? "html" : undefined} reportId={view.properties?.reportId} />
+            return <ReportView previewState={props.previewState == "default" ? "html" : undefined} reportId={view.properties?.reportId} />
         }
 
         if (view.key == "ExternalAccounts") {


### PR DESCRIPTION
## Overview

Report detail preview state was hardcoded as being "html", meaning all report details were showing the same preview report content in Standalone View

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conditional rendering in the Health and Wellness View to ensure the correct `previewState` prop is passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->