### PR TITLE
Fix relative activity bars if no available data

### DIFF
--- a/src/components/container/RelativeActivityDayCoordinator/RelativeActivityDayCoordinator.tsx
+++ b/src/components/container/RelativeActivityDayCoordinator/RelativeActivityDayCoordinator.tsx
@@ -44,9 +44,9 @@ export default function RelativeActivityDateRangeCoordinator(props: RelativeActi
     };
 
     const dayRenderer = (dayKey: string): React.JSX.Element | null => {
-        if (!props.dataTypes.length) return null;
+        if (!props.dataTypes.length || !availableDataTypes?.length) return null;
 
-        let bars: SparkBarChartBar[] = props.dataTypes.map(dataType => {
+        let bars: SparkBarChartBar[] = availableDataTypes.map(dataType => {
             if (!relativeActivityData || !relativeActivityData[dataType.dailyDataType] || !relativeActivityData[dataType.dailyDataType][dayKey]) {
                 return { color: 'var(--mdhui-color-primary)', barFillPercent: 0 };
             }


### PR DESCRIPTION
## Overview

This fixes a bug with the relative activity day coordinator.  The intent was that if you do not have data for a particular data type, it would just not show up in this view; for instance we might include a bunch of data types from Fitbit, Garmin, Apple Health ,etc. but they would only show if you had data.  

However, the bars were just rendering based on props.datatypes rather than availableDataTypes, so it would awkwardly look like this:
<img width="1045" alt="Screenshot 2025-02-16 at 10 05 41 AM" src="https://github.com/user-attachments/assets/c2575b2d-49d1-43aa-874d-b43d1d62b812" />

This fixes it to use availableDataTypes 

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner