### PR TITLE
Fixed AIAssistant base urls in QA

### DIFF
--- a/src/helpers/AIAssistant/AIAssistant.ts
+++ b/src/helpers/AIAssistant/AIAssistant.ts
@@ -28,6 +28,7 @@ import {
     GetUploadedFileTool,
     SaveLastGraphTool
 } from "./Tools";
+import { isDevelopment } from "../env";
 
 export interface AIAssistantState {
     messages: BaseMessage[];
@@ -38,7 +39,9 @@ export interface AIAssistantState {
 export class MyDataHelpsAIAssistant {
 
     constructor(baseUrl: string = "", additionalInstructions: string = "", callbacks: Callbacks, tools: StructuredTool[] = [], appendTools: boolean = true) {
-        this.baseUrl = baseUrl || "https://xwk5dezh5vnf4in2avp6dxswym0tmgxg.lambda-url.us-east-1.on.aws/";
+        this.baseUrl = baseUrl || (isDevelopment() ?
+            "https://2f4jcc2e2wgkjtpckvv2hhaani0ilmam.lambda-url.us-east-1.on.aws/" :
+            "https://xwk5dezh5vnf4in2avp6dxswym0tmgxg.lambda-url.us-east-1.on.aws/");
         this.additionalInstructions = additionalInstructions;
         this.callbacks = callbacks || [];
         this.tools = tools.length ? (appendTools ? this.defaultTools.concat(tools) : tools) : this.defaultTools;
@@ -61,7 +64,7 @@ export class MyDataHelpsAIAssistant {
             const event of await this.graph.streamEvents(inputs, {
                 streamMode: "values",
                 version: "v2",
-                configurable: { 
+                configurable: {
                     thread_id: this.participantId,
                     participantId: this.participantId
                 },

--- a/src/helpers/AIAssistant/Tools.ts
+++ b/src/helpers/AIAssistant/Tools.ts
@@ -4,6 +4,7 @@ import MyDataHelps, { DeviceDataV2AggregateQuery, StringMap } from "@careevoluti
 import { queryDailyData, getAllDailyDataTypes } from "../query-daily-data";
 import { getNewsFeedPage } from "../news-feed/data";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
+import { isDevelopment } from "../env";
 
 const deviceDataV2QuerySchema = z.object({
   namespace: z.enum(["Fitbit", "AppleHealth", "Garmin", "Dexcom", "HealthConnect"])
@@ -267,7 +268,8 @@ export const GetEhrNewsFeedPageTool = tool(
 export const GraphingTool = tool(
   async (input, config: LangGraphRunnableConfig): Promise<string> => {
 
-    let response = await fetch('https://rbbfx4e6nlhghaxv4zbv5krzzu0dound.lambda-url.us-east-1.on.aws', {
+    let codeRunnerUrl = isDevelopment() ? 'https://kwejahcwmsyzidk5vde5uyv33a0saruz.lambda-url.us-east-1.on.aws/' : 'https://rbbfx4e6nlhghaxv4zbv5krzzu0dound.lambda-url.us-east-1.on.aws';
+    let response = await fetch(codeRunnerUrl, {
       method: 'POST',
       body: JSON.stringify({ code: input.code }),
       headers: {
@@ -342,7 +344,7 @@ export const SaveLastGraphTool = tool(
     const uint8Array = new Uint8Array(len);
 
     for (let i = 0; i < len; i++) {
-        uint8Array[i] = binaryString.charCodeAt(i);
+      uint8Array[i] = binaryString.charCodeAt(i);
     }
 
     const blob = new Blob([uint8Array], { type: 'image/png' });

--- a/src/helpers/AIAssistant/Tools.ts
+++ b/src/helpers/AIAssistant/Tools.ts
@@ -268,7 +268,7 @@ export const GetEhrNewsFeedPageTool = tool(
 export const GraphingTool = tool(
   async (input, config: LangGraphRunnableConfig): Promise<string> => {
 
-    let codeRunnerUrl = isDevelopment() ? 'https://kwejahcwmsyzidk5vde5uyv33a0saruz.lambda-url.us-east-1.on.aws/' : 'https://rbbfx4e6nlhghaxv4zbv5krzzu0dound.lambda-url.us-east-1.on.aws';
+    let codeRunnerUrl = isDevelopment() ? 'https://kwejahcwmsyzidk5vde5uyv33a0saruz.lambda-url.us-east-1.on.aws' : 'https://rbbfx4e6nlhghaxv4zbv5krzzu0dound.lambda-url.us-east-1.on.aws';
     let response = await fetch(codeRunnerUrl, {
       method: 'POST',
       body: JSON.stringify({ code: input.code }),

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,0 +1,5 @@
+import MyDataHelps from '@careevolution/mydatahelps-js';
+
+export function isDevelopment() {
+    return MyDataHelps.baseUrl && (MyDataHelps.baseUrl.startsWith('https://mdhorg.ce.dev') || MyDataHelps.baseUrl.startsWith('https://mydatahelps.dev'));
+}

--- a/src/helpers/providerIDs.ts
+++ b/src/helpers/providerIDs.ts
@@ -1,8 +1,4 @@
-import MyDataHelps from '@careevolution/mydatahelps-js';
-
-function isDevelopment() {
-    return MyDataHelps.baseUrl && (MyDataHelps.baseUrl.startsWith('https://mdhorg.ce.dev') || MyDataHelps.baseUrl.startsWith('https://mydatahelps.dev'));
-}
+import { isDevelopment } from "./env";
 
 export function getFitbitProviderID() {
     return isDevelopment() ? 2 : 564;


### PR DESCRIPTION
## Overview

Explain your changes, including any issues or relevant context about why they are needed.

For reference these urls come from outputs from deploying https://github.com/CareEvolution/SecurityAndChangeControl/blob/master/src/aws/pep/qa/open-ai-proxy/terragrunt.hcl

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `isDevelopment` function to check the application environment.
	- Enhanced configurability of `baseUrl` and `codeRunnerUrl` based on the development environment.

- **Bug Fixes**
	- Improved handling of event parameters in the `ask` method of `MyDataHelpsAIAssistant`.

- **Refactor**
	- Simplified the logic for determining provider IDs by importing `isDevelopment` from the `env` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->