### PR TITLE
Add meal created and last modified dates.

### DIFF
--- a/__tests__/helpers/glucose-and-meals/meals.test.ts
+++ b/__tests__/helpers/glucose-and-meals/meals.test.ts
@@ -46,9 +46,9 @@ describe('Meals - Helper Function Tests', () => {
         };
 
         it('Should return all meals for the given date in ascending timestamp order.', async () => {
-            const meal1: Meal = { id: uuid(), timestamp: add(today, { hours: 12 }), type: 'meal', description: 'Some tasty food!' };
+            const meal1: Meal = { id: uuid(), timestamp: add(today, { hours: 12 }), type: 'meal', description: 'Some tasty food!', created: add(today, { hours: 13 }) };
             const meal2: Meal = { id: uuid(), timestamp: add(today, { hours: 11 }), type: 'meal', archiveTimestamp: add(today, { hours: 11, minutes: 30 }) };
-            const meal3: Meal = { id: uuid(), timestamp: add(today, { hours: 10 }), type: 'meal', hasImage: true };
+            const meal3: Meal = { id: uuid(), timestamp: add(today, { hours: 10 }), type: 'meal', hasImage: true, lastModified: add(today, { hours: 16 }) };
 
             setupMeals([meal1, meal2, meal3]);
 

--- a/src/components/container/MealEditor/MealEditor.tsx
+++ b/src/components/container/MealEditor/MealEditor.tsx
@@ -119,6 +119,7 @@ export default function MealEditor(props: MealEditorProps) {
         }
 
         mealToEdit!.description = mealToEdit!.description?.trim();
+        mealToEdit!.lastModified = new Date();
 
         const otherMeals = allMeals!.filter(meal => meal.id !== mealToEdit!.id);
         const updatedMeals = [...otherMeals, mealToEdit!].sort(timestampSortAsc);

--- a/src/components/presentational/MealButtons/MealButtons.tsx
+++ b/src/components/presentational/MealButtons/MealButtons.tsx
@@ -4,7 +4,7 @@ import { Button, DateRangeContext, TextBlock } from '../index';
 import { MealContext } from '../../container';
 import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
 import { faBurger, faCookie, faWineBottle } from '@fortawesome/free-solid-svg-icons';
-import { getMealTypeDisplayText, MealType, prepareMealForEditing } from '../../../helpers';
+import { getMealTypeDisplayText, Meal, MealType, prepareMealForEditing } from '../../../helpers';
 import { v4 as uuid } from 'uuid';
 import { add, startOfDay } from 'date-fns';
 
@@ -37,10 +37,12 @@ export default function MealButtons(props: MealButtonsProps) {
         }
 
         let now = new Date();
-        const meal = {
+        const meal: Meal = {
             id: uuid(),
             timestamp: dateRangeContext ? add(startOfDay(dateRangeContext.intervalStart), { hours: now.getHours(), minutes: now.getMinutes() }) : now,
-            type: type
+            type: type,
+            created: now,
+            lastModified: now
         };
         mealContext.addMeal(meal).then(() => {
             if (props.autoLaunchEditor && props.onEditMeal) {

--- a/src/helpers/glucose-and-meals/meals.ts
+++ b/src/helpers/glucose-and-meals/meals.ts
@@ -12,6 +12,8 @@ interface SerializedMeal {
     description?: string;
     hasImage?: boolean;
     archiveTimestamp?: string;
+    created?: string;
+    lastModified?: string;
 }
 
 interface SerializedMealReference {
@@ -104,7 +106,9 @@ function toMeal(serializedMeal: SerializedMeal): Meal {
         type: serializedMeal.type as MealType,
         description: serializedMeal.description,
         hasImage: serializedMeal.hasImage,
-        archiveTimestamp: serializedMeal.archiveTimestamp ? parseISO(serializedMeal.archiveTimestamp) : undefined
+        archiveTimestamp: serializedMeal.archiveTimestamp ? parseISO(serializedMeal.archiveTimestamp) : undefined,
+        created: serializedMeal.created ? parseISO(serializedMeal.created) : undefined,
+        lastModified: serializedMeal.lastModified ? parseISO(serializedMeal.lastModified) : undefined
     };
 }
 

--- a/src/helpers/glucose-and-meals/types.ts
+++ b/src/helpers/glucose-and-meals/types.ts
@@ -29,6 +29,8 @@ export interface Meal {
     description?: string;
     hasImage?: boolean;
     archiveTimestamp?: Date;
+    created?: Date;
+    lastModified?: Date;
 }
 
 export interface MealReference {


### PR DESCRIPTION
## Overview

This branch adds `created` and `lastModified` dates to meals.  These dates are not being rendered anywhere in the existing meal components, but we have a use case that would like to have this information downstream.

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just adding a couple more date fields to the existing Meals model.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [x] [MyDataHelps website](mydatahelps.org)

### Documentation

- N/A