### PR TITLE
Add deduplication logic for Fitbit sleep data

### DIFF
--- a/__tests__/helpers/daily-data-providers/fitbit-sleep.test.ts
+++ b/__tests__/helpers/daily-data-providers/fitbit-sleep.test.ts
@@ -1,17 +1,209 @@
-import { describe, expect, test } from '@jest/globals';
-import { sampleDailyData, sampleEndDate, sampleResult, sampleStartDate, setupDailyData, setupTotalValueResult, sleepDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
-import { deepSleepMinutes, lightSleepMinutes, remSleepMinutes, totalSleepMinutes } from '../../../src/helpers/daily-data-providers/fitbit-sleep';
+import { describe, expect, test } from "@jest/globals";
+import {
+    sampleDailyData,
+    sampleEndDate,
+    sampleResult,
+    sampleStartDate,
+    setupDailyData,
+    setupTotalValueResult,
+    sleepDateFunctionEvaluator
+} from "../../fixtures/daily-data-providers";
+import {
+    deduplicateSleepData,
+    deepSleepMinutes,
+    lightSleepMinutes,
+    remSleepMinutes,
+    totalSleepMinutes
+} from "../../../src/helpers/daily-data-providers/fitbit-sleep";
+import { DailyData } from "../../../src/helpers/daily-data-providers/daily-data/daily-data-type";
 
-describe('Daily Data Provider - Fitbit Sleep', () => {
+describe("Daily Data Provider - Fitbit Sleep", () => {
     test.each([
-        { title: 'Light', sleepFunction: lightSleepMinutes, types: ["SleepLevelLight"] },
-        { title: 'REM', sleepFunction: remSleepMinutes, types: ["SleepLevelRem"] },
-        { title: 'Deep', sleepFunction: deepSleepMinutes, types: ["SleepLevelDeep"] },
-        { title: 'Total', sleepFunction: totalSleepMinutes, types: ["SleepLevelRem", "SleepLevelLight", "SleepLevelDeep", "SleepLevelAsleep"] }
-    ])('$title - Should query for daily data and build a total value result keyed by observation date + 6 hours.', async ({ sleepFunction, types }) => {
-        setupDailyData('Fitbit', types, sampleStartDate, sampleEndDate, sleepDateFunctionEvaluator, sampleDailyData);
-        setupTotalValueResult(sampleDailyData, sampleResult);
+        {
+            title: "Light",
+            sleepFunction: lightSleepMinutes,
+            types: ["SleepLevelLight"]
+        },
+        {
+            title: "REM",
+            sleepFunction: remSleepMinutes,
+            types: ["SleepLevelRem"]
+        },
+        {
+            title: "Deep",
+            sleepFunction: deepSleepMinutes,
+            types: ["SleepLevelDeep"]
+        },
+        {
+            title: "Total",
+            sleepFunction: totalSleepMinutes,
+            types: [
+                "SleepLevelRem",
+                "SleepLevelLight",
+                "SleepLevelDeep",
+                "SleepLevelAsleep"
+            ]
+        }
+    ])(
+        "$title - Should query for daily data and build a total value result keyed by observation date + 6 hours.",
+        async ({ sleepFunction, types }) => {
+            setupDailyData(
+                "Fitbit",
+                types,
+                sampleStartDate,
+                sampleEndDate,
+                sleepDateFunctionEvaluator,
+                sampleDailyData
+            );
+            setupTotalValueResult(sampleDailyData, sampleResult);
 
-        expect(await sleepFunction(sampleStartDate, sampleEndDate)).toBe(sampleResult);
+            expect(await sleepFunction(sampleStartDate, sampleEndDate)).toBe(
+                sampleResult
+            );
+        }
+    );
+});
+
+describe("Daily Data Provider - dedeuplicate sleep", () => {
+    test("Should return an empty object when daily data is empty", () => {
+        var result = deduplicateSleepData({});
+        expect(result).toEqual({});
+    });
+    test("Should return the same data when no duplicates are present", () => {
+        const dailyData = {
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    observationDate: "2023-10-01T06:00:00Z",
+                    modifiedDate: "2023-10-01T06:00:00Z"
+                }
+            ]
+        } as unknown as DailyData;
+        const result = deduplicateSleepData(dailyData);
+        expect(result).toEqual(dailyData);
+    });
+    test("Should deduplicate sleep data based on startDate and observationDate", () => {
+        const dailyData = {
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    observationDate: "2023-10-01T06:00:00Z",
+                    modifiedDate: "2023-10-01T06:00:00Z"
+                },
+                {
+                    startDate: "2023-10-01T00:05:00Z",
+                    observationDate: "2023-10-01T06:05:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                },
+                {
+                    startDate: "2023-10-01T00:05:00Z",
+                    observationDate: "2023-10-01T06:00:00Z",
+                    modifiedDate: "2023-10-01T06:03:00Z"
+                }
+            ]
+        } as unknown as DailyData;
+        const result = deduplicateSleepData(dailyData);
+        expect(result).toEqual({
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:05:00Z",
+                    observationDate: "2023-10-01T06:05:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                }
+            ]
+        });
+    });
+    test("Should return the any object that is missing startDate or observationDate", () => {
+        const dailyData = {
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    observationDate: "2023-10-01T06:00:00Z",
+                    modifiedDate: "2023-10-01T06:00:00Z"
+                },
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                }
+            ]
+        } as unknown as DailyData;
+        const result = deduplicateSleepData(dailyData);
+        expect(result).toEqual({
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    observationDate: "2023-10-01T06:00:00Z",
+                    modifiedDate: "2023-10-01T06:00:00Z"
+                },
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                }
+            ]
+        });
+    });
+
+    test("should deduplicate if startDate is within 10 minutes, but observationDate is not", () => {
+        const dailyData = {
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    observationDate: "2023-10-01T06:00:00Z",
+                    modifiedDate: "2023-10-01T06:00:00Z"
+                },
+                {
+                    startDate: "2023-10-01T00:05:00Z",
+                    observationDate: "2023-10-01T06:45:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                }
+            ]
+        } as unknown as DailyData;
+        const result = deduplicateSleepData(dailyData);
+        expect(result).toEqual({
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:05:00Z",
+                    observationDate: "2023-10-01T06:45:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                }
+            ]
+        });
+    });
+
+    test("should deduplicate duplicates but keep distinct data points", () => {
+        const dailyData = {
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:00:00Z",
+                    observationDate: "2023-10-01T06:00:00Z",
+                    modifiedDate: "2023-10-01T06:00:00Z"
+                },
+                {
+                    startDate: "2023-10-01T00:05:00Z",
+                    observationDate: "2023-10-01T06:05:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                },
+                {
+                    startDate: "2023-10-01T12:00:00Z",
+                    observationDate: "2023-10-01T12:30:00Z",
+                    modifiedDate: "2023-10-01T12:30:00Z"
+                }
+            ]
+        } as unknown as DailyData;
+        const result = deduplicateSleepData(dailyData);
+        expect(result).toEqual({
+            "2023-10-01": [
+                {
+                    startDate: "2023-10-01T00:05:00Z",
+                    observationDate: "2023-10-01T06:05:00Z",
+                    modifiedDate: "2023-10-01T06:05:00Z"
+                },
+                {
+                    startDate: "2023-10-01T12:00:00Z",
+                    observationDate: "2023-10-01T12:30:00Z",
+                    modifiedDate: "2023-10-01T12:30:00Z"
+                }
+            ]
+        });
     });
 });

--- a/src/helpers/daily-data-providers/fitbit-sleep.ts
+++ b/src/helpers/daily-data-providers/fitbit-sleep.ts
@@ -1,9 +1,83 @@
-﻿import { DailyDataQueryResult } from "../query-daily-data";
-import { buildTotalValueResult, getSleepDate, queryForDailyData } from "./daily-data";
+﻿import { parseISOWithoutOffset } from "../date-helpers";
+import { DailyDataQueryResult } from "../query-daily-data";
+import { buildTotalValueResult, DailyData, getSleepDate, queryForDailyData } from "./daily-data";
+import { DeviceDataPoint } from "@careevolution/mydatahelps-js";
 
 async function querySleep(startDate: Date, endDate: Date, types: string[]): Promise<DailyDataQueryResult> {
     const dailyData = await queryForDailyData("Fitbit", types, startDate, endDate, getSleepDate);
-    return buildTotalValueResult(dailyData);
+    const dedeuplicatedData = deduplicateSleepData(dailyData);
+    return buildTotalValueResult(dedeuplicatedData);
+}
+
+function deduplicateDataPoints(
+    dataPoints: DeviceDataPoint[]
+): DeviceDataPoint[] {
+    const uniqueDataPoints: DeviceDataPoint[] = [];
+
+    if (!dataPoints || dataPoints.length <= 1) {
+        return dataPoints;
+    }
+
+    for (const dataPoint of dataPoints) {
+        if (!dataPoint.startDate || !dataPoint.observationDate || !dataPoint.modifiedDate) {
+            uniqueDataPoints.push(dataPoint);
+            continue;
+        }
+        const duplicateIndex = uniqueDataPoints
+            .filter(dp => dp.startDate && dp.observationDate && dp.modifiedDate)
+            .findIndex(uniquePoint => {
+                const uniqueStartDate = parseISOWithoutOffset(uniquePoint.startDate!);
+                const uniqueObservationDate = parseISOWithoutOffset(uniquePoint.observationDate!);
+                const currentStartDate = parseISOWithoutOffset(dataPoint.startDate!);
+                const currentObservationDate = parseISOWithoutOffset(dataPoint.observationDate!);
+
+                // Check if the start date and observation date are within 10 minutes of each other
+                const tenMinutesInMs = 10 * 60 * 1000;
+                const startDateDiff = Math.abs(uniqueStartDate.getTime() - currentStartDate.getTime());
+                const observationDateDiff = Math.abs(uniqueObservationDate.getTime() - currentObservationDate.getTime());
+
+                return startDateDiff <= tenMinutesInMs || observationDateDiff <= tenMinutesInMs;
+            });
+
+        if (duplicateIndex === -1) {
+            // No duplicate found, add the data point
+            uniqueDataPoints.push(dataPoint);
+        } else {
+            // Duplicate found, keep the one with the most recent modifiedDate
+            const existingPoint = uniqueDataPoints[duplicateIndex];
+            const existingModifiedDate = parseISOWithoutOffset(existingPoint.modifiedDate!);
+            const currentModifiedDate = parseISOWithoutOffset(dataPoint.modifiedDate!);
+
+            if (currentModifiedDate > existingModifiedDate) {
+                uniqueDataPoints[duplicateIndex] = dataPoint;
+            }
+        }
+    }
+
+    return uniqueDataPoints;
+}
+
+/**
+ * Fitbit began sending updates to sleep data with different logIds for the same sleep period.
+ * This function deduplicates sleep data by checking if the startDate and observationDate are within
+ * 10 minutes of each other. If they are, it keeps the most recent entry based on modifiedDate.
+ * @param dailyData - Daily data object where keys are dates in YYYY-MM-DD format and values are arrays of DeviceDataPoint objects.
+ * @returns 
+ */
+export function deduplicateSleepData(dailyData: DailyData): DailyData {
+    const deduplicatedData: DailyData = {};
+
+    if (!dailyData || Object.keys(dailyData).length === 0) {
+        return deduplicatedData;
+    }
+
+    //key is the date in YYYY-MM-DD format
+    for (const [key, dataPoints] of Object.entries(dailyData)) {
+        const uniqueDataPoints = deduplicateDataPoints(dataPoints);
+        deduplicatedData[key] = uniqueDataPoints;
+    }
+
+    return deduplicatedData;
 }
 
 export function totalSleepMinutes(startDate: Date, endDate: Date): Promise<DailyDataQueryResult> {


### PR DESCRIPTION
## Overview

We are seeing duplicate records with fitbit sleep. It appears there was a change sometime early last week (6/23/2025) that changed the was that logid was calculated. This caused updates that we get about sleep to look like new records. 

While this would seem like a blip (since all new records appear to have the new log id), it seems like an important one to manage, at least for the next year or so.

The way these changes work is to look for any sleep records that have a start date OR an end date within 10 min of each other. If there is more than one, select the one that has the most recent modified date. 


DESCRIBE YOUR CHANGES

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [ ] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [ ] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ x These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

DESCRIBE YOUR TEST PLAN

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
