### PR TITLE
Add Omron to connect devices menu by default

### DIFF
--- a/src/components/container/ConnectDevicesMenu/ConnectDevicesMenu.tsx
+++ b/src/components/container/ConnectDevicesMenu/ConnectDevicesMenu.tsx
@@ -170,7 +170,7 @@ export default function (props: ConnectDevicesMenuProps) {
     if (platform == "iOS" || !settings?.healthConnectEnabled) {
         accountTypes = accountTypes.filter(a => a != "HealthConnect");
     }
-    if ((!settings?.airQualityEnabled && !settings?.weatherEnabled) || !props.postalCodeSurveyName) {
+    if ((!settings?.airQualityEnabled && !settings?.weatherEnabled) || !props.postalCodeSurveyName ) { 
         accountTypes = accountTypes.filter(a => a != "Environmental");
     }
 
@@ -252,7 +252,7 @@ export default function (props: ConnectDevicesMenuProps) {
             return null;
         }
 
-        return <EnvironmentalMenuItem settings={settings!} participantInfo={participantInfo!} postalCodeSurveyName={props.postalCodeSurveyName!} />
+        return <EnvironmentalMenuItem settings={settings!} participantInfo={participantInfo!} postalCodeSurveyName={props.postalCodeSurveyName!}/>
     }
 
     let title = props.title || language("connect-devices-title");
@@ -443,27 +443,27 @@ function AppleHealthMenuItem(props: AppleHealthMenuItemProps) {
     </div>;
 }
 
-function EnvironmentalMenuItem(props: { settings: DataCollectionSettings, participantInfo: ParticipantInfo, postalCodeSurveyName: string }) {
+function EnvironmentalMenuItem(props: { settings: DataCollectionSettings, participantInfo: ParticipantInfo, postalCodeSurveyName: string }){
     let action = () => {
         MyDataHelps.startSurvey(props.postalCodeSurveyName);
     }
 
-    const postalCodeCustomFields = Object.keys(props.participantInfo ? props.participantInfo.customFields : {}).filter((k) => k.endsWith('PostalCode'));
+    const postalCodeCustomFields = Object.keys(props.participantInfo ? props.participantInfo.customFields : {}).filter( (k) => k.endsWith('PostalCode'));
     const postalCodes = [...postalCodeCustomFields.map((cf) => props.participantInfo?.customFields[cf]), props.participantInfo?.demographics.postalCode];
-    var postalCode = postalCodes.filter((p) => !!p).slice(0, 3).join(', ');
-    if (postalCodes.length > 3) {
+    var postalCode = postalCodes.filter((p) => !!p).slice(0,3).join(', ');
+    if(postalCodes.length > 3) {
         postalCode = postalCode + ", ...";
     }
 
-    const indicator = postalCode ?
+    const indicator = postalCode ? 
         <div className="mdhui-connect-devices-menu-connect">{postalCode}</div> :
         <div className="mdhui-connect-devices-menu-connect">{language("setup")}</div>;
 
     const titleBits = [];
-    if (props.settings?.airQualityEnabled) {
+    if(props.settings?.airQualityEnabled) {
         titleBits.push('Air Quality');
     }
-    if (props.settings?.weatherEnabled) {
+    if(props.settings?.weatherEnabled) {
         titleBits.push('Weather');
     }
     const title = titleBits.join(" / ");
@@ -471,7 +471,7 @@ function EnvironmentalMenuItem(props: { settings: DataCollectionSettings, partic
     return (
         <div className="mdhui-connect-devices-menu-device">
             <Action onClick={action} indicator={indicator}>
-                <Title autosizeImage image={<FontAwesomeSvgIcon icon={faSun} color={"yellow"} />} order={4}>{title}</Title>
+                <Title autosizeImage image={<FontAwesomeSvgIcon icon={faSun} color={"yellow"}/>} order={4}>{title}</Title>
             </Action>
         </div>
     );

--- a/src/components/container/ConnectDevicesMenu/ConnectDevicesMenu.tsx
+++ b/src/components/container/ConnectDevicesMenu/ConnectDevicesMenu.tsx
@@ -148,12 +148,15 @@ export default function (props: ConnectDevicesMenuProps) {
         return null;
     }
 
-    let accountTypes = props.accountTypes || ["Fitbit", "Garmin", "Dexcom", "AppleHealth", "GoogleFit", "HealthConnect", "Environmental"];
+    let accountTypes = props.accountTypes || ["Fitbit", "Garmin", "Omron", "Dexcom", "AppleHealth", "GoogleFit", "HealthConnect", "Environmental"];
     if (!settings?.fitbitEnabled) {
         accountTypes = accountTypes.filter(a => a != "Fitbit");
     }
     if (!settings?.garminEnabled) {
         accountTypes = accountTypes.filter(a => a != "Garmin");
+    }
+    if (!settings?.omronEnabled) {
+        accountTypes = accountTypes.filter(a => a != "Omron");
     }
     if (!settings?.dexcomEnabled) {
         accountTypes = accountTypes.filter(a => a != "Dexcom");
@@ -167,7 +170,7 @@ export default function (props: ConnectDevicesMenuProps) {
     if (platform == "iOS" || !settings?.healthConnectEnabled) {
         accountTypes = accountTypes.filter(a => a != "HealthConnect");
     }
-    if ((!settings?.airQualityEnabled && !settings?.weatherEnabled) || !props.postalCodeSurveyName ) { 
+    if ((!settings?.airQualityEnabled && !settings?.weatherEnabled) || !props.postalCodeSurveyName) {
         accountTypes = accountTypes.filter(a => a != "Environmental");
     }
 
@@ -249,7 +252,7 @@ export default function (props: ConnectDevicesMenuProps) {
             return null;
         }
 
-        return <EnvironmentalMenuItem settings={settings!} participantInfo={participantInfo!} postalCodeSurveyName={props.postalCodeSurveyName!}/>
+        return <EnvironmentalMenuItem settings={settings!} participantInfo={participantInfo!} postalCodeSurveyName={props.postalCodeSurveyName!} />
     }
 
     let title = props.title || language("connect-devices-title");
@@ -440,27 +443,27 @@ function AppleHealthMenuItem(props: AppleHealthMenuItemProps) {
     </div>;
 }
 
-function EnvironmentalMenuItem(props: { settings: DataCollectionSettings, participantInfo: ParticipantInfo, postalCodeSurveyName: string }){
+function EnvironmentalMenuItem(props: { settings: DataCollectionSettings, participantInfo: ParticipantInfo, postalCodeSurveyName: string }) {
     let action = () => {
         MyDataHelps.startSurvey(props.postalCodeSurveyName);
     }
 
-    const postalCodeCustomFields = Object.keys(props.participantInfo ? props.participantInfo.customFields : {}).filter( (k) => k.endsWith('PostalCode'));
+    const postalCodeCustomFields = Object.keys(props.participantInfo ? props.participantInfo.customFields : {}).filter((k) => k.endsWith('PostalCode'));
     const postalCodes = [...postalCodeCustomFields.map((cf) => props.participantInfo?.customFields[cf]), props.participantInfo?.demographics.postalCode];
-    var postalCode = postalCodes.filter((p) => !!p).slice(0,3).join(', ');
-    if(postalCodes.length > 3) {
+    var postalCode = postalCodes.filter((p) => !!p).slice(0, 3).join(', ');
+    if (postalCodes.length > 3) {
         postalCode = postalCode + ", ...";
     }
 
-    const indicator = postalCode ? 
+    const indicator = postalCode ?
         <div className="mdhui-connect-devices-menu-connect">{postalCode}</div> :
         <div className="mdhui-connect-devices-menu-connect">{language("setup")}</div>;
 
     const titleBits = [];
-    if(props.settings?.airQualityEnabled) {
+    if (props.settings?.airQualityEnabled) {
         titleBits.push('Air Quality');
     }
-    if(props.settings?.weatherEnabled) {
+    if (props.settings?.weatherEnabled) {
         titleBits.push('Weather');
     }
     const title = titleBits.join(" / ");
@@ -468,7 +471,7 @@ function EnvironmentalMenuItem(props: { settings: DataCollectionSettings, partic
     return (
         <div className="mdhui-connect-devices-menu-device">
             <Action onClick={action} indicator={indicator}>
-                <Title autosizeImage image={<FontAwesomeSvgIcon icon={faSun} color={"yellow"}/>} order={4}>{title}</Title>
+                <Title autosizeImage image={<FontAwesomeSvgIcon icon={faSun} color={"yellow"} />} order={4}>{title}</Title>
             </Action>
         </div>
     );


### PR DESCRIPTION
## Overview

Omron used to not have a feature flag so it operated weirdly and was only included in the connect devices menu when explicitly specified.

Now that it does, it can work consistently with fitbit, garmin, etc. so this does that

## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [ ] I have added relevant Storybook updates to this PR as well.
- [ ] If this feature requires a developer doc update, tag @CareEvolution/api-docs.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner