### PR TITLE
Fix: Make device connection text more generic

### DIFF
--- a/src/helpers/strings-de.ts
+++ b/src/helpers/strings-de.ts
@@ -78,7 +78,7 @@ let strings: { [key: string]: string } = {
     "external-account-reconnect": "Erneut verbinden",
     "external-account-refresh": "Aktualisieren",
     "external-account-remove": "Entfernen",
-    "device-data-no-data": "Wenn Sie Apple Health, Google Fit, Fitbit oder Garmin verbunden haben, kommen Sie später zurück, um Ihre Daten anzuzeigen.",
+    "device-data-no-data": "Wenn Sie Ihr Gerät angeschlossen haben, kommen Sie später zurück, um Ihre Daten anzuzeigen.",
     "no-notifications-received": "Keine Benachrichtigungen erhalten",
     "next-button-text": "Weiter",
     "lab-results-title": "Laborergebnisse",

--- a/src/helpers/strings-en.ts
+++ b/src/helpers/strings-en.ts
@@ -78,7 +78,7 @@
     "external-account-reconnect": "Reconnect",
     "external-account-refresh": "Refresh",
     "external-account-remove": "Remove",
-    "device-data-no-data": "If you have connected Apple Health, Google Fit, Fitbit, or Garmin, check back later to view your data.",
+    "device-data-no-data": "If you have connected your device, check back later to view your data.",
     "no-notifications-received": "No notifications received",
     "next-button-text": "Next",
     "lab-results-title": "Lab Results",

--- a/src/helpers/strings-es.ts
+++ b/src/helpers/strings-es.ts
@@ -78,7 +78,7 @@
     "external-account-reconnect": "Volver a conectar",
     "external-account-refresh": "Actualizar",
     "external-account-remove": "Eliminar",
-    "device-data-no-data": "Si ha conectado Apple Health, Google Fit, Fitbit o Garmin, vuelva más tarde para ver sus datos.",
+    "device-data-no-data": "Si ha conectado tu dispositivo, vuelva más tarde para ver sus datos.",
     "no-notifications-received": "No se recibieron notificaciones.",
     "next-button-text": "Siguiente",
     "lab-results-title": "Resultados de laboratorio",

--- a/src/helpers/strings-fr.ts
+++ b/src/helpers/strings-fr.ts
@@ -78,7 +78,7 @@ let strings: { [key: string]: string } = {
     "external-account-reconnect": "Reconnecter",
     "external-account-refresh": "Actualiser",
     "external-account-remove": "Supprimer",
-    "device-data-no-data": "Si vous avez connecté Apple Health, Google Fit, Fitbit ou Garmin, revenez plus tard pour consulter vos données.",
+    "device-data-no-data": "Si vous avez connecté votre appareil, revenez plus tard pour consulter vos données.",
     "no-notifications-received": "Aucune notification reçue",
     "next-button-text": "Suivant",
     "lab-results-title": "Résultats de laboratoire",

--- a/src/helpers/strings-it.ts
+++ b/src/helpers/strings-it.ts
@@ -78,7 +78,7 @@ let strings: { [key: string]: string } = {
     "external-account-reconnect": "Riconnetti",
     "external-account-refresh": "Aggiorna",
     "external-account-remove": "Rimuovi",
-    "device-data-no-data": "Se hai collegato Apple Health, Google Fit, Fitbit o Garmin, torna più tardi per visualizzare i tuoi dati.",
+    "device-data-no-data": "Se hai collegato il tuo dispositivo, torna più tardi per visualizzare i tuoi dati.",
     "no-notifications-received": "Nessuna notifica ricevuta",
     "next-button-text": "Avanti",
     "lab-results-title": "Risultati di laboratorio",

--- a/src/helpers/strings-nl.ts
+++ b/src/helpers/strings-nl.ts
@@ -78,7 +78,7 @@ let strings: { [key: string]: string } = {
     "external-account-reconnect": "Opnieuw verbinden",
     "external-account-refresh": "Vernieuwen",
     "external-account-remove": "Verwijderen",
-    "device-data-no-data": "Als u Apple Health, Google Fit, Fitbit of Garmin hebt aangesloten, kom dan later terug om uw gegevens te bekijken.",
+    "device-data-no-data": "Als u uw apparaat hebt aangesloten, kom dan later terug om uw gegevens te bekijken.",
     "no-notifications-received": "Geen meldingen ontvangen",
     "next-button-text": "Volgende",
     "lab-results-title": "Laboratoriumresultaten",

--- a/src/helpers/strings-pl.ts
+++ b/src/helpers/strings-pl.ts
@@ -78,7 +78,7 @@ let strings: { [key: string]: string } = {
     "external-account-reconnect": "Połącz ponownie",
     "external-account-refresh": "Odśwież",
     "external-account-remove": "Usuń",
-    "device-data-no-data": "Jeśli podłączyłeś Apple Health, Google Fit, Fitbit lub Garmin, wróć później, aby zobaczyć swoje dane.",
+    "device-data-no-data": "Jeśli podłączyłeś swoje urządzenie, wróć później, aby zobaczyć swoje dane.",
     "no-notifications-received": "Nie otrzymano żadnych powiadomień",
     "next-button-text": "Dalej",
     "lab-results-title": "Wyniki badań laboratoryjnych",

--- a/src/helpers/strings-pt.ts
+++ b/src/helpers/strings-pt.ts
@@ -78,7 +78,7 @@ let strings: { [key: string]: string } = {
     "external-account-reconnect": "Reconectar",
     "external-account-refresh": "Atualizar",
     "external-account-remove": "Remover",
-    "device-data-no-data": "Se você conectou o Apple Health, Google Fit, Fitbit ou Garmin, volte mais tarde para ver seus dados.",
+    "device-data-no-data": "Se você conectou seu dispositivo, volte mais tarde para ver seus dados.",
     "no-notifications-received": "Nenhuma notificação recebida",
     "next-button-text": "Próximo",
     "lab-results-title": "Resultados de laboratório",


### PR DESCRIPTION
## Overview
The Default Device Data Tab (in view library 1) has a little blurb about connecting devices. To avoid confusion the text should be made generic so that if a device type isn't turned on for a project, it wouldn't confuse a participant

Issue: https://github.com/CareEvolution/Product/issues/476

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner