### PR TITLE
Asthma: Fix device data date comparison.

### DIFF
--- a/__tests__/components/asthma/helpers/daily-data-providers/shared.test.ts
+++ b/__tests__/components/asthma/helpers/daily-data-providers/shared.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals';
+import { DeviceDataPoint, DeviceDataPointQuery } from '@careevolution/mydatahelps-js';
+import * as deviceDataQueryFunctions from '../../../../../src/helpers/daily-data-providers/query-all-device-data';
+import { add } from 'date-fns';
+import { sampleEndDate, sampleStartDate } from '../../../../fixtures/daily-data-providers';
+import { queryAsthmaDeviceData } from '../../../../../src/components/asthma/helpers/daily-data-providers';
+
+describe('Asthma - Daily Data Providers - Shared', () => {
+    describe('queryAsthmaDeviceData', () => {
+        it('Should query for data and return a result with the latest value from each day.', async () => {
+            const dataPoints: DeviceDataPoint[] = [
+                { observationDate: '2025-05-02T09:25:23-06:00', value: '100' } as DeviceDataPoint,
+                { observationDate: '2025-05-02T09:30:23-06:00', value: '101' } as DeviceDataPoint,
+                { observationDate: '2025-05-03T09:40:23-06:00', value: '200' } as DeviceDataPoint,
+                { observationDate: '2025-05-03T09:35:23-06:00', value: '201' } as DeviceDataPoint,
+                { observationDate: '2025-05-04T09:45:23-06:00', value: '300' } as DeviceDataPoint,
+                { observationDate: '2025-05-04T09:50:23-06:00', value: '301' } as DeviceDataPoint
+            ];
+            jest.spyOn(deviceDataQueryFunctions, 'default').mockImplementation(
+                (actualParameters: DeviceDataPointQuery): Promise<DeviceDataPoint[]> => {
+                    if (actualParameters.namespace !== 'Project') return Promise.reject();
+                    if (actualParameters.type !== 'Steps') return Promise.reject();
+                    if (actualParameters.observedAfter !== add(sampleStartDate, { days: -1 }).toISOString()) return Promise.reject();
+                    if (actualParameters.observedBefore !== add(sampleEndDate, { days: 1 }).toISOString()) return Promise.reject();
+                    return Promise.resolve(dataPoints);
+                }
+            );
+
+            const result = await queryAsthmaDeviceData('Steps', sampleStartDate, sampleEndDate);
+
+            expect(result).toEqual({
+                '2025-05-02': 101,
+                '2025-05-03': 200,
+                '2025-05-04': 301
+            });
+        });
+    });
+});

--- a/src/components/asthma/helpers/daily-data-providers/shared.ts
+++ b/src/components/asthma/helpers/daily-data-providers/shared.ts
@@ -1,4 +1,4 @@
-import { DailyDataQueryResult } from '../../../../helpers/query-daily-data';
+import { DailyDataQueryResult } from '../../../../helpers';
 import { add, isAfter, parseISO } from 'date-fns';
 import getDayKey from '../../../../helpers/get-day-key';
 import queryAllDeviceData from '../../../../helpers/daily-data-providers/query-all-device-data';
@@ -7,8 +7,8 @@ export const queryAsthmaDeviceData = async (type: string, startDate: Date, endDa
     const dataPoints = await queryAllDeviceData({
         namespace: 'Project',
         type: type,
-        observedAfter: add(startDate, {days: -1}).toISOString(),
-        observedBefore: add(endDate, {days: 1}).toISOString()
+        observedAfter: add(startDate, { days: -1 }).toISOString(),
+        observedBefore: add(endDate, { days: 1 }).toISOString()
     });
 
     let result: DailyDataQueryResult = {};
@@ -23,7 +23,7 @@ export const queryAsthmaDeviceData = async (type: string, startDate: Date, endDa
 
         // There should only be one data point per day, but just in case, if there happens to be
         // more than one, take the value from the data point with the later observationDate.
-        if (!result[dayKey] || isAfter(observationDates[dayKey], observationDate)) {
+        if (!result[dayKey] || isAfter(observationDate, observationDates[dayKey])) {
             result[dayKey] = parseFloat(dataPoint.value);
             observationDates[dayKey] = observationDate;
         }


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

Small bug fix.  I was passing the arguments to the `date-fns` `isAfter` function in the wrong order.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No security risk.  Just a sorting/selection bug fix.

## Testing

- Unit test added.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
