### PR TITLE
Fixed button placement was blocking content

### DIFF
--- a/src/components/step/ConnectEhrStep/ConnectEhrStep.css
+++ b/src/components/step/ConnectEhrStep/ConnectEhrStep.css
@@ -1,0 +1,9 @@
+.mdhui-step-container.mdhui-connect-ehr-step .mdhui-provider-search {
+    margin-bottom: 94px;
+}
+.mdhui-step-container.mdhui-connect-ehr-step .mdhui-step-next-button {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}

--- a/src/components/step/ConnectEhrStep/ConnectEhrStep.tsx
+++ b/src/components/step/ConnectEhrStep/ConnectEhrStep.tsx
@@ -7,6 +7,8 @@ import StepTitle from "../StepTitle";
 import { ExternalAccountProvider } from "@careevolution/mydatahelps-js";
 import { ProviderSearchPreviewState } from "../../container/ProviderSearch/ProviderSearch";
 
+import './ConnectEhrStep.css';
+
 export interface ConnectEhrStepProps {
     title?: string;
     text?: string;
@@ -23,7 +25,7 @@ export interface ConnectEhrStepProps {
  */
 export default function ConnectEhrStep (props: ConnectEhrStepProps) {
     return (
-        <StepLayout>
+        <StepLayout className="mdhui-connect-ehr-step">
             <StepTitle
                 text={props.title}
                 textAlign={props.styles.titleAlignment}

--- a/src/components/step/StepLayout/StepLayout.tsx
+++ b/src/components/step/StepLayout/StepLayout.tsx
@@ -4,11 +4,12 @@ import './StepLayout.css'
 
 export interface StepLayoutProps {
   children?: React.ReactNode;
+  className?: string;
 }
 
 export default function (props: StepLayoutProps) {
   return (
-    <Layout colorScheme='light' className='mdhui-step-container' bodyBackgroundColor="#FFFFFF">
+    <Layout colorScheme='light' className={'mdhui-step-container' + (props.className ? ` ${props.className}` : "")} bodyBackgroundColor="#FFFFFF">
       {props.children}
     </Layout>
   );

--- a/src/components/step/StepNextButton/StepNextButton.css
+++ b/src/components/step/StepNextButton/StepNextButton.css
@@ -11,10 +11,7 @@
   width: calc(100% - 40px);
   box-sizing: border-box;
   text-align: center;
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  display: inline-block;
 }
 
 .mdhui-step-container .mdhui-step-next-button:disabled,


### PR DESCRIPTION
## Overview

- Button was moved to a fixed position in #100, to work properly with an infinite scroll so that the button wasn't pushed off the screen constantly by the new data.
- This broke the layout of the YouTube step, content would end up behind the button (the story was obviously broken and it wasn't noticed in review of #100):
![image](https://github.com/user-attachments/assets/76f5adf7-18d7-4586-8c80-1f824e202141)

- Also technically didn't work correctly in all cases anyway; if the list stopped loading, the last rows would be behind the button.
![image](https://github.com/user-attachments/assets/792cde6e-cc8f-4c76-95b0-59107d081309)

- Revert button to inline-block by default, customize only for ConnectEhrStep; fix ConnectEhrStep by adding margin-bottom so next button doesn't obscure content.
![image](https://github.com/user-attachments/assets/496f226f-ed00-4df9-8ac7-572ceb8f2e1b)
![image](https://github.com/user-attachments/assets/b845863f-e191-44f3-9279-6309482c12dc)

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

N/A; styling changes only.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

- Test that the YouTubeStep stories look correct.
- Test that the ConnectEhrStep stories look correct.
  - Verify using the Live story that infinite scroll/load works properly.
  - Verify using the Live story with a specific search that is more than one page, that scrolling to the end of the search allows you to see the last results.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
