### PR TITLE
Add temporary hack to populate the external account provider enabled flag.

### DIFF
--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -119,7 +119,18 @@ export default function ProviderSearch(props: ProviderSearchProps) {
             newResults = newResults.concat(props.featuredProviders);
             providers = providers.filter(a => !props.featuredProviders!.find(b => b.id == a.id));
         }
-        setSearchResults(newResults.concat(providers).filter(a => props.providerCategories?.indexOf(a.category) != -1 && a.message !== UNAVAILABLE_PROVIDER_MESSAGE));
+        const updatedSearchResults = newResults.concat(providers).filter(a => props.providerCategories?.indexOf(a.category) != -1 && a.message !== UNAVAILABLE_PROVIDER_MESSAGE);
+
+        // HACK: Temporarily default all provider enabled flags to true when they have not been set by the API.
+        // This should remain while the API is not setting the enabled flag.
+        // This should also remain until any hard coded featured provider lists are updated to include the enabled flag.
+        updatedSearchResults.forEach(provider => {
+            if (provider.enabled === undefined) {
+                provider.enabled = true;
+            }
+        });
+
+        setSearchResults(updatedSearchResults);
     }
 
     const debounce = (fn: Function, ms = 300) => {


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

This branch adds a temporary hack to populate the external account provider enabled flag on search results.  This is necessary until the API endpoint begins returning the enabled flag values so that providers are not considered disabled in the meantime.

It can be removed once the API updates in QA go live.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just populating an enabled flag for providers that don't yet have it set.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

DESCRIBE YOUR TEST PLAN

- We tested in both the storybook and with VB views in QA and Prod-DryRun environments.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
