### PR TITLE
Fix the daily-data-query self import.

### DIFF
--- a/src/helpers/daily-data-providers/daily-data/daily-data-query.ts
+++ b/src/helpers/daily-data-providers/daily-data/daily-data-query.ts
@@ -5,8 +5,7 @@ import { add, endOfDay, Interval, isWithinInterval, startOfDay } from 'date-fns'
 import queryAllDeviceDataV2 from '../../query-all-device-data-v2';
 import { DailyData, DailyDataDateFunction, DailyDataV2 } from './daily-data-type';
 import { parseISOWithoutOffset } from '../../date-helpers';
-
-const self = module.exports as typeof import('./daily-data-query');
+import * as self from './daily-data-query';
 
 export async function queryForDailyData(
     namespace: DeviceDataNamespace,


### PR DESCRIPTION
## Overview

The `daily-data-query.ts` file uses a self import to allow for unit test mocking of internally called functions.  This worked fine locally, but it fails when using MDH from VB due to the presence of `module.exports`.

I have verified that the unit tests continue to pass and that VB is happy with this update.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just adjusting a self import to work in the browser.

## Testing

- This update can be tested against a local VB instance.  If the local VB loads, all is good.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
