### PR TITLE
Fix Garmin sleep data selection logic.

### DIFF
--- a/src/helpers/daily-data-providers/garmin-sleep.ts
+++ b/src/helpers/daily-data-providers/garmin-sleep.ts
@@ -24,7 +24,7 @@ function querySleep(property: string, startDate: Date, endDate: Date, divideBy?:
                 value = value / divideBy;
             }
 
-            if (!data[dataKey] || data[dataKey] > value) {
+            if (!data[dataKey] || data[dataKey] < value) {
                 data[dataKey] = value;
             }
         });


### PR DESCRIPTION
## Overview

Fixes https://github.com/CareEvolution/MyDataHelpsUI/issues/393

This branch updates the Garmin sleep daily data provider such that it selects the max value for a given day instead of the min value.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just adjusting the daily sleep value selection logic.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

- N/A