### PR TITLE
Fix Recharts Bar graph edge case

### DIFF
--- a/src/components/container/SurveyAnswerChart/SurveyAnswerChart.stories.tsx
+++ b/src/components/container/SurveyAnswerChart/SurveyAnswerChart.stories.tsx
@@ -126,6 +126,59 @@ export const ffwelBarChart = {
     render: render
 };
 
+export const ffwelBarChartWithOneDataPoint = {
+    args: {
+        title: "FFWEL Response Bar Chart",
+        options: {
+            yAxisOptions: {
+                domain: [0, 'auto']
+            }
+        },
+        intervalType: "6Month",
+        weekStartsOn: "6DaysAgo",
+        series: [{ color: "#e41a1c", dataKey: "Creative Self", surveyName: "FFWEL", stepIdentifier: "CreativeSelf", resultIdentifier: "CreativeSelf" },
+                {  color: "#377eb8", dataKey: "Coping Self", surveyName: "FFWEL", stepIdentifier: "CopingSelf", resultIdentifier: "CopingSelf" },
+                {  color: "#4daf4a", dataKey: "Social Self", surveyName: "FFWEL", stepIdentifier: "SocialSelf", resultIdentifier: "SocialSelf" }],
+        chartType: "Bar",
+        previewState: 'default',
+        previewDataProvider: async (start: Date, end: Date) => {
+            var data = await getRandomFFWELData(start, end);
+            var returnedData = [
+                [data[0][0]],
+                [data[1][0]],
+                [data[2][0]]
+            ]
+            return Promise.resolve(returnedData);
+        }
+    },
+    render: render
+};
+
+export const ffwelBarChartWithTwoDataPoints = {
+    args: {
+        title: "FFWEL Response Bar Chart",
+        options: {
+            yAxisOptions: {
+                domain: [0, 'auto']
+            }
+        },
+        intervalType: "6Month",
+        weekStartsOn: "6DaysAgo",
+        series: [{ color: "#e41a1c", dataKey: "Creative Self", surveyName: "FFWEL", stepIdentifier: "CreativeSelf", resultIdentifier: "CreativeSelf" },
+                {  color: "#377eb8", dataKey: "Coping Self", surveyName: "FFWEL", stepIdentifier: "CopingSelf", resultIdentifier: "CopingSelf" }],
+        chartType: "Bar",
+        previewState: 'default',
+        previewDataProvider: async (start: Date, end: Date) => {
+            var data = await getRandomFFWELData(start, end);
+            var returnedData = [
+                [data[0][0], data[0][1]],
+                [data[1][0], data[1][1]]
+            ]
+            return Promise.resolve(returnedData);
+        }
+    },
+    render: render
+};
 
 export const ffwelBarChartThresholds = {
     args: {

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.stories.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.stories.tsx
@@ -50,7 +50,7 @@ async function getRandomDataWithGaps(start: Date, end: Date) {
 async function getRandomMultipointData(start: Date, end: Date) {
     var responses = [];
     let currentDate = new Date(start);
-    while (currentDate < end) {
+    while (currentDate <= end) {
         responses.push({
             timestamp: currentDate.setHours(0, 0, 0, 0),
             key1: (await predictableRandomNumber(`${currentDate.toISOString()}key1`)) % 200,
@@ -354,6 +354,42 @@ export const multipleBarChart: Story = {
     loaders: [
         async () => ({
             randomData: await getRandomMultipointData(new Date(), addDays(new Date(), 6))
+        })
+    ]
+};
+
+export const multipleBarChartSingleDataPoint: Story = {
+    args: {
+        title: "Multiple Bar Chart Single Data Point",
+        intervalType: "Week",
+        chartType: "Bar",
+        chartHasData: true,
+        data: [],
+        series: [{ dataKey: 'key1', color: 'red' }, { dataKey: 'key2', color: 'green' }, { dataKey: 'key3' }],
+        intervalStart: new Date(),
+        tooltip
+    },
+    loaders: [
+        async () => ({
+            randomData: await getRandomMultipointData(new Date(), addDays(new Date(), 0))
+        })
+    ]
+};
+
+export const multipleBarChartSingleDataPointEndOfWeek: Story = {
+    args: {
+        title: "Multiple Bar Chart Single Data Point",
+        intervalType: "Week",
+        chartType: "Bar",
+        chartHasData: true,
+        data: [],
+        series: [{ dataKey: 'key1', color: 'red' }, { dataKey: 'key2', color: 'green' }, { dataKey: 'key3' }],
+        intervalStart: new Date(),
+        tooltip
+    },
+    loaders: [
+        async () => ({
+            randomData: await getRandomMultipointData(addDays(new Date(), 5), addDays(new Date(), 5))
         })
     ]
 };

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -161,6 +161,14 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
     }
 
     const xAxisTicks = getXAxisTicks();
+    
+    if(props.data?.length === 1 && props.chartType === 'Bar'){
+        let currentPoint = new Date(props.data[0].timestamp);
+        let nextExpectedPoint = add(currentPoint, props.expectedDataInterval || {days: 1});
+        dataToDisplay?.push({
+            timestamp: nextExpectedPoint.getTime()
+        });
+    }
 
     return <div className="mdhui-time-series-chart" ref={props.innerRef}>
         {props.title &&


### PR DESCRIPTION
## Overview

Recharts has trouble rendering bar graphs on number based x-axis lines when there's only one data point.  It fails to properly calculate the width of the bar (https://github.com/recharts/recharts/issues/3640) as well as the gap between the x-axis and the first tick.  

While Recharts has provided some theoretical tools to help (letting you manually set the width, or manually set the padding), it turns out that for this edge case a trivial solution is to pad the data with a null data point at an expected interval.  

![image](https://github.com/user-attachments/assets/d4eefa54-a6ba-4d26-8a93-4d401a66cb51)
![image](https://github.com/user-attachments/assets/963d6be9-3ed1-47cf-af95-641e583138ff)

There's a very minor visual artifact of this if you're on desktop and can hover the chart; you get a line where it attempts to put a tooltip for the data point, but no tooltip displays.  This is the same artifact that you get on a line chart where we need to enforce a "gap" in the data and not have the line connect.

## Security

REMINDER: All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner