### PR TITLE
MostRecentNotification: Add identifier regex filter

### DIFF
--- a/src/components/container/MostRecentNotification/MostRecentNotification.previewdata.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.previewdata.tsx
@@ -1,16 +1,77 @@
 import { Notification } from "@careevolution/mydatahelps-js";
+import { add } from 'date-fns'
 
-export var previewNotification: Notification =
-{
-	"id": "1",
-	"identifier": "SurveyReminder",
-	"sentDate": "2022-03-10T13:37:41.16+00:00",
-	"statusCode": "Succeeded",
-	"type": "Push",
-	"content": {
-		"title": "Please Complete Your Surveys",
-		"body": "Your latest surveys are due"
+export var previewNotifications: Notification[] =
+	[{
+		"id": "1",
+		"identifier": "SurveyReminder-Thanks",
+		"sentDate": (new Date()).toISOString(),
+		"statusCode": "Succeeded",
+		"type": "Push",
+		"content": {
+			"body": "Thank you for completing your surveys!"
+		},
+		recipients: [],
+		contentVersion: 1
+	}, {
+		"id": "2",
+		"identifier": "SurveyReminder",
+		"sentDate": add(new Date(), { hours: -1 }).toISOString(),
+		"statusCode": "Succeeded",
+		"type": "Push",
+		"content": {
+			"title": "Please Complete Your Surveys",
+			"body": "Your latest surveys are due"
+		},
+		recipients: [],
+		contentVersion: 1
+	}, {
+		"id": "4",
+		"identifier": "SurveyReminder-Fitbit",
+		"sentDate": add(new Date(), { days: -1 }).toISOString(),
+		"statusCode": "Succeeded",
+		"type": "Push",
+		"content": {
+			"title": "Have you received your Fitbit? Connect it!"
+		},
+		recipients: [],
+		contentVersion: 1
+	}, {
+		"id": "5",
+		"identifier": "SurveyReminder-Fitbit2",
+		"sentDate": add(new Date(), { days: -2 }).toISOString(),
+		"statusCode": "Succeeded",
+		"type": "Push",
+		"content": {
+			"title": "Consent and get a Fitbit",
+			"body": "Are you missing out on a Fitbit device? Complete your consent - you could get a new Fitbit at no cost to you!"
+		},
+		recipients: [],
+		contentVersion: 1
 	},
-	recipients: [],
-	contentVersion: 0
-};
+	{
+		"id": "6",
+		"identifier": "EmailSurveyReminder",
+		"sentDate": add(new Date(), { days: -3 }).toISOString(),
+		"statusCode": "Succeeded",
+		"type": "Email",
+		"content": {
+			"subject": "Subject - Email reminder to complete daily survey",
+			"body": "Complete your daily survey to earn rewards!"
+		},
+		recipients: [],
+		contentVersion: 1
+	},
+	{
+		"id": "7",
+		"identifier": "SMSSurveyReminder",
+		"sentDate": add(new Date(), { days: -4 }).toISOString(),
+		"statusCode": "Succeeded",
+		"type": "Sms",
+		"content": {
+			"title": "SMS Title - complete daily survey",
+			"body": "Visit MDH to complete your daily survey"
+		},
+		recipients: [],
+		contentVersion: 1
+	}];

--- a/src/components/container/MostRecentNotification/MostRecentNotification.stories.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.stories.tsx
@@ -34,8 +34,6 @@ const render = (args: MostRecentNotificationStoryArgs) => {
 		}
 	}
 
-	console.log("args", args)
-
 	return <Layout colorScheme={args.colorScheme}>
 		<Card>
 			<MostRecentNotification

--- a/src/components/container/MostRecentNotification/MostRecentNotification.stories.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.stories.tsx
@@ -1,25 +1,91 @@
-﻿import React from "react"
-import { ComponentStory, ComponentMeta } from "@storybook/react"
-import MostRecentNotification, { MostRecentNotificationProps } from "./MostRecentNotification"
-import Card from "../../presentational/Card"
-import Layout from "../../presentational/Layout"
+﻿import React from 'react'
+import { Meta, StoryObj } from '@storybook/react'
+import MostRecentNotification, { MostRecentNotificationPreviewState } from './MostRecentNotification'
+import Layout from '../../presentational/Layout'
+import { Card } from '../../presentational'
+import { argTypesToHide } from '../../../../.storybook/helpers';
+import { tryParseRegex } from '../../../helpers';
 
-export default {
-	title: "Container/MostRecentNotification",
+
+type MostRecentNotificationStoryArgs = React.ComponentProps<typeof MostRecentNotification> & {
+	colorScheme: 'auto' | 'light' | 'dark';
+	state: MostRecentNotificationPreviewState | 'live';
+	notificationIdentifierRegexString?: string;
+};
+
+const meta: Meta<MostRecentNotificationStoryArgs> = {
+	title: 'Container/MostRecentNotification',
 	component: MostRecentNotification,
 	parameters: {
-		layout: 'fullscreen',
-	}
-} as ComponentMeta<typeof MostRecentNotification>;
+		layout: 'fullscreen'
+	},
+};
+export default meta;
 
-const Template: ComponentStory<typeof MostRecentNotification> = (args: MostRecentNotificationProps) =>
-	<Layout colorScheme="auto">
+type Story = StoryObj<MostRecentNotificationStoryArgs>;
+
+const render = (args: MostRecentNotificationStoryArgs) => {
+	if (args.notificationIdentifierRegexString) {
+		const { success, regex } = tryParseRegex(args.notificationIdentifierRegexString);
+		if (success) {
+			args.notificationIdentifierRegex = regex;
+		} else {
+			console.log('Invalid identifier regex.')
+		}
+	}
+
+	console.log("args", args)
+
+	return <Layout colorScheme={args.colorScheme}>
 		<Card>
-			<MostRecentNotification {...args} />
+			<MostRecentNotification
+				previewState={args.state !== 'live' ? args.state : undefined}
+				{...args}
+			/>
 		</Card>
 	</Layout>;
-
-export const Default = Template.bind({});
-Default.args = {
-	previewState: "Default"
 };
+
+export const Default: Story = {
+	args: {
+		colorScheme: 'auto',
+		state: "loaded with data",
+		notificationType: undefined,
+		notificationIdentifierRegexString: '',
+	},
+	argTypes: {
+		colorScheme: {
+			name: 'color scheme',
+			control: 'radio',
+			options: ['auto', 'light', 'dark']
+		},
+		state: {
+			name: 'state',
+			control: 'radio',
+			options: ['loading', 'loaded with data', 'loaded with no data', 'live']
+		},
+		notificationType: {
+			name: 'type filter',
+			control: {
+				type: 'radio',
+				labels: {
+					undefined: 'None'
+				}
+			},
+			options: [undefined, 'Email', 'Push', 'Sms']
+		},
+		hideAfterHours: {
+			name: 'hide after hours',
+			control: {
+				type: 'number',
+				step: 1
+			}
+		},
+		notificationIdentifierRegexString: {
+			name: 'identifier regex',
+		},
+		...argTypesToHide(['previewState', 'notificationIdentifierRegex', 'innerRef'])
+	},
+	render: render
+};
+

--- a/src/components/container/MostRecentNotification/MostRecentNotification.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.tsx
@@ -99,16 +99,12 @@ export default function (props: MostRecentNotificationProps) {
 
 		} while (count <= MAX_PAGES); //limit to 100 requests just for sanity
 
-
+		return null;
 	}
 
 	useInitializeView(() => {
 		initialize().catch(console.error);
 	}, [], [props.previewState, props.notificationType, props.notificationIdentifierRegex, props.hideAfterHours]);
-
-	if (!notification) {
-		return null;
-	}
 
 	return (
 		<div ref={props.innerRef} className="mdhui-most-recent-notification">

--- a/src/components/container/MostRecentNotification/MostRecentNotification.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.tsx
@@ -25,6 +25,7 @@ export default function (props: MostRecentNotificationProps) {
 	async function initialize() {
 		setLoading(true);
 		if (props.previewState === 'loading') {
+			setNotification(null);
 			return;
 		}
 
@@ -43,6 +44,7 @@ export default function (props: MostRecentNotificationProps) {
 		}
 
 		if (props.previewState === 'loaded with no data') {
+			setNotification(null);
 			setLoading(false);
 			return;
 		}

--- a/src/components/container/MostRecentNotification/MostRecentNotification.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.tsx
@@ -81,16 +81,12 @@ export default function (props: MostRecentNotificationProps) {
 
 		let count = 1;
 		const MAX_PAGES = 100;
+		const MAX_PAGE_SIZE = 100;
+		const LIMIT_INCREASE_STEP = 20;
 
 		do {
-
-			//limit to 100 requests just for sanity
-			if (count >= MAX_PAGES) {
-				return null;
-			}
-
-			queryParams.limit = Math.min(100, count * 20);
 			count++;
+			queryParams.limit = Math.min(MAX_PAGE_SIZE, count * LIMIT_INCREASE_STEP);
 			const result = await MyDataHelps.queryNotifications(queryParams);
 			const matchingNotification = result.notifications.find(n => n.identifier.match(identifierRegex));
 			if (matchingNotification) {
@@ -101,7 +97,7 @@ export default function (props: MostRecentNotificationProps) {
 			}
 			queryParams.pageID = result.nextPageID;
 
-		} while (true);
+		} while (count <= MAX_PAGES); //limit to 100 requests just for sanity
 
 
 	}

--- a/src/components/container/MostRecentNotification/MostRecentNotification.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.tsx
@@ -79,7 +79,6 @@ export default function (props: MostRecentNotificationProps) {
 
 	async function findMatchingNotification(queryParams: NotificationQueryParameters, identifierRegex: string): Promise<Notification | null> {
 
-		const foundNotification: Notification | null = null;
 		let count = 1;
 		do {
 			queryParams.limit = Math.min(100, count * 20);
@@ -91,9 +90,9 @@ export default function (props: MostRecentNotificationProps) {
 			}
 			queryParams.pageID = result.nextPageID;
 
-		} while (queryParams.pageID !== null && !foundNotification && count < 100);
+		} while (queryParams.pageID !== null && count < 100); // limit to 100 requests just for sanity
 
-		return foundNotification;
+		return null;
 
 	}
 

--- a/src/components/container/MostRecentNotification/MostRecentNotification.tsx
+++ b/src/components/container/MostRecentNotification/MostRecentNotification.tsx
@@ -80,7 +80,15 @@ export default function (props: MostRecentNotificationProps) {
 	async function findMatchingNotification(queryParams: NotificationQueryParameters, identifierRegex: string): Promise<Notification | null> {
 
 		let count = 1;
+		const MAX_PAGES = 100;
+
 		do {
+
+			//limit to 100 requests just for sanity
+			if (count >= MAX_PAGES) {
+				return null;
+			}
+
 			queryParams.limit = Math.min(100, count * 20);
 			count++;
 			const result = await MyDataHelps.queryNotifications(queryParams);
@@ -88,11 +96,13 @@ export default function (props: MostRecentNotificationProps) {
 			if (matchingNotification) {
 				return matchingNotification;
 			}
+			if (!result.nextPageID) {
+				return null;
+			}
 			queryParams.pageID = result.nextPageID;
 
-		} while (queryParams.pageID !== null && count < 100); // limit to 100 requests just for sanity
+		} while (true);
 
-		return null;
 
 	}
 

--- a/src/components/presentational/SingleNotification/SingleNotification.tsx
+++ b/src/components/presentational/SingleNotification/SingleNotification.tsx
@@ -4,11 +4,18 @@ import { Notification } from "@careevolution/mydatahelps-js"
 import { getRelativeDateString } from '../../../helpers/date-helpers';
 
 export interface SingleNotificationProps {
-	notification: Notification
+	notification: Notification | null
 	innerRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function (props: SingleNotificationProps) {
+	if (!props.notification) {
+		return (
+			<div ref={props.innerRef} className="mdhui-single-notification">
+				<div className="notification-body">No notifications received</div>
+			</div>
+		)
+	}
 	return (
 		<div ref={props.innerRef} className="mdhui-single-notification">
 			{props.notification.content?.title &&

--- a/src/components/view/HomeView/HomeView.tsx
+++ b/src/components/view/HomeView/HomeView.tsx
@@ -57,7 +57,7 @@ export default function HomeView(props: HomeViewProps) {
 				<MostRecentNotification
 					notificationType={notificationType}
 					onViewMore={props.notificationsViewUrl ? () => viewAllNotifications() : undefined}
-					previewState={props.preview ? "Default" : undefined}
+					previewState={props.preview ? "loaded with data" : undefined}
 					hideAfterHours={props.notificationHideAfterHours} />
 			</Card>
 			<SurveyTaskList


### PR DESCRIPTION
## Overview

This is a change needed for IHS 2025.

This adds a new property to the MostRecentNotification component: A regex string that will filter the notifications. It works like the NotificationList component.

One major change I had to make here was how we fetched notifications. If the notification identifier regex is supplied, we have to query until something matches or we run out of results.

Another change I made here is brough the storybook for this component up to date. I followed the example set by NotificationList component.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.


## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner