### PR TITLE
ProviderSearch: Fix the public provider endpoint page numbers.

### DIFF
--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -86,13 +86,13 @@ export default function ProviderSearch(props: ProviderSearchProps) {
             }).catch(function (error) {
                 console.error("Error fetching external account providers", error);
                 setSearching(false);
-            });;
+            });
         }
         else {
             const url = new URL(props.publicProviderSearchApiUrl);
             url.searchParams.append('keyword', search);
             url.searchParams.append('pageSize', String(pageSize));
-            url.searchParams.append('pageNumber', String(currentPage));
+            url.searchParams.append('pageNumber', String(currentPage + 1));
             fetch(url.toString(), {
                 method: "GET",
                 headers: { "Accept": "application/json" },


### PR DESCRIPTION
## Overview

Our public provider search endpoint uses 1-based paging.  This branch adjusts the value used by the `ProviderSearch` component to avoid loading the first page from the public endpoint twice.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just fixing a bug that causes the first page of providers from the public endpoint to load twice.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

DESCRIBE YOUR TEST PLAN

- Open the "Public Endpoint" storybook story for the `ProviderSearch` component.  Verify that the first page of results (100 by default) does not get loaded a second time when you scroll to the bottom.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
