### PR TITLE
InsightMatrix: Add a flag to control whether unmatched thresholds are shown.

### DIFF
--- a/src/components/container/InsightMatrix/InsightMatrix.stories.tsx
+++ b/src/components/container/InsightMatrix/InsightMatrix.stories.tsx
@@ -4,10 +4,10 @@ import { Card, Layout } from '../../presentational'
 import { Meta, StoryObj } from '@storybook/react';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
 import {
-    createNonZeroAverageValueInsightMatrixValueCalculator,
     createIntegerInsightMatrixValueFormatter,
     createMinMaxInsightMatrixValueEvaluator,
     createMinutesToHoursInsightMatrixValueFormatter,
+    createNonZeroAverageValueInsightMatrixValueCalculator,
     createPercentageOfDaysInsightMatrixValueCalculator,
     createShrinkThousandsInsightMatrixValueFormatter,
     DailyDataType,
@@ -82,6 +82,7 @@ export const Default: Story = {
         colorScheme: 'auto',
         previewState: 'preview',
         daysToCompute: 28,
+        showUnmatchedThresholds: false,
         groupByDataConfigurationName: 'mood',
         comparisonDataConfigurationNames: ['sleep', 'steps', 'mindful', 'therapy'],
         groupByHeaderBackgroundColor: undefined,
@@ -110,6 +111,9 @@ export const Default: Story = {
                 min: 0,
                 max: 28
             }
+        },
+        showUnmatchedThresholds: {
+            name: 'show unmatched thresholds?'
         },
         groupByDataConfigurationName: {
             name: 'group-by data',

--- a/src/components/container/InsightMatrix/InsightMatrix.tsx
+++ b/src/components/container/InsightMatrix/InsightMatrix.tsx
@@ -13,6 +13,7 @@ export interface InsightMatrixProps {
     groupByDataConfiguration: InsightMatrixGroupByDataConfiguration;
     comparisonDataConfigurations: InsightMatrixComparisonDataConfiguration[];
     daysToCompute?: number;
+    showUnmatchedThresholds?: boolean;
     groupByHeaderBackgroundColor?: ColorDefinition;
     groupByHeaderTextColor?: ColorDefinition;
     goodValueBackgroundColor?: ColorDefinition;
@@ -80,8 +81,11 @@ export default function InsightMatrix(props: InsightMatrixProps) {
 
     const thresholdDaysLookup = computeThresholdDays(startDate, endDate, groupByData);
 
-    const allThresholds = groupByData.configuration.thresholds.map(threshold => threshold.label).concat(NotEnteredThreshold);
-    const filteredThresholds = allThresholds.filter(threshold => Object.keys(thresholdDaysLookup).includes(threshold));
+    let thresholds = groupByData.configuration.thresholds.map(threshold => threshold.label).concat(NotEnteredThreshold);
+    if (!props.showUnmatchedThresholds) {
+        const matchedThresholds = Object.keys(thresholdDaysLookup);
+        thresholds = thresholds.filter(threshold => matchedThresholds.includes(threshold));
+    }
 
     const getDefaultDataLabel = (configuration: InsightMatrixDataConfiguration): string => {
         if (isSurveyDataType(configuration.rawDataType)) {
@@ -123,8 +127,8 @@ export default function InsightMatrix(props: InsightMatrixProps) {
                 <div className="mdhui-insight-matrix-header-comparison-units">{configuration.units ?? <div>&nbsp;</div>}</div>
             </div>;
         })}
-        {filteredThresholds.map(threshold => {
-            const thresholdDays = thresholdDaysLookup[threshold];
+        {thresholds.map(threshold => {
+            const thresholdDays = thresholdDaysLookup[threshold] ?? [];
             return <React.Fragment key={threshold}>
                 <div className="mdhui-insight-matrix-threshold">{threshold}</div>
                 {comparisonData.map((data: InsightMatrixData<InsightMatrixComparisonDataConfiguration>, index: number) => {


### PR DESCRIPTION
## Overview

This branch adds an additional config property to the `InsightMatrix` component to allow for displaying all thresholds, including those which were not matched by any data.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risks.  Just a rendering update.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional property `showUnmatchedThresholds` to the `InsightMatrix` component, allowing for conditional display of unmatched thresholds.
	- Added a new argument `showUnmatchedThresholds` in the `Default` story configuration for enhanced functionality.

- **Bug Fixes**
	- Updated threshold filtering logic to improve clarity between matched and unmatched thresholds.

- **Documentation**
	- Enhanced story documentation with the addition of the new argument for better clarity in usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->