### PR TITLE
Combined Resting Heart Rate Availability Check issue w/ Oura

### DIFF
--- a/src/helpers/daily-data-types/combined.tsx
+++ b/src/helpers/daily-data-types/combined.tsx
@@ -27,7 +27,7 @@ const RESTING_HEART_RATE_SOURCES = sources(
     ["AppleHealth", "RestingHeartRate"],
     ["Fitbit", "RestingHeartRate"],
     ["Garmin", "Daily"],
-    ["Oura", "heart-rate", true],
+    ["Oura", "sleep", true],
     ["HealthConnect", "resting-heart-rate", true]
 );
 


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

Fixes https://github.com/CareEvolution/MyDataHelpsUI/issues/479 by checking that the sleep route is available, rather than the heart-rate route. I think this was just a mix up in the initial implementation and merge confusion.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] These changes do not introduce any security risks, or any such risks have been properly mitigated.

This is a one word change that has no security impact.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

This is a pretty straight forward change, I can put together a ViewBuilder PR if required, but not sure it is needed here.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
