### PR TITLE
Fix the AppleHealth therapy minutes CBT data point filter.

### DIFF
--- a/src/helpers/daily-data-providers/common-mindful-and-therapy.ts
+++ b/src/helpers/daily-data-providers/common-mindful-and-therapy.ts
@@ -5,7 +5,7 @@ import getDayKey from '../get-day-key';
 
 export function isSilverCloudCbtDataPoint(dataPoint: DeviceDataPoint): boolean {
     return dataPoint.source?.properties?.['SourceIdentifier'] === 'com.silvercloudhealth.SilverCloud'
-        && dataPoint.source.properties['Metadata_sub-type'] === 'CBT';
+        && dataPoint.properties?.['Metadata_sub-type'] === 'CBT';
 }
 
 export function collateDataPoints(dataPoints: DeviceDataPoint[]) {


### PR DESCRIPTION
## Overview

Fixes a bug with Apple Health SilverCloud CBT data point filtering.

The `Metadata_sub-type` property exists on the SilverCloud CBT data points, not on their data sources.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

- N/A