### PR TITLE
Fix issue with sleep V2 date parsing.

### DIFF
--- a/__tests__/helpers/time-range.test.ts
+++ b/__tests__/helpers/time-range.test.ts
@@ -27,14 +27,9 @@ describe('TimeRange - Helper Function Tests', () => {
     const deviceDataV2PointsFactory: DataPointFactory<DeviceDataV2Point> = {
         name: 'DeviceDataV2Point',
         create: (startDate: Date, observationDate: Date): DeviceDataV2Point => {
-            // Special formatting is used here to simulate the date and offset formats that will be present in V2 data points.
-            // For dates, the format needs to be an ISO 8601 date/time without a timezone offset (e.g. "2025-03-14T15:09:23").
-            // For offsets, the format needs to be an ISO 8601 timezone offset plus ":00" (e.g. "-05:00:00").
             return {
                 startDate: format(startDate, 'yyyy-MM-dd\'T\'HH:mm:ss'),
-                startDateOffset: format(startDate, 'xxx\':00\''),
-                observationDate: format(observationDate, 'yyyy-MM-dd\'T\'HH:mm:ss'),
-                observationDateOffset: format(observationDate, 'xxx\':00\'')
+                observationDate: format(observationDate, 'yyyy-MM-dd\'T\'HH:mm:ss')
             } as DeviceDataV2Point;
         }
     };

--- a/src/helpers/time-range.ts
+++ b/src/helpers/time-range.ts
@@ -71,8 +71,8 @@ function splitSampleIntoRanges(dataPoint: DeviceDataPoint | DeviceDataV2Point, o
         return [];
     }
 
-    const startDate = parseISO(applyOffsetToDate(dataPoint, 'startDate'));
-    const observationDate = parseISO(applyOffsetToDate(dataPoint, 'observationDate'));
+    const startDate = parseISO(dataPoint.startDate);
+    const observationDate = parseISO(dataPoint.observationDate);
 
     if (!isBefore(startDate, observationDate)) {
         return [];
@@ -100,16 +100,4 @@ function combineRanges(range1: TimeRange, range2: TimeRange): TimeRange {
         startTime: (range2.startTime < range1.startTime) ? range2.startTime : range1.startTime,
         endTime: (range2.endTime > range1.endTime) ? range2.endTime : range1.endTime
     };
-}
-
-function applyOffsetToDate(dataPoint: DeviceDataPoint | DeviceDataV2Point, datePropertyName: keyof DeviceDataPoint & keyof DeviceDataV2Point): string {
-    const dateStr = dataPoint[datePropertyName] as string;
-
-    const dateOffsetPropertyName = (datePropertyName + 'Offset') as keyof DeviceDataV2Point;
-    if (dataPoint.hasOwnProperty(dateOffsetPropertyName)) {
-        // The substring call here is to trim the offset values from "-05:00:00" to "-05:00" so they will parse correctly.
-        return dateStr + ((dataPoint as DeviceDataV2Point)[dateOffsetPropertyName]?.substring(0, 6) ?? '');
-    }
-
-    return dateStr;
 }


### PR DESCRIPTION
## Overview

This branch fixes an issue that I discovered while testing the latest VB upgrade.

I had recently updated the sleep de-duplication and overlap code to account for the V2 data and its date offsets.  However, there was a bug I missed with the parsing when the offset does not contain a sign (i.e. `00:00:00` rather than `-04:00:00`).

It was also brought to my attention recently that we should be ignoring the offsets from V2, since all of the dates are in local time, and that is how we want to chart/present them anyways.  As such, rather than attempting to fix the parsing logic here, I've just updated the code to ignore the V2 date offsets, which is the desired behavior.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just removing unnecessary date offset parsing that was causing an issue for some data.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [x] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)
- This is being tested via the latest VB upgrade PR.

DESCRIBE YOUR TEST PLAN

- Attempt to load V2 Fitbit sleep data using the `GlucoseChart` component.
- See that the sleep values render appropriately.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
