### PR TITLE
TimeSeriesChart Fixes

### DIFF
--- a/src/components/container/DailyDataChart/DailyDataChart.tsx
+++ b/src/components/container/DailyDataChart/DailyDataChart.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react'
 import { DateRangeContext } from '../../presentational/DateRangeCoordinator/DateRangeCoordinator'
 import { DailyDataProvider, DailyDataQueryResult, checkDailyDataAvailability, getDailyDataTypeDefinition, queryDailyData } from '../../../helpers/query-daily-data'
-import { add, format } from 'date-fns'
+import { add, format, startOfDay } from 'date-fns'
 import MyDataHelps from '@careevolution/mydatahelps-js'
 import getDayKey from '../../../helpers/get-day-key'
 import { WeekStartsOn, getDefaultIntervalStart } from '../../../helpers/get-interval-start'
@@ -43,7 +43,7 @@ export default function DailyDataChart(props: DailyDataChartProps) {
         intervalStart = dateRangeContext.intervalStart;
     }
     else {
-        intervalStart = getDefaultIntervalStart(intervalType, props.weekStartsOn);
+        intervalStart = startOfDay(getDefaultIntervalStart(intervalType, props.weekStartsOn));
     }
 
     let intervalEnd = intervalType === "Week" ? add(intervalStart, { days: 7 })

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.stories.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.stories.tsx
@@ -67,7 +67,7 @@ function getRandomInt(min: number, max: number) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function getRandomIntradayWithinDomainMultipointData(start: Date) {
+function getRandomIntradayWithinDomainMultipointData(start: Date, domainMin: number = 0, domainMax: number = 200) {
     var responses = [];
     let currentTime = new Date(start);
     currentTime.setHours(0, 0, 0, 0);
@@ -75,9 +75,8 @@ function getRandomIntradayWithinDomainMultipointData(start: Date) {
     while (currentTime < endTime) {
         responses.push({
             timestamp: currentTime,
-            key1: (getRandomInt(0, 200)),
-            key2: (getRandomInt(0, 200)),
-            key3: (getRandomInt(0, 200)),
+            key1: (getRandomInt(domainMin - 6, domainMax + 15)),
+            key2: (getRandomInt(domainMin - 2, domainMax + 5)),
         });
         currentTime = add(currentTime, { minutes: 5 });
     }
@@ -278,6 +277,25 @@ export const multipleLineChartWithThresholds: Story = {
     loaders: [
         async () => ({
             randomData: await getRandomIntradayWithinDomainMultipointData(new Date())
+        })
+    ]
+};
+
+export const multipleLineChartWithThresholdsSmallRange: Story = {
+    args: {
+        title: "Multiple Line Chart with Thresholds",
+        intervalType: "Day",
+        chartType: "Line",
+        chartHasData: true,
+        series: [{ dataKey: 'key1', color: 'blue' }, { dataKey: 'key2', color: 'purple' }, { dataKey: 'key3', color: 'black' }],
+        data: undefined,
+        intervalStart: new Date(),
+        options: multiSeriesLineOptions,
+        tooltip
+    },
+    loaders: [
+        async () => ({
+            randomData: await getRandomIntradayWithinDomainMultipointData(new Date(), 20, 150)
         })
     ]
 };

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.stories.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.stories.tsx
@@ -323,12 +323,17 @@ export const noData: Story = {
         title: "No Data Chart",
         intervalType: "Week",
         chartType: "Line",
-        chartHasData: true,
+        chartHasData: false,
         data: [],
         series: [{ dataKey: 'value' }],
         intervalStart: new Date(),
         tooltip
     },
+    loaders: [
+        async () => ({
+            randomData: []
+        })
+    ]
 };
 
 export const loading: Story = {

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -147,6 +147,11 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                 } else if (domainMin !== undefined) {
                     domain = [domainMin, "auto"];
                 }
+
+                let domainMax = (props.options as MultiSeriesLineChartOptions).domainMax;
+                if( domainMax ) {
+                    domain![1] = domainMax;
+                }
             }
         }
 
@@ -157,7 +162,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                 <Tooltip wrapperStyle={{ outline: "none" }} active content={<props.tooltip />} />
             }
             <CartesianGrid vertical={props.chartType !== "Bar"} strokeDasharray="2 4" />
-            <YAxis tickFormatter={tickFormatter} axisLine={false} interval={0} tickLine={false} width={32} domain={domain} />
+            <YAxis allowDataOverflow tickFormatter={tickFormatter} axisLine={false} interval={0} tickLine={false} width={32} domain={domain} />
             <XAxis id="myXAxis"
                 domain={[xTicks![0], xTicks![xTicks!.length - 1]]}
                 padding={props.chartType === 'Bar' ? 'gap' : { left: 0, right: 0 }}
@@ -170,6 +175,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                 minTickGap={0}
                 tickLine={false}
                 ticks={getXAxisTicks()}
+                allowDataOverflow
                 interval={0}
             />
         </>
@@ -251,7 +257,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                         {(props.options as MultiSeriesLineChartOptions)?.thresholds?.filter(t => t.referenceLineColor)?.map((threshold, index) =>
                             <ReferenceLine y={threshold.value} stroke={resolveColor(layoutContext.colorScheme, threshold.referenceLineColor)} />
                         )}
-                        {createLineChartDefs(layoutContext, gradientKey, seriesLineColors, props.options)}
+                        {createLineChartDefs(layoutContext, gradientKey, seriesLineColors, props.options, keys, dataToDisplay!)}
                         {standardChartComponents()}
                         {keys.map((dk, i) =>
                             <Line connectNulls={(props.options as MultiSeriesLineChartOptions)?.connectNulls} strokeWidth={2}

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -175,7 +175,14 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
     if (props.options && props.chartType === "Line") {
         let domainMin = (props.options as MultiSeriesLineChartOptions)?.domainMin;
         let domainMax = (props.options as MultiSeriesLineChartOptions)?.domainMax;
-        yAxisDomain = [domainMin || "auto", domainMax || "auto"];
+        const getDomainValue = (v: number | "Auto" | undefined) => {
+            if(v === "Auto" || v === undefined) return "auto";
+            return v;
+        }
+        yAxisDomain = [
+            getDomainValue(domainMin),
+            getDomainValue(domainMax)
+        ];
     }
 
     const xAxisTicks = getXAxisTicks();
@@ -223,7 +230,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                         <>
                             {props.chartType === "Line" &&
                                 <>
-                                    {createLineChartDefs(layoutContext, gradientKey, props.series, props.options)}
+                                    {createLineChartDefs(layoutContext, gradientKey, props.series, props.options, keys, dataToDisplay!)}
                                     {(props.options as MultiSeriesLineChartOptions)?.thresholds?.filter(t => t.referenceLineColor)?.map(threshold =>
                                         <ReferenceLine y={threshold.value} stroke={resolveColor(layoutContext.colorScheme, threshold.referenceLineColor)} />
                                     )}

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -170,7 +170,6 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                 minTickGap={0}
                 tickLine={false}
                 ticks={getXAxisTicks()}
-                includeHidden
                 interval={0}
             />
         </>

--- a/src/helpers/chartHelpers.tsx
+++ b/src/helpers/chartHelpers.tsx
@@ -36,10 +36,6 @@ export function createLineChartDefs(
             lineColor = resolveColor(layoutContext.colorScheme, thresholds[0].overThresholdColor) || defaultLineColor;
         }
 
-        console.log()
-
-        console.log(`Index: ${index}, lineMin: ${lineRange.min}, lineMax, ${lineRange.max}`);
-
         stops.push(<stop offset="0%" stopColor={lineColor} />);
         for (var i = 0; i < thresholds.length; i++) {
             if (lineRange.max >= thresholds[i].value) {

--- a/src/helpers/chartHelpers.tsx
+++ b/src/helpers/chartHelpers.tsx
@@ -24,7 +24,7 @@ export function createLineChartDefs(
         return 0;
     }
 
-    const createStopsFromThresholds = function (defaultLineColor: string, chartThresholds: ChartThreshold[] | undefined, index: number) {
+    const createStopsFromThresholds = function (defaultLineColor: string, chartThresholds: ChartThreshold[] | undefined, dataKey: string) {
         let stops: any[] = [];
         let lineColor: string = defaultLineColor;
         let thresholds = chartThresholds ?? [];
@@ -32,10 +32,10 @@ export function createLineChartDefs(
         thresholds.sort((a, b) => a.value - b.value);
 
         const lineRange = data.reduce((result, dataPoint) => ({
-            min: (dataPoint[dataKeys[index]] < result.min || result.min === 0) ? dataPoint[dataKeys[index]] : result.min,
-            max: (dataPoint[dataKeys[index]] > result.max || result.max === 0) ? dataPoint[dataKeys[index]] : result.max,
-        }), { min: 0, max: 0 });
-
+            min: (dataPoint[dataKey] < result.min) ? dataPoint[dataKey] : result.min,
+            max: (dataPoint[dataKey] > result.max) ? dataPoint[dataKey] : result.max,
+        }), { min: data[0][dataKey], max: data[0][dataKey] });
+        
         if (thresholds.length && lineRange.min >= thresholds[0].value) {
             lineColor = colorOrDefault(thresholds[0].overThresholdColor, defaultLineColor);
         }
@@ -59,7 +59,7 @@ export function createLineChartDefs(
             let lineColor = colorOrDefault(s.color, "var(--mdhui-color-primary");
 
             return <linearGradient id={`${gradientKey}${i}`} key={`${gradientKey}${i}`} x1="0%" y1="100%" x2="0%" y2="0%">
-                {createStopsFromThresholds(lineColor, options?.thresholds, i)}
+                {createStopsFromThresholds(lineColor, options?.thresholds, dataKeys[i])}
             </linearGradient>;
         })}
     </defs>;


### PR DESCRIPTION
## Overview

In discussing some work that @greinard was working on (https://github.com/CareEvolution/MyDataHelpsUI/pull/279) we talked over a few bugs he'd come across that I said I'd tackle.

1) The No Data story wasn't working; this was a quick fix as the story was just set up wrong.

2) The DailyDataChart stories were generating an extra data point.  This was caused by a discrepancy in generating data from the "start of a day" - it was causing the loop which generates fake data to generate too much data, and Recharts was stubbornly trying to display it even though the domain is constrained.  I've fixed both the dates *and* set `allowDataOverflow` on the X-Axis which should (despite how it's named) prevent extra data outside of the range from being displayed (the variable "allows data to overflow" on the graph which means Recharts doesn't attempt to show everything you give it).

3) The newly introduced thresholds for line charts weren't actually working correctly.  They look like they are because in the stories, the data range being generated was almost always covering the fully range of the graph.  However, if you adjusted the story so that it only generated data in the middle of the graph, it would look like this (you can see here that data is red well below the red threshold line, and yellow well below the yellow threshold line):
![image](https://github.com/user-attachments/assets/0b0210d3-6784-47b6-974b-bf4d19d4151d)

This is because the `<stop>` added to a `<linearGradient>` SVG element is described in percentages - but it's percentages of the *displayed SVG* - and in the case where the line's "height" isn't full range of the graph, doing the stop calculation as percentages of the Y-Axis is incorrect (50% of the SVG's height isn't 50% up the Y-Axis).  This fix for this is to adjust for using the specific data line's min/max values as the domain, and *not* the actual y-domain, which makes the graph properly look like this when the line isn't the full domain:
![image](https://github.com/user-attachments/assets/d2f8d2e5-0e3e-4eab-81e8-7a3f25ae341d)

And if it is the full domain, the calculation still works:
![image](https://github.com/user-attachments/assets/9d9ae1c7-3698-4fb4-8d52-067a6e192223)



## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new chart story `multipleLineChartWithThresholdsSmallRange` with custom data loading logic for better range handling in TimeSeriesChart.

- **Enhancements**
  - Improved data generation in TimeSeriesChart stories with new parameters for finer control over the data range.
  - Updated DailyDataChart to start the interval at the beginning of the day for more accurate data representation.
  - Enhanced TimeSeriesChart component with streamlined handling of domain boundaries and improved Y-axis data management.

- **Bug Fixes**
  - Fixed an issue with the `noData` story in TimeSeriesChart by setting `chartHasData` to false for accurate representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->