### PR TITLE
Update the ProviderSearch "request add" functionality to handle additional category configuration scenarios.

### DIFF
--- a/src/components/container/ProviderSearch/ProviderSearch.previewdata.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.previewdata.tsx
@@ -9,6 +9,12 @@ export var previewProviders: ExternalAccountProvider[] =
             "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/20/logo"
         },
         {
+            "id": 2,
+            "name": "Fitbit",
+            "category": "Device Manufacturer",
+            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/2/logo"
+        },
+        {
             "id": 13,
             "name": "A Woman's Place, LLC",
             "category": "Provider",

--- a/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
@@ -38,12 +38,52 @@ export const ProvidersOnly: Story = {
 	render: render
 }
 
-export const HealthPlanOnly: Story = {
+export const HealthPlansOnly: Story = {
 	args: {
 		previewState: "Default",
 		providerCategories: ["Health Plan"]
 	},
 	render: render
+}
+
+export const DeviceManufacturersOnly: Story = {
+	args: {
+		previewState: "Default",
+		providerCategories: ["Device Manufacturer"]
+	},
+	render: render
+}
+
+export const ProvidersAndHealthPlans: Story = {
+	args: {
+		previewState: "Default",
+		providerCategories: ["Provider", "Health Plan"]
+	},
+	render: render
+}
+
+export const ProvidersAndDeviceManufacturers: Story = {
+	args: {
+		previewState: "Default",
+		providerCategories: ["Provider", "Device Manufacturer"]
+	},
+	render: render
+}
+
+export const HealthPlansAndDeviceManufacturers: Story = {
+	args: {
+		previewState: "Default",
+		providerCategories: ["Health Plan", "Device Manufacturer"]
+	},
+	render: render
+}
+
+export const ProvidersAndHealthPlansAndDeviceManufacturers: Story = {
+    args: {
+        previewState: "Default",
+        providerCategories: ["Provider", "Health Plan", "Device Manufacturer"]
+    },
+    render: render
 }
 
 export const onProviderSelected: Story = {

--- a/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
@@ -79,22 +79,14 @@ export const HealthPlansAndDeviceManufacturers: Story = {
 }
 
 export const ProvidersAndHealthPlansAndDeviceManufacturers: Story = {
-    args: {
-        previewState: "Default",
-        providerCategories: ["Provider", "Health Plan", "Device Manufacturer"]
-    },
-    render: render
-}
-
-export const onProviderSelected: Story = {
 	args: {
 		previewState: "Default",
-		onProviderConnected: (provider: ExternalAccountProvider) => alert(`You selected ${provider.name}`)
+		providerCategories: ["Provider", "Health Plan", "Device Manufacturer"]
 	},
 	render: render
 }
 
-export const hideAddNewAction: Story = {
+export const HideAddNewAction: Story = {
 	args: {
 		previewState: "Default",
 		hideRequestProviderButton: true
@@ -123,6 +115,13 @@ export const LiveStandalone: Story = {
 			openNewWindow: false,
 			standaloneModeFinalRedirectPath: "https://mydatahelps.org"// replace with actual redirect url for this to work
 		}
+	},
+	render: render
+}
+
+export const LiveOnProviderConnected: Story = {
+	args: {
+		onProviderConnected: (provider: ExternalAccountProvider) => alert(`Provider ${provider.name} connected.`)
 	},
 	render: render
 }

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -130,26 +130,6 @@ export default function ProviderSearch(props: ProviderSearchProps) {
         setCurrentPage(currentPage + 1);
     }
 
-    function buildActionTitle() {
-        let title = language("request-add");
-
-        if (!props.providerCategories || props.providerCategories.length == 0) {
-            return `${title} ${language('external-accounts-title-providers')} ${language('external-accounts-title-divider')} ${language('external-accounts-title-health-plans')}`;
-        }
-
-        if (props.providerCategories.length == 1 && props.providerCategories[0] === "Provider") {
-            return `${title} ${language('external-accounts-title-providers')}`;
-        }
-
-        if (props.providerCategories.length == 1 && props.providerCategories[0] === "Health Plan") {
-            return `${title} ${language('external-accounts-title-health-plans')}`;
-        }
-    }
-
-    const requestProviderAction = () => {
-        MyDataHelps.openEmbeddedUrl(addNewProviderUrl);
-    }
-
     useEffect(() => {
         initialize();
         MyDataHelps.on("applicationDidBecomeVisible", onApplicationDidBecomeVisible);
@@ -163,6 +143,38 @@ export default function ProviderSearch(props: ProviderSearchProps) {
             performSearch(searchStringRef.current)
         }
     }, [currentPage]);
+
+    const supportsRequestProviderAction = (): boolean => {
+        return !props.providerCategories
+            || props.providerCategories.length == 0
+            || props.providerCategories.includes("Provider")
+            || props.providerCategories.includes("Health Plan");
+    };
+
+    const shouldShowRequestProviderAction = (): boolean => {
+        return !searching && !props.hideRequestProviderButton && supportsRequestProviderAction();
+    };
+
+    const buildRequestProviderActionTitle = (): string => {
+        let titleSuffix = "";
+
+        if (!props.providerCategories || props.providerCategories.length == 0 || props.providerCategories.includes("Provider")) {
+            titleSuffix += language('external-accounts-title-providers');
+        }
+
+        if (!props.providerCategories || props.providerCategories.length == 0 || props.providerCategories.includes("Health Plan")) {
+            if (titleSuffix.length > 0) {
+                titleSuffix += language('external-accounts-title-divider');
+            }
+            titleSuffix += language('external-accounts-title-health-plans');
+        }
+
+        return `${(language("request-add"))} ${titleSuffix}`;
+    };
+
+    const requestProviderAction = (): void => {
+        MyDataHelps.openEmbeddedUrl(addNewProviderUrl);
+    };
 
     return (
         <div ref={props.innerRef} className="mdhui-provider-search">
@@ -189,9 +201,9 @@ export default function ProviderSearch(props: ProviderSearchProps) {
                         </div>
                     </UnstyledButton>
                 )}
-                {!searching &&
-                    !props.hideRequestProviderButton &&
-                    <Action onClick={requestProviderAction} title={buildActionTitle()} />}
+                {shouldShowRequestProviderAction() &&
+                    <Action onClick={requestProviderAction} title={buildRequestProviderActionTitle()} />
+                }
                 {searching &&
                     <LoadingIndicator />
                 }


### PR DESCRIPTION
## Overview

This branch updates the `ProviderSearch` component's "request add" functionality to handle additional category configuration scenarios.  Specifically, what to do when the "Device Manufacturer" category is solely or also present, and what to do when multiple "add-able" categories are present.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just adjusting when and what gets displayed on the "request add" button with some additional category configuration scenarios.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
