### PR TITLE
Update add provider URL with launch of MDH help center

### DIFF
--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -38,7 +38,7 @@ export default function ProviderSearch(props: ProviderSearchProps) {
     const [searchString, _setSearchString] = useState("");
     const [currentPage, setCurrentPage] = useState(0);
     const [totalResults, setTotalResults] = useState(0);
-    const addNewProviderUrl = "https://support.mydatahelps.org/hc/en-us/requests/new?ticket_form_id=34288897775635";
+    const addNewProviderUrl = "https://help.mydatahelps.org/hc/en-us/requests/new?ticket_form_id=34288897775635";
 
     const searchStringRef = useRef(searchString);
     const setSearchString = (data: string) => {


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

Resolves https://github.com/CareEvolution/MyDataHelpsUI/issues/440.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

N/A - changing a URL to another static URL

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

- This is slightly tricky to test since the MDH.js function it calls doesn't work in Storybook.  However a developer can breakpoint the `requestProviderAction` function and verify that the new URL is being passed to it.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
