### PR TITLE
Update survey answer chart answer selection to prefer the latest answer per day.

### DIFF
--- a/src/components/container/SurveyAnswerChart/SurveyAnswerChart.tsx
+++ b/src/components/container/SurveyAnswerChart/SurveyAnswerChart.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react'
 import { DateRangeContext } from '../../presentational/DateRangeCoordinator/DateRangeCoordinator'
-import { add, Duration, parseISO } from 'date-fns'
+import { add, compareAsc, Duration, parseISO } from 'date-fns'
 import { SurveyAnswer, SurveyAnswersQuery } from '@careevolution/mydatahelps-js'
 import { WeekStartsOn, getDefaultIntervalStart } from '../../../helpers/get-interval-start'
 import TimeSeriesChart from '../../presentational/TimeSeriesChart/TimeSeriesChart'
@@ -93,7 +93,7 @@ export default function SurveyAnswerChart(props:SurveyAnswerChartProps) {
     function processPages(pages: SurveyAnswer[][]) {
         var newDailyData: { [key: string]: SurveyAnswer[] } = {};
         for (var i = 0; i < props.series.length; i++) {
-            newDailyData[getDataKey(props.series[i])] = pages[i] || [];
+            newDailyData[getDataKey(props.series[i])] = pages[i]?.sort((a, b) => compareAsc(parseISO(a.date), parseISO(b.date))) || [];
         }
         
         return newDailyData;


### PR DESCRIPTION
## Overview

Small update to ensure that the Survey Answer Chart renders the most recent answer from a given day when more than one answer exists.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No new security risk.  Just fixes the selection process for the answer to render for a given day.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

- N/A