### PR TITLE
Added a couple more options to ProviderSearch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.61.0",
+  "version": "2.61.1-WelcomeScreenProviderSearch.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.61.0",
+      "version": "2.61.1-WelcomeScreenProviderSearch.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.61.0",
+  "version": "2.61.1-WelcomeScreenProviderSearch.0",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
@@ -49,7 +49,23 @@ export const HealthPlanOnly: Story = {
 export const onProviderSelected: Story = {
 	args: {
 		previewState: "Default",
-		onProviderConnected: (provider: ExternalAccountProvider) => alert(`You selected ${provider.name}`)
+		onProviderSelected: (provider: ExternalAccountProvider) => alert(`You selected ${provider.name}`)
+	},
+	render: render
+}
+
+export const onProviderConnected: Story = {
+	args: {
+		previewState: "Default",
+		onProviderConnected: (provider: ExternalAccountProvider) => alert(`You connected to ${provider.name}`)
+	},
+	render: render
+}
+
+export const publicEndpoint: Story = {
+	args: {
+		publicProviderSearchApiUrl: "https://designer.mydatahelps.dev/api/fhirpublicproviders",
+		onProviderSelected: (provider: ExternalAccountProvider) => alert(`You selected ${provider.name}`)
 	},
 	render: render
 }
@@ -72,7 +88,7 @@ export const Searching: Story = {
 export const Live: Story = {
 	args: {
 		previewState: "Default",
-		onProviderConnected: (provider: ExternalAccountProvider) => alert(`You selected ${provider.name}`)
+		onProviderConnected: (provider: ExternalAccountProvider) => alert(`You connected to ${provider.name}`)
 	},
 	render: render
 }


### PR DESCRIPTION
Added:
* `onProviderSelected()` property which can override default behavior (start the connection process) when you select a provider
* `publicProviderSearchApiUrl` property which can be used to query our public provider search endpoint (instead of the default authenticated one)

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [x] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner