### PR TITLE
Fix MicroTrend Grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.69.0",
+  "version": "2.69.1-FixTrendGrid.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.69.0",
+      "version": "2.69.1-FixTrendGrid.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.69.0",
+  "version": "2.69.1-FixTrendGrid.0",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/presentational/Grid/Grid.css
+++ b/src/components/presentational/Grid/Grid.css
@@ -13,15 +13,10 @@
     flex-shrink: 0;
 }
 
+.mdhui-grid .mdhui-grid-column.mdhui-card {
+    margin: 0;
+}
+
 .mdhui-grid .mdhui-grid-column:empty {
     display: none;
-}
-
-/* If there is only an empty card and no other non-empty elements in the column, hide the column */
-.mdhui-grid .mdhui-grid-column:has(> .mdhui-card:empty):not(:has(> *:not(:empty))) {
-    display: none;
-}
-
-.mdhui-grid .mdhui-grid-column>.mdhui-card {
-    margin: 0;
 }

--- a/src/components/presentational/Grid/Grid.stories.tsx
+++ b/src/components/presentational/Grid/Grid.stories.tsx
@@ -112,71 +112,55 @@ export const DailyDataGoals = {
 let trendGrid: GridProps = {
     children: [
         <>
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend previewState="default" dataType={{
-                        dailyDataType: DailyDataType.Steps,
-                        color: "rgba(255, 166, 102, 1)"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend previewState="default" dataType={{
+                    dailyDataType: DailyDataType.Steps,
+                    color: "rgba(255, 166, 102, 1)"
+                }} />
             </Grid.Column>
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend previewState="default" dataType={{
-                        dailyDataType: DailyDataType.SleepMinutes,
-                        color: "rgba(74, 144, 226, 1)"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend previewState="default" dataType={{
+                    dailyDataType: DailyDataType.SleepMinutes,
+                    color: "rgba(74, 144, 226, 1)"
+                }} />
             </Grid.Column>
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend previewState="default" dataType={{
-                        label: "Air Quality",
-                        dailyDataType: DailyDataType.HomeAirQuality,
-                        color: "rgb(53, 166, 160)"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend previewState="default" dataType={{
+                    label: "Air Quality",
+                    dailyDataType: DailyDataType.HomeAirQuality,
+                    color: "rgb(53, 166, 160)"
+                }} />
             </Grid.Column>
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend previewState="default" dataType={{
-                        dailyDataType: DailyDataType.RestingHeartRate,
-                        color: "#e35c33"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend previewState="default" dataType={{
+                    dailyDataType: DailyDataType.RestingHeartRate,
+                    color: "#e35c33"
+                }} />
             </Grid.Column>
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend previewState="default" dataType={{
-                        dailyDataType: DailyDataType.RestingHeartRate,
-                        color: "#e35c33"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend previewState="default" dataType={{
+                    dailyDataType: DailyDataType.RestingHeartRate,
+                    color: "#e35c33"
+                }} />
             </Grid.Column>
             {/* Preview state not specified on purpose to ensure the grid collapses correctly */}
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend dataType={{
-                        dailyDataType: DailyDataType.RestingHeartRate,
-                        color: "#e35c33"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend dataType={{
+                    dailyDataType: DailyDataType.RestingHeartRate,
+                    color: "#e35c33"
+                }} />
             </Grid.Column>
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend dataType={{
-                        dailyDataType: DailyDataType.RestingHeartRate,
-                        color: "#e35c33"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend dataType={{
+                    dailyDataType: DailyDataType.RestingHeartRate,
+                    color: "#e35c33"
+                }} />
             </Grid.Column>
-            <Grid.Column span={6}>
-                <Card>
-                    <MicroTrend previewState="default" dataType={{
-                        dailyDataType: DailyDataType.RestingHeartRate,
-                        color: "#e35c33"
-                    }} />
-                </Card>
+            <Grid.Column span={6} variant="card">
+                <MicroTrend previewState="default" dataType={{
+                    dailyDataType: DailyDataType.RestingHeartRate,
+                    color: "#e35c33"
+                }} />
             </Grid.Column>
         </>
     ],

--- a/src/components/presentational/Grid/Grid.stories.tsx
+++ b/src/components/presentational/Grid/Grid.stories.tsx
@@ -23,22 +23,20 @@ const render = (args: GridProps) => <Layout colorScheme='auto'>
 
 
 let defaultProps: GridProps = {
-    children: [
-        <>
-            <Grid.Column span={1}>1</Grid.Column>
-            <Grid.Column span={1}>2</Grid.Column>
-            <Grid.Column span={1}>3</Grid.Column>
-            <Grid.Column span={1}>4</Grid.Column>
-            <Grid.Column span={1}>5</Grid.Column>
-            <Grid.Column span={1}>6</Grid.Column>
-            <Grid.Column span={1}>7</Grid.Column>
-            <Grid.Column span={1}>8</Grid.Column>
-            <Grid.Column span={1}>9</Grid.Column>
-            <Grid.Column span={1}>10</Grid.Column>
-            <Grid.Column span={1}>11</Grid.Column>
-            <Grid.Column span={1}>12</Grid.Column>
-        </>
-    ]
+    children: <>
+        <Grid.Column span={1}>1</Grid.Column>
+        <Grid.Column span={1}>2</Grid.Column>
+        <Grid.Column span={1}>3</Grid.Column>
+        <Grid.Column span={1}>4</Grid.Column>
+        <Grid.Column span={1}>5</Grid.Column>
+        <Grid.Column span={1}>6</Grid.Column>
+        <Grid.Column span={1}>7</Grid.Column>
+        <Grid.Column span={1}>8</Grid.Column>
+        <Grid.Column span={1}>9</Grid.Column>
+        <Grid.Column span={1}>10</Grid.Column>
+        <Grid.Column span={1}>11</Grid.Column>
+        <Grid.Column span={1}>12</Grid.Column>
+    </>
 }
 
 export const Numbers = {
@@ -47,58 +45,56 @@ export const Numbers = {
 };
 
 let dailyDataGoals: GridProps = {
-    children: [
-        <>
-            <Grid.Column span={6}>
-                <DailyDataGoal
-                    previewState="Default"
-                    goal={1}
-                    dailyDataType={DailyDataType.FitbitSleepMinutes}
-                    title="Worn to Sleep"
-                    subtitle="200 points"
-                    messages={[
-                        {
-                            threshold: 0,
-                            message: "No points yet"
-                        },
-                        {
-                            threshold: 1,
-                            message: "Complete!"
-                        }
-                    ]} />
-            </Grid.Column>
-            <Grid.Column span={6}>
-                <DailyDataGoal
-                    previewState="Default"
-                    goal={600}
-                    dailyDataType={DailyDataType.FitbitWearMinutes}
-                    title="Worn 10 Hours"
-                    subtitle="100 points"
-                    messages={[
-                        {
-                            threshold: 0,
-                            message: "No points yet"
-                        },
-                        {
-                            threshold: 150,
-                            message: "Keep going!"
-                        },
-                        {
-                            threshold: 300,
-                            message: "Halfway there!"
-                        },
-                        {
-                            threshold: 450,
-                            message: "Almost there!"
-                        },
-                        {
-                            threshold: 600,
-                            message: "Complete!"
-                        }
-                    ]} />
-            </Grid.Column>
-        </>
-    ],
+    children: <>
+        <Grid.Column span={6}>
+            <DailyDataGoal
+                previewState="Default"
+                goal={1}
+                dailyDataType={DailyDataType.FitbitSleepMinutes}
+                title="Worn to Sleep"
+                subtitle="200 points"
+                messages={[
+                    {
+                        threshold: 0,
+                        message: "No points yet"
+                    },
+                    {
+                        threshold: 1,
+                        message: "Complete!"
+                    }
+                ]} />
+        </Grid.Column>
+        <Grid.Column span={6}>
+            <DailyDataGoal
+                previewState="Default"
+                goal={600}
+                dailyDataType={DailyDataType.FitbitWearMinutes}
+                title="Worn 10 Hours"
+                subtitle="100 points"
+                messages={[
+                    {
+                        threshold: 0,
+                        message: "No points yet"
+                    },
+                    {
+                        threshold: 150,
+                        message: "Keep going!"
+                    },
+                    {
+                        threshold: 300,
+                        message: "Halfway there!"
+                    },
+                    {
+                        threshold: 450,
+                        message: "Almost there!"
+                    },
+                    {
+                        threshold: 600,
+                        message: "Complete!"
+                    }
+                ]} />
+        </Grid.Column>
+    </>,
     style: {
         margin: "16px"
     }
@@ -110,60 +106,59 @@ export const DailyDataGoals = {
 };
 
 let trendGrid: GridProps = {
-    children: [
-        <>
-            <Grid.Column span={6} variant="card">
-                <MicroTrend previewState="default" dataType={{
-                    dailyDataType: DailyDataType.Steps,
-                    color: "rgba(255, 166, 102, 1)"
-                }} />
-            </Grid.Column>
-            <Grid.Column span={6} variant="card">
-                <MicroTrend previewState="default" dataType={{
-                    dailyDataType: DailyDataType.SleepMinutes,
-                    color: "rgba(74, 144, 226, 1)"
-                }} />
-            </Grid.Column>
-            <Grid.Column span={6} variant="card">
-                <MicroTrend previewState="default" dataType={{
-                    label: "Air Quality",
-                    dailyDataType: DailyDataType.HomeAirQuality,
-                    color: "rgb(53, 166, 160)"
-                }} />
-            </Grid.Column>
-            <Grid.Column span={6} variant="card">
-                <MicroTrend previewState="default" dataType={{
-                    dailyDataType: DailyDataType.RestingHeartRate,
-                    color: "#e35c33"
-                }} />
-            </Grid.Column>
-            <Grid.Column span={6} variant="card">
-                <MicroTrend previewState="default" dataType={{
-                    dailyDataType: DailyDataType.RestingHeartRate,
-                    color: "#e35c33"
-                }} />
-            </Grid.Column>
-            {/* Preview state not specified on purpose to ensure the grid collapses correctly */}
-            <Grid.Column span={6} variant="card">
-                <MicroTrend dataType={{
-                    dailyDataType: DailyDataType.RestingHeartRate,
-                    color: "#e35c33"
-                }} />
-            </Grid.Column>
-            <Grid.Column span={6} variant="card">
-                <MicroTrend dataType={{
-                    dailyDataType: DailyDataType.RestingHeartRate,
-                    color: "#e35c33"
-                }} />
-            </Grid.Column>
-            <Grid.Column span={6} variant="card">
-                <MicroTrend previewState="default" dataType={{
-                    dailyDataType: DailyDataType.RestingHeartRate,
-                    color: "#e35c33"
-                }} />
-            </Grid.Column>
-        </>
-    ],
+    children: <>
+        <Grid.Column span={6} variant="card">
+            <MicroTrend previewState="default" dataType={{
+                dailyDataType: DailyDataType.Steps,
+                color: "rgba(255, 166, 102, 1)"
+            }} />
+        </Grid.Column>
+        <Grid.Column span={6} variant="card">
+            <MicroTrend previewState="default" dataType={{
+                dailyDataType: DailyDataType.SleepMinutes,
+                color: "rgba(74, 144, 226, 1)"
+            }} />
+        </Grid.Column>
+        <Grid.Column span={6} variant="card">
+            <MicroTrend previewState="default" dataType={{
+                label: "Air Quality",
+                dailyDataType: DailyDataType.HomeAirQuality,
+                color: "rgb(53, 166, 160)"
+            }} />
+        </Grid.Column>
+        <Grid.Column span={6} variant="card">
+            <MicroTrend previewState="default" dataType={{
+                dailyDataType: DailyDataType.RestingHeartRate,
+                color: "#e35c33"
+            }} />
+        </Grid.Column>
+        <Grid.Column span={6} variant="card">
+            <MicroTrend previewState="default" dataType={{
+                dailyDataType: DailyDataType.RestingHeartRate,
+                color: "#e35c33"
+            }} />
+        </Grid.Column>
+        {/* Preview state not specified on purpose to ensure the grid collapses correctly */}
+        <Grid.Column span={6} variant="card">
+            <MicroTrend dataType={{
+                dailyDataType: DailyDataType.RestingHeartRate,
+                color: "#e35c33"
+            }} />
+        </Grid.Column>
+        <Grid.Column span={6} variant="card">
+            <MicroTrend dataType={{
+                dailyDataType: DailyDataType.RestingHeartRate,
+                color: "#e35c33"
+            }} />
+        </Grid.Column>
+        <Grid.Column span={6} variant="card">
+            <MicroTrend previewState="default" dataType={{
+                dailyDataType: DailyDataType.RestingHeartRate,
+                color: "#e35c33"
+            }} />
+        </Grid.Column>
+    </>
+    ,
     gap: 16,
     style: {
         marginLeft: "16px",

--- a/src/components/presentational/Grid/Grid.tsx
+++ b/src/components/presentational/Grid/Grid.tsx
@@ -1,5 +1,6 @@
 import React, { createContext } from 'react';
 import "./Grid.css"
+import Card from '../Card';
 
 export interface GridProps {
     children?: React.ReactNode;
@@ -12,6 +13,7 @@ export interface GridProps {
 export interface GridColumnProps {
     children?: React.ReactNode;
     span: number;
+    variant?: "default" | "card";
 }
 
 export interface GridContext {
@@ -40,11 +42,16 @@ export function Grid(props: GridProps) {
 
 Grid.Column = function (props: GridColumnProps) {
     if (!props.children) {
-		return null;
-	}
+        return null;
+    }
 
     let widthPercent = props.span / 12 * 100;
     let gridContext = React.useContext(GridContext);
     let width = `calc(${widthPercent}% - ${gridContext.gap}px)`;
-    return <div className="mdhui-grid-column" style={{ width: width }}>{props.children}</div>
+
+    if (props.variant === "card") {
+        return <Card className="mdhui-grid-column" style={{ width: width }}>{props.children}</Card>
+    } else {
+        return <div className="mdhui-grid-column" style={{ width: width }}>{props.children}</div>
+    }
 }


### PR DESCRIPTION
## Overview

Turns out my fancy CSS rules for hiding grid columns if there's just an empty card child causes some major issues in iOS safari.

Unfortunately it looks like there's not much of an elegant solution to the whole "hide an element if it's children are hidden" problem, without implementing a whole lot of "onVisible" props or something.  I would definitely like to avoid that.

So this tackles it a bit of a different way by having a "Card" variant for "GridColumn".  This means that Grid columns themselves can just render as cards, which of course already hide themselves if they are empty via the tried and true ```:empty``` css selector

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner