### PR TITLE
TimeSeriesChart: Restore default yAxis domain defaulting.

### DIFF
--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -178,7 +178,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                         interval={0}
                         tickLine={false}
                         width={32}
-                        domain={['auto', 'auto']}
+                        domain={props.chartType === 'Line' ? ['auto', 'auto'] : undefined}
                         allowDataOverflow
                         {...props.options?.yAxisOptions}
                     />


### PR DESCRIPTION
## Overview

This branch restores some y-axis domain defaulting behavior that was mistakenly lost here: https://github.com/CareEvolution/MyDataHelpsUI/pull/283/files#diff-c7d85721f79b358b3ab7238e978537aa98ffcf42fc45afbb6a1eb497b473892fR192

The default domain for non-line charts should be left `undefined`, which results in having a domain of `[0, auto]` (the Recharts default) rather than `[auto, auto]`.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risks.  Just restoring the default domain behavior for non-line time series charts.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

n/a