### PR TITLE
Fix missing final tick for a 6 month view

### DIFF
--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -107,6 +107,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
                 ticks.push(addDays(currentTick, 14).getTime());
                 currentTick = addMonths(currentTick, 1);
             }
+            ticks.push(currentTick.getTime());
 
             return ticks;
         } else if (intervalType === "Day") {


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

The 6 month view for a Time Series chart was only showing 5.5 months.  This was caused by the tick generation for the X-Axis.  In generating ticks only a the 1st and 15th of the month, the interval was stopping on the 1st of the next month, but not actually pushing a tick for it, which meant that the last tick was the 15th of the last month.  This meant that the graph wasn't ever showing data between the 15th and the end of the month.

A graph generated for today, 5/28:
![image](https://github.com/user-attachments/assets/62e5b25d-4199-487f-8e61-1dfc0778e742)


## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

DESCRIBE YOUR TEST PLAN

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
