### PR TITLE
Fix the giant navigation bar

### DIFF
--- a/src/components/presentational/NavigationBar/NavigationBar.css
+++ b/src/components/presentational/NavigationBar/NavigationBar.css
@@ -72,7 +72,7 @@
 }
 
 .mdhui-navigation-bar .children {
-    padding-top: 48px;
+    padding-top: 56px;
 }
 
 .mdhui-navigation-bar.mdhui-navigation-bar-compressed .children {

--- a/src/components/presentational/NavigationBar/NavigationBar.css
+++ b/src/components/presentational/NavigationBar/NavigationBar.css
@@ -72,7 +72,7 @@
 }
 
 .mdhui-navigation-bar .children {
-    padding-top: calc(56px + env(safe-area-inset-top, 0px));
+    padding-top: 48px;
 }
 
 .mdhui-navigation-bar.mdhui-navigation-bar-compressed .children {


### PR DESCRIPTION
## Overview

Another nav bar issue.

The nav bar children has safe area padding added to the top of it, which is redundant because it's already added to the navigation bar itself.  Ends up giving it a ton of extra space:
![IMG_3442](https://github.com/user-attachments/assets/e04c2b06-0bc2-4d39-b2f0-71052072e741)

This removes that extra padding.  I think this mostly affects the EHR views as they follow this pattern.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [x] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner