### PR TITLE
GlucoseChart: Updated handling of data gaps and partial data when meals are present/selected.

### DIFF
--- a/src/components/container/GlucoseChart/GlucoseChart.previewData.ts
+++ b/src/components/container/GlucoseChart/GlucoseChart.previewData.ts
@@ -1,6 +1,6 @@
 import { generateGlucose, generateSteps, Reading } from '../../../helpers';
 
-export type GlucoseChartPreviewState = 'no data' | 'with data';
+export type GlucoseChartPreviewState = 'no data' | 'with gap in data' | 'with partial data' | 'with data';
 
 export interface GlucoseChartPreviewData {
     glucose: Reading[];
@@ -14,6 +14,20 @@ export const previewData = async (previewState: GlucoseChartPreviewState, date: 
             glucose: [],
             steps: [],
             sleepMinutes: undefined
+        };
+    }
+    if (previewState === 'with gap in data') {
+        return {
+            glucose: (await generateGlucose(date)).filter(reading => reading.timestamp.getHours() <= 16 || reading.timestamp.getHours() >= 19),
+            steps: generateSteps(date),
+            sleepMinutes: 385 + (Math.random() * 60)
+        };
+    }
+    if (previewState === 'with partial data') {
+        return {
+            glucose: (await generateGlucose(date)).filter(reading => reading.timestamp.getHours() <= 16),
+            steps: generateSteps(date),
+            sleepMinutes: 385 + (Math.random() * 60)
         };
     }
     if (previewState === 'with data') {

--- a/src/components/container/GlucoseChart/GlucoseChart.stories.tsx
+++ b/src/components/container/GlucoseChart/GlucoseChart.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import GlucoseChart, { GlucoseChartProps } from './GlucoseChart';
-import { Card, DateRangeTitle, Layout } from '../../presentational';
+import { Card, DateRangeTitle, Layout, MealLog } from '../../presentational';
 import { GlucoseChartPreviewState } from './GlucoseChart.previewData';
 import { GlucoseDayCoordinator, MealCoordinator } from '../../container';
+import { noop } from '../../../helpers/functions';
 
 export default {
     title: 'Container/GlucoseChart',
@@ -30,6 +31,9 @@ const render = (args: GlucoseChartStoryArgs) => {
                     <Card>
                         <GlucoseChart {...args} previewState={args.state !== 'live' ? args.state as GlucoseChartPreviewState : undefined} />
                     </Card>
+                    <Card>
+                        <MealLog preview={true} showMealNumbers={true} highlightSelectedMeal={true} onEditMeal={noop} />
+                    </Card>
                 </MealCoordinator>
             }
         </GlucoseDayCoordinator>
@@ -53,7 +57,7 @@ export const Default = {
         state: {
             name: 'state',
             control: 'radio',
-            options: ['loading', 'no data', 'with data', 'live']
+            options: ['loading', 'no data', 'with gap in data', 'with partial data', 'with data', 'live']
         },
         withMeals: {
             name: 'with meals'

--- a/src/components/container/MealCoordinator/MealCoordinator.previewData.ts
+++ b/src/components/container/MealCoordinator/MealCoordinator.previewData.ts
@@ -27,7 +27,7 @@ export const createPreviewData = (previewState: MealCoordinatorPreviewState, dat
                 type: 'snack'
             }, {
                 id: uuid(),
-                timestamp: createDate(date, 9, 25),
+                timestamp: createDate(date, 9, 45),
                 type: 'meal',
                 description: 'Three pancakes, two eggs, hashbrowns, three strips of bacon, and a piece of toast.'
             }, {


### PR DESCRIPTION
## Overview

This branch fixes a couple issues with the `GlucoseChart` related to partial data when meals are present.

Scenario:
- You have some glucose data for the morning hours only, but logged a meal in the afternoon. 

The issues:
- The chart was connecting the graphed line from the final glucose reading over to the meal.  This was because the chart was using a single series to represent both the glucose readings and the meals.  As such, it treated the meal as if it were another glucose reading, which is incorrect.
- If you selected the afternoon meal on the meal log to zoom in on the glucose chart, it would crash because no glucose readings were present during the zoomed time period in order to compute the meal's vertical position.

Testing:
- I have updated the `GlucoseChart` story so you can test these scenarios there.
- Select the "with partial data" state.
- Verify that the line does not extend over to meals 3 and 4.
- Click meal 3 or meal 4 to zoom in.  Verify that it does not crash.
- You can also select the "with gap in data" state, select meal 3, and verify that it zooms without crashing with a partial gap in the data.
## Security

REMINDER: All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

- No security risk.  Just adjusting the chart rendering to gracefully handle data gaps and partial data when meals are present.

## Checklist

### Testing
- [ ] MyDataHelps iOS app
- [ ] MyDataHelps Android app
- [ ] [MyDataHelps website](mydatahelps.org)

### Documentation
- [x] I have added relevant Storybook updates to this PR as well.