### PR TITLE
Adjust locale selection.

### DIFF
--- a/__tests__/helpers/locale/locale.test.ts
+++ b/__tests__/helpers/locale/locale.test.ts
@@ -31,6 +31,12 @@ describe('Locale Tests', () => {
             const result = getIntlLocale();
             expect(result).toBe("es-co");
         });
+        it('Should not use browser locale if it is set to a different language.', () => {
+            mockMDHLanguage = "en";
+            jest.spyOn(navigator, 'language', 'get').mockReturnValue('es-CO');
+            const result = getIntlLocale();
+            expect(result).toBe("en");
+        });
         it('Should return base language if no browser language.', () => {
             mockMDHLanguage = "en";
             jest.spyOn(navigator, 'language', 'get').mockReturnValue('');
@@ -68,11 +74,11 @@ describe('Locale Tests', () => {
             const result = getDateLocale();
             expect(result).toBe(enUS);
         });     
-        it('Should use browser locale even if it set to a different (supported) language.', () => {
+        it('Should not use browser locale if it is set to a different language.', () => {
             mockMDHLanguage = "en";
             jest.spyOn(navigator, 'language', 'get').mockReturnValue('es-es');
             const result = getDateLocale();
-            expect(result).toBe(es);
+            expect(result).toBe(enUS);
         });
         it('Should use base language if browser is set to an unsupported language.', () => {
             mockMDHLanguage = "en";

--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -9,23 +9,21 @@ import { toDate } from "./date-helpers";
 //
 // Priority for locale selection:
 // 1. If MDH locale has a country code (like "en-AU") use that.
-// 2. If MDH locale does NOT have a locale code (like "en"), use the browser locale. 
-//    The browser often has more locale specificity than MDH.
+// 2. If MDH locale does NOT have a locale code (like "en"), use the browser locale
+//    as long as the language code matches. The browser often has more locale
+//    specificity than MDH.
 // 3. Fall back to the original language string.
 export function getIntlLocale() : string {
     // Intl libraries don't support underscores, so it needs "en-US" not "en_US".
     const lang =`${MyDataHelps.getCurrentLanguage()}`.replace("_", "-");
-
     if (lang.length < 2) return "en-us";
 
-    let countryCode = getCountryCodeFromIso(lang);
-    let intlLocale;
-    
-    if (countryCode) {
-        intlLocale = lang;
-    }
-    else {
-        intlLocale = navigator?.language || lang;
+    const languageCode = getLanguageCodeFromIso(lang);
+    const countryCode = getCountryCodeFromIso(lang);
+
+    let intlLocale = lang;
+    if (!countryCode && navigator?.language && getLanguageCodeFromIso(navigator.language) === languageCode) {
+        intlLocale = navigator.language;
     }
     return intlLocale.toLowerCase();
 }
@@ -40,18 +38,18 @@ export function getIntlLocale() : string {
 // 1. If MDH language has a country code (like "en-AU") use it to
 //    select the appropriate locale for that language.
 // 2. If MDH language does NOT have a country code (like "en"), use the browser language
-//    to determine locale. The browser often has more locale specificity than MDH.
+//    to determine locale as long as the language code matches. The browser often has
+//    more locale specificity than MDH.
 // 3. If neither MDH nor browser specifies a locale, use the
 //    default locale based on the current language.
 export function getDateLocale(): Locale {
     const lang = MyDataHelps.getCurrentLanguage();
     if (lang.length < 2) return enUS;
 
-    let languageCode = lang.toLowerCase().slice(0,2);
-
+    const languageCode = getLanguageCodeFromIso(lang);
     let countryCode = getCountryCodeFromIso(lang);
-    if (!countryCode && navigator?.language) {
-        languageCode = getLanguageCodeFromIso(navigator.language) || "en";
+
+    if (!countryCode && navigator?.language && getLanguageCodeFromIso(navigator.language) === languageCode) {
         countryCode = getCountryCodeFromIso(navigator.language);
     }
 


### PR DESCRIPTION
## Overview

This branch adjusts how locales are selected when formatting numbers, dates, etc.

Specifically, it adjusts the logic such that locale specificity can only be improved by using the browser's language setting when that language's code matches the MDH language code.

Without this change, when the MDH language is set to something like `de` (German), it gets ignored during locale selection if the browser is not also set to some German variant.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation

- N/A