### PR TITLE
Fix dot clipping

### DIFF
--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -161,10 +161,10 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
     }
 
     const xAxisTicks = getXAxisTicks();
-    
-    if(props.data?.length === 1 && props.chartType === 'Bar'){
+
+    if (props.data?.length === 1 && props.chartType === 'Bar') {
         let currentPoint = new Date(props.data[0].timestamp);
-        let nextExpectedPoint = add(currentPoint, props.expectedDataInterval || {days: 1});
+        let nextExpectedPoint = add(currentPoint, props.expectedDataInterval || { days: 1 });
         dataToDisplay?.push({
             timestamp: nextExpectedPoint.getTime()
         });
@@ -226,6 +226,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                                             type="monotone"
                                             dataKey={dk}
                                             stroke={`url(#${gradientKey}${i})`}
+                                            dot={{ clipDot: false }}
                                             {...(props.options as MultiSeriesLineChartOptions)?.lineOptions}
                                         />
                                     )}


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

We have discovered a bug where the dots in line graphs on either end of the axis are being clipped

![image](https://github.com/user-attachments/assets/430bc850-5d00-4ad4-8e35-27d6254e0851)

This is related to the `allowDataOverflow` on the YAxis property. @ajmenca found a [PR that fixed the issue](https://github.com/recharts/recharts/pull/3602) merged into recharts. This adds a new (undocumented 😟) property to the Dot element called `clipDot`. When you set this to false, the dot now renders correctly

![image](https://github.com/user-attachments/assets/3d4aa4d4-463c-4927-a6a4-db824c80e3cc)

From the recharts PR: 


> When `allowDataOverflow` is true on `XAxis` or `YAxis`, set `clipDot` within the dot object to determine if recharts should clip the dots at the end of the page.


## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ x These changes do not introduce any security risks, or any such risks have been properly mitigated.

None, this pr is concrned with layout only

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

I have clicked through all the relevant stories we have saved, and have not come across any weird looking graphs

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.

