### PR TITLE
Fix MealEditor time input value population.

### DIFF
--- a/src/components/container/MealEditor/MealEditor.tsx
+++ b/src/components/container/MealEditor/MealEditor.tsx
@@ -2,11 +2,11 @@ import React, { CSSProperties, useContext, useEffect, useState } from 'react';
 import './MealEditor.css';
 import { getMealImageUrls, getMeals, getMealToEdit, getMealTypeDisplayText, language, Meal, resolveColor, saveMeals, timestampSortAsc, uploadMealImageFile } from '../../../helpers';
 import { Button, LayoutContext, LoadingIndicator, UnstyledButton } from '../../presentational';
-import { parse, startOfDay } from 'date-fns';
+import { format, parse, startOfDay } from 'date-fns';
 import { createPreviewData, MealEditorPreviewState } from './MealEditor.previewData';
 import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
 import { faEdit, faPlus, faTrashCan } from '@fortawesome/free-solid-svg-icons';
-import { getFullDayAndDateString, getTimeOfDayString } from '../../../helpers/date-helpers';
+import { getFullDayAndDateString } from '../../../helpers/date-helpers';
 
 export interface MealEditorProps {
     previewState?: 'loading' | MealEditorPreviewState;
@@ -198,7 +198,7 @@ export default function MealEditor(props: MealEditorProps) {
                     <input
                         className="mdhui-meal-editor-time-input"
                         type="time"
-                        value={getTimeOfDayString(mealToEdit.timestamp)}
+                        value={format(mealToEdit.timestamp, 'HH:mm')}
                         onChange={event => onTimeChanged(event.target.value)}
                         style={{ colorScheme: layoutContext.colorScheme }}
                     />


### PR DESCRIPTION
## Overview

A recent [change to support better date/time localization](https://github.com/CareEvolution/MyDataHelpsUI/pull/367/files#diff-f912f9d7e60086d38b3d51ea89997c2a904b2e97a0eaab91f269bdb2cac21245R201) caused an issue with the `MealEditor`'s time input field.  The HTML time input field requires a specific canonical format for the values, so it was no longer rendering the values.  I have reverted that change with a slight modification to use the specific format (`HH:mm`), regardless of locale.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just correcting and issue with time input value setting.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

- N/A