### PR TITLE
Fix micro trend if valid value for current date

### DIFF
--- a/src/components/container/MicroTrend/MicroTrend.stories.tsx
+++ b/src/components/container/MicroTrend/MicroTrend.stories.tsx
@@ -38,3 +38,14 @@ export const StepsWithThresholds = {
     },
     render: render
 };
+
+export const StepsNoTrend = {
+    args: {
+        dataType: {
+            dailyDataType: DailyDataType.Steps,
+            color: "rgba(255, 166, 102, 1)"
+        },
+        previewState: "noTrend"
+    },
+    render: render
+};

--- a/src/components/container/MicroTrend/MicroTrend.tsx
+++ b/src/components/container/MicroTrend/MicroTrend.tsx
@@ -30,7 +30,7 @@ export default function MicroTrend(props: MicroTrendProps) {
         return null;
     }
 
-    const hasRecentData = Object.values(results).some(r => r.value > 0);
+    const hasRecentData = Object.values(results).some(r => r.value > 0 && r.threshold !== undefined);
     if (props.hideIfNoRecentData && !hasRecentData) {
         return null;
     }

--- a/src/components/container/MicroTrend/MicroTrend.tsx
+++ b/src/components/container/MicroTrend/MicroTrend.tsx
@@ -7,7 +7,7 @@ import "./MicroTrend.css"
 export interface MicroTrendProps {
     date?: Date
     dataType: RelativeActivityDataType
-    previewState?: "default"
+    previewState?: "default" | "noTrend"
     innerRef?: React.Ref<HTMLDivElement>
     hideIfNoRecentData?: boolean
 }
@@ -19,9 +19,17 @@ export default function MicroTrend(props: MicroTrendProps) {
     const date = props.date ?? dateRangeContext?.intervalStart ?? startOfDay(new Date());
 
     function loadData() {
-        queryRelativeActivity(add(date, { days: -6 }), date, [props.dataType], !!props.previewState).then(results => {
-            setResults(results[props.dataType.dailyDataType]);
-        });
+        if (props.previewState === "noTrend") {
+            setResults({
+                [getDayKey(date)]: {
+                    value: 5000
+                }
+            });
+        } else {
+            queryRelativeActivity(add(date, { days: -6 }), date, [props.dataType], !!props.previewState).then(results => {
+                setResults(results[props.dataType.dailyDataType]);
+            });
+        }
     }
 
     useInitializeView(loadData, ["externalAccountSyncComplete"]);

--- a/src/components/container/RelativeActivity/RelativeActivity.tsx
+++ b/src/components/container/RelativeActivity/RelativeActivity.tsx
@@ -93,7 +93,7 @@ export default function (props: RelativeActivityProps) {
         {props.title && <CardTitle title={props.title} />}
         {dataTypes.map(d => {
             let dataTypeResult = results![d.dailyDataType];
-            if (!dataTypeResult) {
+            if (!dataTypeResult || dataTypeResult.threshold === undefined || dataTypeResult.relativePercent === undefined) {
                 return null;
             }
             let dataTypeDefinition = getDailyDataTypeDefinition(d.dailyDataType);

--- a/src/components/container/RelativeActivityDayCoordinator/RelativeActivityDayCoordinator.tsx
+++ b/src/components/container/RelativeActivityDayCoordinator/RelativeActivityDayCoordinator.tsx
@@ -47,11 +47,12 @@ export default function RelativeActivityDateRangeCoordinator(props: RelativeActi
         if (!props.dataTypes.length || !availableDataTypes?.length) return null;
 
         let bars: SparkBarChartBar[] = availableDataTypes.map(dataType => {
-            if (!relativeActivityData || !relativeActivityData[dataType.dailyDataType] || !relativeActivityData[dataType.dailyDataType][dayKey]) {
+            const relativePercent = relativeActivityData?.[dataType.dailyDataType]?.[dayKey]?.relativePercent;
+            if (relativePercent === undefined) {
                 return { color: 'var(--mdhui-color-primary)', barFillPercent: 0 };
             }
 
-            const value = relativeActivityData[dataType.dailyDataType][dayKey].value || 0;
+            const value = relativeActivityData![dataType.dailyDataType][dayKey].value || 0;
             let color = dataType.color || 'var(--mdhui-color-primary)';
             if (dataType.threshold !== undefined && dataType.threshold !== '30DayAverage' && value > dataType.threshold && dataType.overThresholdColor) {
                 color = dataType.overThresholdColor;
@@ -59,7 +60,7 @@ export default function RelativeActivityDateRangeCoordinator(props: RelativeActi
 
             return {
                 color: color,
-                barFillPercent: relativeActivityData[dataType.dailyDataType][dayKey].relativePercent
+                barFillPercent: relativePercent
             };
         });
 

--- a/src/helpers/relative-activity.tsx
+++ b/src/helpers/relative-activity.tsx
@@ -4,9 +4,9 @@ import { queryDailyData } from "./query-daily-data";
 import getDayKey from "./get-day-key";
 
 export interface RelativeActivityQueryResult {
-    relativePercent: number;
     value: number;
-    threshold: number;
+    threshold?: number;
+    relativePercent?: number;
 }
 
 export interface RelativeActivityDataType {
@@ -38,17 +38,17 @@ export function queryRelativeActivity(startDate: Date, endDate: Date, dataTypes:
                 let dayKey = getDayKey(currentDate);
                 let value = dataTypeData?.[dayKey] ?? 0;
                 let threshold = (dataType.threshold === "30DayAverage" || dataType.threshold === undefined) ? calculatePrevious30DayAverage(dataTypeData, currentDate) : dataType.threshold;
+                relativeActivityResults[dataType.dailyDataType][dayKey] = {
+                    value: value
+                };
                 if (threshold !== undefined) {
                     let fillPercent = value / (threshold * 2);
                     if (fillPercent > 1) {
                         fillPercent = 1;
                     }
 
-                    relativeActivityResults[dataType.dailyDataType][dayKey] = {
-                        relativePercent: fillPercent,
-                        value: value,
-                        threshold: threshold
-                    }
+                    relativeActivityResults[dataType.dailyDataType][dayKey].relativePercent = fillPercent;
+                    relativeActivityResults[dataType.dailyDataType][dayKey].threshold = threshold;
                 }
                 currentDate = add(currentDate, { days: 1 });
             }


### PR DESCRIPTION
## Overview

Closes https://github.com/CareEvolution/MyDataHelpsViewBuilder/issues/248

QueryRelativeActivity was just returning nothing for a day if it could not calculate a threshold (30 day average).  This means that for some data types like air quality which start collecting when enabled, you'd have to wait a long time for the component to display.

This addresses that by updating QueryRelativeActivity to return values regardless of whether a trend is there, and then updates the components to handle that scenario.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Standard react code, no real security risks

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

- Test MicroTrend component where there isn't enough data to calculate a 30 day avg
- Regression test relative activity day coordinator component and ensure it functions as it did before
- Regression test relative activity component and ensure it functions as it did before

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [x] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
