### PR TITLE
Fix nav bar height when no title / subtitle

### DIFF
--- a/src/components/presentational/NavigationBar/NavigationBar.css
+++ b/src/components/presentational/NavigationBar/NavigationBar.css
@@ -1,6 +1,6 @@
 ﻿.mdhui-navigation-bar {
     text-align: left;
-    padding: calc(8px + 24px) 16px 8px;
+    padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 8px;
     min-height: calc(56px + env(safe-area-inset-top, 0px));
     margin-bottom: 8px;
     box-sizing: border-box;

--- a/src/components/presentational/NavigationBar/NavigationBar.css
+++ b/src/components/presentational/NavigationBar/NavigationBar.css
@@ -1,7 +1,7 @@
 ﻿.mdhui-navigation-bar {
     text-align: left;
-    padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 8px;
-    min-height: 56px;
+    padding: calc(8px + 24px) 16px 8px;
+    min-height: calc(56px + env(safe-area-inset-top, 0px));
     margin-bottom: 8px;
     box-sizing: border-box;
     position: -webkit-sticky;


### PR DESCRIPTION
## Overview

When there is no title/subtitle in the navigation bar, it was getting squished like this:
![image](https://github.com/user-attachments/assets/b6cc26f2-97ad-46ac-8d8b-3355a7ee8d2a)

This is because 1) the nav bar uses box-sizing border-box and 2) the top padding adds the safe-area-inset-top (which is like 90px or something on iOS), and the only thing causing the nav bar to have height was min-height:56px, which was essentially irrelevant because of 1/2.

Easy solution is to incorporate the safe area calculation into the min-height.

I have verified this fix in the iOS safari debugger.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [x] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner