### PR TITLE
Fix Times in Time Series Chart

### DIFF
--- a/__tests__/helpers/locale/date-helpers.test.ts
+++ b/__tests__/helpers/locale/date-helpers.test.ts
@@ -268,7 +268,7 @@ describe('Date Helper Tests', () => {
             const result = getTimeOfDayString(new Date(2024, 11, 4, 3, 22));
             expect(result).toBe("03:22");
         });
-        it('Should return an empty string if mising a time.', () => {            
+        it('Should return an empty string if missing a time.', () => {            
             mockMDHLanguage = "de-DE";
             const result = getTimeOfDayString(new Date(2024, 11, 4));
             expect(result).toBe("");
@@ -286,7 +286,7 @@ describe('Date Helper Tests', () => {
             const result = getShortTimeOfDayString(new Date(2024, 11, 4, 3, 22));
             expect(result).toBe("03:22");
         });
-        it('Should return an empty string if mising a time.', () => {            
+        it('Should return an empty string if missing a time.', () => {            
             mockMDHLanguage = "de-DE";
             const result = getShortTimeOfDayString(new Date(2024, 11, 4));
             expect(result).toBe("");

--- a/__tests__/helpers/locale/date-helpers.test.ts
+++ b/__tests__/helpers/locale/date-helpers.test.ts
@@ -5,7 +5,7 @@ import { toDate, daysInMonth, getDayOfWeek, getDayOfWeekLetter,
     getAbbreviatedDayOfWeek, getDayAndDateAndTimeString, getFullDayAndDateString,
     getFullDateString, getLongDateString, getShortDateString, getShortestDateString,
     getMonthName, getAbbreviatedMonthName, getTimeFromNowString,
-    getRelativeDateString, getTimeOfDayString, getDayOfMonth } from '../../../src/helpers/date-helpers';
+    getRelativeDateString, getTimeOfDayString, getShortTimeOfDayString, getDayOfMonth } from '../../../src/helpers/date-helpers';
 import { describe, it } from '@jest/globals';
 
 let mockMDHLanguage = "en";
@@ -273,5 +273,23 @@ describe('Date Helper Tests', () => {
             const result = getTimeOfDayString(new Date(2024, 11, 4));
             expect(result).toBe("");
         });
-    });        
+    });
+    
+    describe('getShortTimeOfDayString', () => {        
+        it('Should return an English short time string.', () => {            
+            mockMDHLanguage = "en";
+            const result = getShortTimeOfDayString(new Date(2024, 11, 4, 3, 22));
+            expect(result).toBe("3 AM");
+        });
+        it('Should return a localized short time string.', () => {            
+            mockMDHLanguage = "de-DE";
+            const result = getShortTimeOfDayString(new Date(2024, 11, 4, 3, 22));
+            expect(result).toBe("03:22");
+        });
+        it('Should return an empty string if mising a time.', () => {            
+            mockMDHLanguage = "de-DE";
+            const result = getShortTimeOfDayString(new Date(2024, 11, 4));
+            expect(result).toBe("");
+        });
+    });
 });

--- a/src/components/container/GlucoseChart/GlucoseChart.tsx
+++ b/src/components/container/GlucoseChart/GlucoseChart.tsx
@@ -8,7 +8,7 @@ import { Bar, ReferenceLine } from 'recharts';
 import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
 import { faShoePrints } from '@fortawesome/free-solid-svg-icons';
 import { GlucoseContext, MealContext } from '../../container';
-import { getTimeOfDayString } from '../../../helpers/date-helpers';
+import { getShortTimeOfDayString, getTimeOfDayString } from '../../../helpers/date-helpers';
 import { formatNumberForLocale } from "../../../helpers/locale";
 
 export interface GlucoseChartProps {
@@ -112,7 +112,7 @@ export default function (props: GlucoseChartProps) {
         add(selectedDate, { hours: 18 }).valueOf(),
         add(selectedDate, { hours: 21 }).valueOf()
     ];
-    let chartTickFormatter = (value: number) => getTimeOfDayString(new Date(value));
+    let chartTickFormatter = (value: number) => getShortTimeOfDayString(new Date(value));
 
     if (selectedMeal) {
         chartDomain = [add(selectedMeal.timestamp, { minutes: -3 }).valueOf(), add(selectedMeal.timestamp, { hours: 2 }).valueOf()];

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -6,7 +6,7 @@ import './TimeSeriesChart.css'
 import { AreaChartSeries, ChartSeries, createAreaChartDefs, createBarChartDefs, createLineChartDefs, MultiSeriesBarChartOptions, MultiSeriesLineChartOptions, resolveColor } from '../../../helpers'
 import ceil from 'lodash/ceil'
 import language from "../../../helpers/language"
-import { getAbbreviatedMonthName, getAbbreviatedDayOfWeek, getTimeOfDayString } from '../../../helpers/date-helpers'
+import { getAbbreviatedMonthName, getAbbreviatedDayOfWeek, getShortTimeOfDayString } from '../../../helpers/date-helpers'
 import { formatNumberForLocale } from "../../../helpers/locale";
 
 export interface TimeSeriesDataPoint {
@@ -70,7 +70,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                 return <></>;
             }
             return <>
-                <text fill="var(--mdhui-text-color-2)" x={x} y={y + 15} textAnchor="middle" fontSize="12">{getTimeOfDayString(currentDate)}</text>
+                <text fill="var(--mdhui-text-color-2)" x={x} y={y + 15} textAnchor="middle" fontSize="12">{getShortTimeOfDayString(currentDate)}</text>
             </>;
         }
         return <>

--- a/src/helpers/date-helpers.ts
+++ b/src/helpers/date-helpers.ts
@@ -189,3 +189,18 @@ export function getTimeOfDayString(dateOrDateString: Date | string) {
 	}
 	return formatDateForLocale(date, "p");
 }
+
+/** e.g., 12p (localized, may be 24h) - a time of 00:00:00 is returned as an empty string */
+export function getShortTimeOfDayString(dateOrDateString: Date | string) {
+	const date = toDate(dateOrDateString);
+	if (!date || (date.getHours() === 0 && date.getMinutes() === 0 && date.getSeconds() === 0)) {
+		return "";
+	}
+	// date-fns doesn't have a format for this one, so we have to fall back to Intl
+	const locale = getIntlLocale();
+	const formatOptions = new Intl.DateTimeFormat(locale, {
+		timeStyle: 'short',
+		}).resolvedOptions();
+
+		return formatOptions.hour12 ? formatDateForLocale(date, "h a") : formatDateForLocale(date, 'p');
+}

--- a/src/helpers/date-helpers.ts
+++ b/src/helpers/date-helpers.ts
@@ -190,7 +190,7 @@ export function getTimeOfDayString(dateOrDateString: Date | string) {
 	return formatDateForLocale(date, "p");
 }
 
-/** e.g., 12p (localized, may be 24h) - a time of 00:00:00 is returned as an empty string */
+/** e.g., 12 P (localized, may be 24h) - a time of 00:00:00 is returned as an empty string */
 export function getShortTimeOfDayString(dateOrDateString: Date | string) {
 	const date = toDate(dateOrDateString);
 	if (!date || (date.getHours() === 0 && date.getMinutes() === 0 && date.getSeconds() === 0)) {

--- a/src/helpers/date-helpers.ts
+++ b/src/helpers/date-helpers.ts
@@ -202,5 +202,5 @@ export function getShortTimeOfDayString(dateOrDateString: Date | string) {
 		timeStyle: 'short',
 		}).resolvedOptions();
 
-		return formatOptions.hour12 ? formatDateForLocale(date, "h a") : formatDateForLocale(date, 'p');
+		return formatDateForLocale(date, formatOptions.hour12 ? "h a" : "p");
 }


### PR DESCRIPTION
## Overview

Times in the time series chart (used in GlucoseChart)  are squished in:

* 12-hour time format locales (e.g., en-US)
* mobile width
* "Day" `intervalType` option (for hours of the day)

<img width="477" alt="image" src="https://github.com/user-attachments/assets/7eeeefa8-c8fb-4582-9f87-aa3c66325629" />

Fix was adding a new "short time of day" format that appears as "6 AM" in 12-hour locales and "06:00" in 24-hour ones.

<img width="492" alt="image" src="https://github.com/user-attachments/assets/b5219b63-cad4-44e6-8761-c2f8dcb3062e" />

**Testing Notes**

* Date/time formats are governed by the browser's language setting, not the language dropdown.
* Test both `TimeSeriesChart` and `GlucoseChart`. I didn't see anywhere else using TimeSeriesChart with a custom tickFormatter.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner