### PR TITLE
Add ability to ensure sequential completion of survey tasks

### DIFF
--- a/src/components/container/SurveyTaskList/SurveyTaskList.stories.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.stories.tsx
@@ -22,7 +22,8 @@ Incomplete.args = {
 	status: 'incomplete',
 	title: 'Incomplete Tasks',
 	previewState: "IncompleteTasks",
-	variant: "singleCard"
+	variant: "singleCard",
+	sequential: false
 }
 
 export const Complete = Template.bind({});
@@ -40,7 +41,8 @@ Multicard.args = {
 	status: 'incomplete',
 	title: 'Incomplete Tasks',
 	previewState: "IncompleteTasks",
-	variant: "multiCard"
+	variant: "multiCard",
+	sequential: false
 }
 
 export const CustomStyle = Template.bind({});
@@ -56,5 +58,6 @@ CustomStyle.args = {
 		boxShadow:"none"
 	},
 	buttonVariant: "default",
-	buttonColor: "blue"
+	buttonColor: "blue",
+	sequential: false
 }

--- a/src/components/container/SurveyTaskList/SurveyTaskList.stories.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.stories.tsx
@@ -26,23 +26,16 @@ Incomplete.args = {
 	sequential: false
 }
 
-export const Complete = Template.bind({});
-Complete.args = {
-	limit: 3,
-	status: 'complete',
-	title: 'Completed Tasks',
-	previewState: "CompleteTasks",
-	variant: "singleCard"
+export const Sequential = Template.bind();
+Sequential.args = {
+	...Incomplete.args,
+	sequential: true
 }
 
 export const Multicard = Template.bind({});
 Multicard.args = {
-	limit: 3,
-	status: 'incomplete',
-	title: 'Incomplete Tasks',
-	previewState: "IncompleteTasks",
-	variant: "multiCard",
-	sequential: false
+	...Incomplete.args,
+	variant: "multiCard"
 }
 
 export const CustomStyle = Template.bind({});
@@ -60,4 +53,13 @@ CustomStyle.args = {
 	buttonVariant: "default",
 	buttonColor: "blue",
 	sequential: false
+}
+
+export const Complete = Template.bind({});
+Complete.args = {
+	limit: 3,
+	status: 'complete',
+	title: 'Completed Tasks',
+	previewState: "CompleteTasks",
+	variant: "singleCard"
 }

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -65,12 +65,18 @@ export default function (props: SurveyTaskListProps) {
 	}
 
 	function getSurveyTaskElement(task: SurveyTask) {
-		return <SingleSurveyTask buttonColor={props.buttonColor} buttonVariant={props.buttonVariant} key={task.id.toString()} task={task} onClick={() => onTaskClicked(task)} surveyActive={isSurveyActive(task)} surveyBlocked={isSurveyBlocked(task)}/>
+		return <SingleSurveyTask buttonColor={props.buttonColor}
+			buttonVariant={props.buttonVariant}
+			key={task.id.toString()}
+			task={task}
+			onClick={() => onTaskClicked(task)}
+			surveyActive={isSurveyActive(task)}
+			surveyBlocked={isSurveyBlocked(task)} />
 	}
 
 	function initialize() {
 
-		var sortIncomplete = function (a : any, b : any){
+		var sortIncomplete = function (a: any, b: any) {
 			if (!a.dueDate) { return 1; }
 			if (!b.dueDate) { return -1; }
 			if (parseISO(a.dueDate) > parseISO(b.dueDate)) { return 1; }
@@ -100,7 +106,7 @@ export default function (props: SurveyTaskListProps) {
 					parameters.pageID = pageID;
 				}
 
-				return MyDataHelps.querySurveyTasks(parameters).then(function (result : any) {
+				return MyDataHelps.querySurveyTasks(parameters).then(function (result: any) {
 					allTasks = allTasks.concat((result as any).surveyTasks);
 					if (result.nextPageID) {
 						makeRequest(result.nextPageID);

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -12,6 +12,7 @@ import { useInitializeView } from '../../../helpers/Initialization';
 export interface SurveyTaskListProps {
 	status: SurveyTaskStatus,
 	limit?: number,
+	sequential?: boolean,
 	title?: string,
 	surveys?: string[],
 	onDetailLinkClick?: Function,
@@ -51,8 +52,20 @@ export default function (props: SurveyTaskListProps) {
 		}
 	};
 
+	const isSurveyBlocked = (task: SurveyTask): boolean => {
+		let blocked = false;
+
+		if (tasks && props.sequential && tasks?.length > 1) {
+			if (tasks.at(0)?.id != task.id) {
+				blocked = true;
+			}
+		}
+
+		return blocked;
+	}
+
 	function getSurveyTaskElement(task: SurveyTask) {
-		return <SingleSurveyTask buttonColor={props.buttonColor} buttonVariant={props.buttonVariant} key={task.id.toString()} task={task} onClick={() => onTaskClicked(task)} surveyActive={isSurveyActive(task)}/>
+		return <SingleSurveyTask buttonColor={props.buttonColor} buttonVariant={props.buttonVariant} key={task.id.toString()} task={task} onClick={() => onTaskClicked(task)} surveyActive={isSurveyActive(task)} surveyBlocked={isSurveyBlocked(task)}/>
 	}
 
 	function initialize() {
@@ -70,6 +83,7 @@ export default function (props: SurveyTaskListProps) {
 			setTasks(previewIncompleteTasks);
 			return;
 		}
+
 		if (props.previewState == "CompleteTasks") {
 			setTasks(previewCompleteTasks);
 			return;

--- a/src/components/container/SurveyTaskList/SurveyTaskList.tsx
+++ b/src/components/container/SurveyTaskList/SurveyTaskList.tsx
@@ -53,15 +53,7 @@ export default function (props: SurveyTaskListProps) {
 	};
 
 	const isSurveyBlocked = (task: SurveyTask): boolean => {
-		let blocked = false;
-
-		if (tasks && props.sequential && tasks?.length > 1) {
-			if (tasks.at(0)?.id != task.id) {
-				blocked = true;
-			}
-		}
-
-		return blocked;
+		return props.sequential! && (tasks![0].id !== task.id);
 	}
 
 	function getSurveyTaskElement(task: SurveyTask) {

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.css
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.css
@@ -5,8 +5,11 @@
 .mdhui-single-survey-task.incomplete-expanded {
     padding: 16px;
     width: 100%;
-    cursor: pointer;
     box-sizing: border-box;
+}
+
+.mdhui-single-survey-task.incomplete-expanded.active {
+    cursor: pointer;
 }
 
 .mdhui-single-survey-task.incomplete-expanded .header {

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.stories.tsx
@@ -20,6 +20,7 @@ interface SingleSurveyTaskStoryArgs {
 	variant?: SingleSurveyTaskVariant;
 	endDate?: number;
 	surveyActive?: boolean;
+	surveyBlocked?: boolean;
 }
 
 const render = (args: SingleSurveyTaskStoryArgs) => {
@@ -34,7 +35,7 @@ const render = (args: SingleSurveyTaskStoryArgs) => {
 
 	return <Layout colorScheme="auto">
 		<Card>
-			<SingleSurveyTask task={task} variant={args.variant} surveyActive={args.surveyActive} onClick={noop}/>
+			<SingleSurveyTask task={task} variant={args.variant} surveyActive={args.surveyActive} onClick={noop} surveyBlocked={args.surveyBlocked}/>
 		</Card>
 	</Layout>;
 };
@@ -48,7 +49,8 @@ export const Default = {
 		dueDate: undefined,
 		hasSavedProgress: false,
 		endDate: undefined,
-		surveyActive: false
+		surveyActive: false,
+		surveyBlocked: false
 	},
 	argTypes: {
 		variant: {
@@ -71,6 +73,11 @@ export const Default = {
 		},
 		surveyActive: {
 			name: 'survey active',
+			control: 'boolean',
+			if: {arg: 'status', eq: 'incomplete'}
+		},
+		surveyBlocked: {
+			name: 'survey blocked',
 			control: 'boolean',
 			if: {arg: 'status', eq: 'incomplete'}
 		},

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -38,7 +38,7 @@ export default function (props: SingleSurveyTaskProps) {
 	const getDueDate = () => {
 		let today = startOfToday();
 		let tomorrow = add(new Date(today), {days: 1});
-		let dueDate = parseISO(props.task.dueDate);
+		let dueDate = parseISO(props.task.dueDate ?? '');
 
 		let dueDateClasses: string[] = ['due-date'];
 		let dueDateString: string;

--- a/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
+++ b/src/components/presentational/SingleSurveyTask/SingleSurveyTask.tsx
@@ -26,6 +26,7 @@ export interface SingleSurveyTaskProps {
 	variant?: SingleSurveyTaskVariant;
 	descriptionIcon?: IconDefinition;
 	surveyActive?: boolean;
+	surveyBlocked?: boolean;
 	buttonColor?: ColorDefinition;
 	buttonVariant?: ButtonVariant;
 	innerRef?: React.Ref<HTMLDivElement>;
@@ -59,7 +60,8 @@ export default function (props: SingleSurveyTaskProps) {
 	};
 
 	const getExpandedIncompleteTask = () => {
-		return <div className="mdhui-single-survey-task incomplete-expanded" onClick={() => props.onClick()}>
+		return <div className={`mdhui-single-survey-task incomplete-expanded ${!props.surveyBlocked ? 'active' : ''}`}
+			onClick={!props.surveyBlocked ? () => props.onClick() : undefined}>
 			<div className="header">
 				<div className="survey-name">{props.task.surveyDisplayName}</div>
 				{props.task.dueDate && getDueDate()}
@@ -69,7 +71,7 @@ export default function (props: SingleSurveyTaskProps) {
 			</div>
 			{props.surveyActive && <LoadingIndicator/>}
 			{!props.surveyActive &&
-				<Button color={resolveColor(layoutContext.colorScheme, props.buttonColor)} variant={props.buttonVariant} onClick={noop}>
+				<Button color={resolveColor(layoutContext.colorScheme, props.buttonColor)} variant={props.buttonVariant} onClick={noop} disabled={props.surveyBlocked}>
 					{!props.task.hasSavedProgress ? language('start-survey') : language('resume-survey')}
 				</Button>
 			}
@@ -77,10 +79,15 @@ export default function (props: SingleSurveyTaskProps) {
 	};
 
 	const getIncompleteTask = () => {
-		const indicator = props.surveyActive ? <LoadingIndicator/> : <Button color={resolveColor(layoutContext.colorScheme, props.buttonColor)} variant={props.buttonVariant ?? 'light'} onClick={noop}>
-			{!props.task.hasSavedProgress ? language('start') : language('resume')}
-		</Button>;
-		return <Action renderAs='div' innerRef={props.innerRef} onClick={() => props.onClick()} className="mdhui-single-survey-task incomplete" indicator={indicator}>
+		let indicator;
+		if (props.surveyActive) {
+			indicator = <LoadingIndicator/>;
+		} else {
+			indicator = <Button color={resolveColor(layoutContext.colorScheme, props.buttonColor)} variant={props.buttonVariant ?? 'light'} onClick={noop} disabled={props.surveyBlocked}>
+				{!props.task.hasSavedProgress ? language('start') : language('resume')}
+			</Button>;
+		}
+		return <Action renderAs='div' innerRef={props.innerRef} onClick={!props.surveyBlocked ? () => props.onClick() : undefined} className="mdhui-single-survey-task incomplete" indicator={indicator}>
 			<div className="survey-name">{props.task.surveyDisplayName}</div>
 			<div className="survey-description">
 				<>{props.descriptionIcon} {props.task.surveyDescription}</>


### PR DESCRIPTION
## Overview

Paves way for https://github.com/CareEvolution/MyDataHelpsViewBuilder/issues/111.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

No security risks come to mind.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [x] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `sequential` property to enhance task presentation in the survey task components.
	- Added a `surveyBlocked` property to manage user interactions based on survey availability.
	- Created a new story for sequential task presentation in the storybook.

- **Bug Fixes**
	- Improved control flow to prevent user interactions when a survey task is blocked, enhancing overall user experience.

- **Style**
	- Updated cursor behavior for interactive elements to improve user interface clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->