### PR TITLE
Connect devices menu refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.78.4",
+  "version": "2.78.5-RefreshConnectDevices.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@careevolution/mydatahelps-ui",
-      "version": "2.78.4",
+      "version": "2.78.5-RefreshConnectDevices.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@careevolution/mydatahelps-ui",
-  "version": "2.78.4",
+  "version": "2.78.5-RefreshConnectDevices.0",
   "description": "MyDataHelps UI Library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/container/ConnectDevicesMenu/ConnectDevicesMenu.tsx
+++ b/src/components/container/ConnectDevicesMenu/ConnectDevicesMenu.tsx
@@ -42,6 +42,7 @@ interface ConnectDevicesMenuState {
     hasRecentAppleHealthData: boolean;
     healthConnectStatus: HealthConnectStatus | null;
     participantInfo: ParticipantInfo | null;
+    refresh: () => void;
 }
 
 function useConnectDevicesMenuState(
@@ -55,7 +56,8 @@ function useConnectDevicesMenuState(
         platform: null,
         hasRecentAppleHealthData: false,
         healthConnectStatus: null,
-        participantInfo: null
+        participantInfo: null,
+        refresh: initialize
     });
 
     if (previewState) {
@@ -72,7 +74,8 @@ function useConnectDevicesMenuState(
             platform: "Web",
             hasRecentAppleHealthData: false,
             healthConnectStatus: null,
-            participantInfo: generateSampleParticipantInfo()
+            participantInfo: generateSampleParticipantInfo(),
+            refresh: initialize
         }
 
         if (previewState == "ConnectedStates") {
@@ -111,7 +114,8 @@ function useConnectDevicesMenuState(
                     platform: deviceInfo ? deviceInfo.platform : "Web",
                     hasRecentAppleHealthData: false,
                     healthConnectStatus: null,
-                    participantInfo: participantInfo
+                    participantInfo: participantInfo,
+                    refresh: initialize
                 };
 
                 if (deviceInfo?.platform == "iOS") {
@@ -142,7 +146,7 @@ function useConnectDevicesMenuState(
 }
 
 export default function (props: ConnectDevicesMenuProps) {
-    const { loading, settings, deviceExternalAccounts, platform, hasRecentAppleHealthData, healthConnectStatus, participantInfo } =
+    const { loading, settings, deviceExternalAccounts, platform, hasRecentAppleHealthData, healthConnectStatus, participantInfo, refresh } =
         useConnectDevicesMenuState(props.previewState, props.enableAppleHealthSurveyName, props.enableGoogleFitSurveyName);
 
     if (loading) {
@@ -220,7 +224,8 @@ export default function (props: ConnectDevicesMenuProps) {
             providerID={providerID}
             image={image}
             externalAccount={externalAccount}
-            connectExternalAccountOptions={props.connectExternalAccountOptions} />;
+            connectExternalAccountOptions={props.connectExternalAccountOptions}
+            onConnect={() => refresh()} />;
     }
 
     function getAppleHealthMenuItem() {
@@ -338,13 +343,16 @@ interface ExternalAccountMenuItemProps {
     image: ReactNode;
     externalAccount?: ExternalAccount;
     connectExternalAccountOptions?: ConnectExternalAccountOptions;
+    onConnect: () => void;
 }
 
 function ExternalAccountMenuItem(props: ExternalAccountMenuItemProps) {
     let indicator = <div className="mdhui-connect-devices-menu-connect">{language("connect")}</div>;
     let action: (() => void) | undefined = () => {
         if (props.preview) return;
-        MyDataHelps.connectExternalAccount(props.providerID, props.connectExternalAccountOptions || { openNewWindow: true });
+        MyDataHelps.connectExternalAccount(props.providerID, props.connectExternalAccountOptions || { openNewWindow: true }).then(() => {
+            props.onConnect();
+        });
     };
 
     if (props.externalAccount) {


### PR DESCRIPTION
## Overview

Closes https://github.com/CareEvolution/MyDataHelpsViewBuilder/issues/262

Connect Devices Menu was not refreshing on web after connecting to Oura/Fitbit/Garmin.  This worked fine on iOS/Android because applicationDidBecomeVisible gets triggered, but on web we need to handle the result of the connectExternalAccount action promise to refresh

This was slightly awkward because I use a hook for the state here; I ended up passing a "refresh" function out of the hook so that it could be called by the component, which makes sense to me, but not sure if there's a better convention

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Just a bugfix

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [x] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

This requires testing in the web app specifically

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
