### PR TITLE
Fix app download height when not shown

### DIFF
--- a/src/components/container/AppDownload/AppDownload.tsx
+++ b/src/components/container/AppDownload/AppDownload.tsx
@@ -40,8 +40,8 @@ export default function (props: AppDownloadProps) {
 	let title = props.title || language('app-download-title');
 	let text = props.text || language('app-download-subtitle').replace("@@PROJECT_NAME@@", projectInfo.name);
 	return (
-		<div className="mdhui-app-download" ref={props.innerRef}>
-			<PlatformSpecificContent platforms={['Web']} previewDevicePlatform={props.previewDevicePlatform}>
+		<PlatformSpecificContent platforms={['Web']} previewDevicePlatform={props.previewDevicePlatform} innerRef={props.innerRef}>
+			<div className="mdhui-app-download">
 				<CardTitle title={title} />
 				<TextBlock>
 					<div className="mdhui-app-download-subtitle">
@@ -60,7 +60,7 @@ export default function (props: AppDownloadProps) {
 						}
 					</div>
 				</TextBlock>
-			</PlatformSpecificContent>
-		</div>
+			</div>
+		</PlatformSpecificContent>
 	);
 }


### PR DESCRIPTION
## Overview

Because app download has a wrapper div around the ```<PlatformSpecificContent>``` that wrapper div was being output even when the component should be entirely hidden.

This can result in showing a 0-height card or section if the AppDownload is the only child of that card/section

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ x There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner