### PR TITLE
Time Series Fixes

### DIFF
--- a/src/components/container/DailyDataChart/DailyDataChart.stories.tsx
+++ b/src/components/container/DailyDataChart/DailyDataChart.stories.tsx
@@ -6,6 +6,7 @@ import { add } from "date-fns";
 
 export default { title: "Container/DailyDataChart", component: DailyDataChart, parameters: { layout: 'fullscreen' } };
 let render = (args: DailyDataChartProps) => <Layout colorScheme="auto"><Card><DailyDataChart {...args} /></Card></Layout>
+let renderDRC = (args: DailyDataChartProps) => <Layout colorScheme="auto"><Card><DateRangeCoordinator intervalType="Week"><DailyDataChart {...args} /></DateRangeCoordinator></Card></Layout>
 
 export const stepsLineChart = {
     args: {
@@ -22,6 +23,23 @@ export const stepsLineChart = {
     },
     render: render
 };
+
+export const stepsLineChartDRC = {
+    args: {
+        title: "Steps with Date Range Coordinator",
+        options: {
+            domainMin: 0,
+            lineColor: "red"
+        },
+        intervalType: "Week",
+        weekStartsOn: "6DaysAgo",
+        dailyDataType: DailyDataType.Steps,
+        chartType: "Line",
+        previewState: "default"
+    },
+    render: renderDRC
+};
+
 
 export const stepsWithGapLineChart = {
     args: {

--- a/src/components/container/DailyDataChart/DailyDataChart.tsx
+++ b/src/components/container/DailyDataChart/DailyDataChart.tsx
@@ -102,7 +102,7 @@ export default function DailyDataChart(props: DailyDataChartProps) {
         while (currentDate < intervalEnd) {
             let dayKey = getDayKey(currentDate);
             let dataDay: any = {
-                timestamp: currentDate.getTime()
+                timestamp: currentDate.setHours(0,0,0,0)
             };
 
             if(currentData[dayKey] !== undefined && currentData[dayKey] !== null){

--- a/src/components/container/SurveyAnswerChart/SurveyAnswerChart.stories.tsx
+++ b/src/components/container/SurveyAnswerChart/SurveyAnswerChart.stories.tsx
@@ -54,6 +54,27 @@ export const ffwelLineChart = {
     render: render
 };
 
+export const ffwelLineChartDRC = {
+    args: {
+        title: "FFWEL Responses Line Chart Date Range Coordinator",
+        options: {
+            domainMin: 0,
+            connectNulls: true
+        },
+        intervalType: "6Month",
+        weekStartsOn: "6DaysAgo",
+        series: [{ color: "#e41a1c", dataKey: "Creative Self", surveyName: "FFWEL", stepIdentifier: "CreativeSelf", resultIdentifier: "CreativeSelf" },
+                {  color: "#377eb8", dataKey: "Coping Self", surveyName: "FFWEL", stepIdentifier: "CopingSelf", resultIdentifier: "CopingSelf" },
+                {  color: "#4daf4a", dataKey: "Social Self", surveyName: "FFWEL", stepIdentifier: "SocialSelf", resultIdentifier: "SocialSelf" }],
+        valueFormatter: (value: number) => Number(value.toFixed(0)).toLocaleString(),
+        chartType: "Line",
+        previewState: "default"
+    },
+    render: (args: SurveyAnswerChartProps) => <Layout colorScheme="auto"><Card><DateRangeCoordinator intervalType="6Month"><SurveyAnswerChart {...args} /></DateRangeCoordinator></Card></Layout>
+};
+
+
+
 export const ffwelLineChartWithDataGap = {
     args: {
         title: "FFWEL Responses Line Chart",

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -196,7 +196,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
 
     const keys = props.series.map(s => s.dataKey);
 
-    let dataToDisplay: Record<string, any>[] | undefined;
+    let dataToDisplay: TimeSeriesDataPoint[] | undefined;
     if (props.data && props.expectedDataInterval) {
         dataToDisplay = [];
         for (let i = 0; i < props.data.length - 1; ++i) {

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -11,11 +11,20 @@ import addHours from 'date-fns/addHours'
 import startOfMonth from 'date-fns/startOfMonth'
 import { AreaChartSeries, ChartSeries, MultiSeriesBarChartOptions, MultiSeriesLineChartOptions } from '../../../helpers/chartOptions'
 
+export interface TimeSeriesDataPoint {
+    timestamp: number; // Unix Timestamp in ms since epoch
+    // Other properties of this object are either either:
+    //  - Named the same as a dataKey property of the configured ChartSeries for the graph
+    //  - Arbitrary properties you want access to in places such as the tooltip callback.
+    [key: string]: any;
+}
+
+
 export interface TimeSeriesChartProps {
     title?: string
     intervalType?: "Week" | "Month" | "6Month" | "Day",
     intervalStart: Date,
-    data: Record<string, any>[] | undefined,
+    data: TimeSeriesDataPoint[] | undefined,
     expectedDataInterval?: Duration,
     series: ChartSeries[] | AreaChartSeries[],
     chartHasData: boolean,

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -101,7 +101,6 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                 ticks.push(addDays(currentTick, 14).getTime());
                 currentTick = addMonths(currentTick, 1);
             }
-            //ticks.push(addMonths(startTime, 5).getTime());
 
             return ticks;
         }
@@ -133,6 +132,8 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
             }
         }
 
+        const xTicks = getXAxisTicks();
+
         return <>
             {props.chartHasData &&
                 <Tooltip wrapperStyle={{ outline: "none" }} active content={<props.tooltip />} />
@@ -140,7 +141,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
             <CartesianGrid vertical={props.chartType !== "Bar"} strokeDasharray="2 4" />
             <YAxis tickFormatter={tickFormatter} axisLine={false} interval={0} tickLine={false} width={32} domain={domain} />
             <XAxis id="myXAxis"
-                domain={['auto', 'auto']}
+                domain={[xTicks![0], xTicks![xTicks!.length - 1]]}
                 padding={props.chartType === 'Bar' ? 'gap' : { left: 0, right: 0 }}
                 tick={DayTick}
                 scale={'time'}

--- a/src/helpers/date-helpers.ts
+++ b/src/helpers/date-helpers.ts
@@ -47,7 +47,7 @@ export function getMonthName(month: number) {
 }
 
 export function titleForDateRange(intervalType: "Day" | "Week" | "Month" | "6Month", intervalStart: Date, variant?: "short" | "long") {
-	var duration: Duration = intervalType === "Month" ? { months: 1 } : intervalType === "Day" ? { days: 1 } : { weeks: 1 };
+	var duration: Duration = intervalType === "Month" ? { months: 1 } : intervalType === "Day" ? { days: 1 } : intervalType === "Week" ? { weeks: 1 } : intervalType === "6Month" ? { months: 6 } : { weeks: 1 };
 	var intervalEnd = add(intervalStart, duration);
 
 	if(intervalType === "6Month" && intervalStart.getDate() === 1){

--- a/src/helpers/date-helpers.ts
+++ b/src/helpers/date-helpers.ts
@@ -47,8 +47,8 @@ export function getMonthName(month: number) {
 }
 
 export function titleForDateRange(intervalType: "Day" | "Week" | "Month" | "6Month", intervalStart: Date, variant?: "short" | "long") {
-	var duration: Duration = intervalType === "Month" ? { months: 1 } : intervalType === "Day" ? { days: 1 } : intervalType === "Week" ? { weeks: 1 } : intervalType === "6Month" ? { months: 6 } : { weeks: 1 };
-	var intervalEnd = add(intervalStart, duration);
+	const duration: Duration = intervalType === "Month" ? { months: 1 } : intervalType === "Day" ? { days: 1 } : intervalType === "Week" ? { weeks: 1 } : intervalType === "6Month" ? { months: 6 } : { weeks: 1 };
+	const intervalEnd = add(intervalStart, duration);
 
 	if(intervalType === "6Month" && intervalStart.getDate() === 1){
 		return `${getMonthName(intervalStart.getMonth())} - ${getMonthName(sub(intervalEnd, { months: 1}).getMonth())}`;


### PR DESCRIPTION
## Overview

Fixes a few bugs in the TimeSeriesChart, or related to changes made with the TimeSeriesChart

- Fixes a UI issue where the 6 Month Date Range Coordinator was displaying an extremely incorrect end month.
- Fixes X-Axis flashing on SurveyData/DailyData Charts when paging with a DateRangeCoordinator
  - When the Date Range Coordinator changes the intervalStart, this is passed to both the SurveyData/DailyData component and immediately passed down to the child TimeSeriesChart.  This causes a re-render of the TimeSeriesChart with new X-Ticks - but the parent componet hasn't yet reacted to the intervalStart changing (via a `useEffect`) in order to set the data to `null` and get back to a Loading indicator.  This means there's a render cycle where the data is for a range that doesn't match the X-Ticks generated.  Since the domain was being set to `['auto', 'auto']` it would still attempt to graph the old data against the current ticks, which shifts the ticks to the left or right.  The next render cycle would fix it, but there was a noticeable visual artifact.  Setting the domain directly to the values of the first and last tick fixes this by effectively "filtering out" the mismatched data from the chart.
  - I'll note that this probably indicates the structure here is... incorrect?  But this is an intermediate fix for now while considering if something larger needs to be done.
- Fixes an issue in stories where DailyData values were being generated with non-midnight timestamps, which meant that they didn't align with the "at midnight" X-Ticks of the TimeSeriesChart.  I chose to fix this directly in the DailyDataChart instead of the fake data generation because it seemed worth handling potential "misformatted" data there.  I had accidentally re-introduced this [here](https://github.com/CareEvolution/MyDataHelpsUI/commit/80c55ed528f9f086c91654f471d4d54f94bd8baf#diff-d75dc4cf796cdf15a20309aa5453c94fe93c13d62ebe5c45d0a4f0d2f00bfb2dL100-R104]) when the way `currentDate` was being set changed.
- Makes a small typing improvement to the `TimeSeriesChart` to indicate that the `timestamp` value is expected, and what its format should be, and that the rest of the data can have arbitrary properties.


## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new line chart configurations with Date Range Coordinator for visualizing survey responses and daily data.

- **Bug Fixes**
  - Updated timestamp setting in the DailyDataChart to reset hours, minutes, seconds, and milliseconds to zero.
  - Improved X-axis tick generation in TimeSeriesChart for more accurate data representation.

- **Enhancements**
  - Extended `titleForDateRange` to support a new "6Month" interval type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->