### PR TITLE
ProviderSearch: Operating mode, updated featured provider support, and a couple bug fixes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "@rollup/rollup-linux-x64-gnu": "4.6.1"
       },
       "peerDependencies": {
-        "@careevolution/mydatahelps-js": "^3.35.0",
+        "@careevolution/mydatahelps-js": "^4.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
@@ -1930,9 +1930,9 @@
       "license": "MIT"
     },
     "node_modules/@careevolution/mydatahelps-js": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@careevolution/mydatahelps-js/-/mydatahelps-js-3.35.0.tgz",
-      "integrity": "sha512-v1aoyUuBt9q8k/iBn5SUMhNowsv1BU3M+YgypwbeD9ah9WVBKU27PSu0UNwHBJLAa/dnmmWy3LyGlBYO64Wzbw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@careevolution/mydatahelps-js/-/mydatahelps-js-4.2.1.tgz",
+      "integrity": "sha512-g6xUFeHYwUsAPNYhobSUF2velRNOHKxhknsl8MWGSuKLSJBnDwrhoTNhzZ1Ob6cFCzYFDvUsEuSn6AVj69FpKA==",
       "license": "Apache-2.0",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@careevolution/mydatahelps-js": "^3.35.0",
+    "@careevolution/mydatahelps-js": "^4.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/container/ProviderSearch/ProviderSearch.previewdata.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.previewdata.tsx
@@ -1,68 +1,73 @@
-import { ExternalAccountProvider } from "@careevolution/mydatahelps-js";
+import { ExternalAccount, ExternalAccountProvider } from '@careevolution/mydatahelps-js';
 
-export var previewProviders: ExternalAccountProvider[] =
-    [
+export type ProviderSearchPreviewState = 'Default' | 'Searching' |
+    'Connected Provider' | 'Connected Provider - Unauthorized' |
+    'Disabled Provider - Same Endpoint' | 'Disabled Provider - Same Managing Org' | 'Disabled Provider - Unavailable';
+
+export interface ProviderSearchPreviewData {
+    searchResults: ExternalAccountProvider[];
+    externalAccounts: ExternalAccount[];
+}
+
+export function createPreviewData(previewState: ProviderSearchPreviewState): ProviderSearchPreviewData {
+    const providers: ExternalAccountProvider[] = [
         {
-            "id": 20,
-            "name": "1upHealth sandbox",
-            "category": "Health Plan",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/20/logo",
-            "enabled": true
+            id: 20,
+            name: '1upHealth sandbox',
+            category: 'Health Plan',
+            logoUrl: 'https://mydatahelps.dev/api/v1/delegated/externalaccountproviders/20/logo',
+            enabled: previewState === 'Default',
+            relatedProvider: previewState.startsWith('Disabled') ? 'Some Related Provider' : undefined,
+            managingOrganization: previewState === 'Disabled Provider - Same Managing Org' ? 'Some Managing Org' : undefined,
+            message: previewState === 'Disabled Provider - Unavailable' ? 'Unavailable' : undefined
         } as ExternalAccountProvider,
         {
-            "id": 2,
-            "name": "Fitbit",
-            "category": "Device Manufacturer",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/2/logo",
-            "enabled": true
+            id: 2,
+            name: 'Fitbit',
+            category: 'Device Manufacturer',
+            logoUrl: 'https://mydatahelps.dev/api/v1/delegated/externalaccountproviders/2/logo',
+            enabled: true
         } as ExternalAccountProvider,
         {
-            "id": 13,
-            "name": "A Woman's Place, LLC",
-            "category": "Provider",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/13/logo",
-            "enabled": true
+            id: 130,
+            name: 'Abington Jefferson Health',
+            category: 'Provider',
+            logoUrl: 'https://mydatahelps.dev/api/v1/delegated/externalaccountproviders/130/logo',
+            enabled: true
         } as ExternalAccountProvider,
         {
-            "id": 130,
-            "name": "Abington Jefferson Health",
-            "category": "Provider",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/130/logo",
-            "enabled": true
+            id: 1,
+            name: 'CareEvolution FHIR',
+            category: 'Provider',
+            logoUrl: 'https://mydatahelps.dev/api/v1/delegated/externalaccountproviders/1/logo',
+            enabled: true
         } as ExternalAccountProvider,
         {
-            "id": 41,
-            "name": "Access Community Health Network",
-            "category": "Provider",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/41/logo",
-            "enabled": true
+            id: 37,
+            name: 'Cedars-Sinai Health System',
+            category: 'Provider',
+            logoUrl: 'https://mydatahelps.dev/api/v1/delegated/externalaccountproviders/37/logo',
+            enabled: true
         } as ExternalAccountProvider,
         {
-            "id": 125,
-            "name": "Aurora Health Care - myAurora",
-            "category": "Provider",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/125/logo",
-            "enabled": true
-        } as ExternalAccountProvider,
-        {
-            "id": 1,
-            "name": "CareEvolution FHIR",
-            "category": "Provider",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/1/logo",
-            "enabled": true
-        } as ExternalAccountProvider,
-        {
-            "id": 37,
-            "name": "Cedars-Sinai Health System",
-            "category": "Provider",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/37/logo",
-            "enabled": true
-        } as ExternalAccountProvider,
-        {
-            "id": 27,
-            "name": "Maui Medical Group",
-            "category": "Provider",
-            "logoUrl": "https://mdhorg.ce.dev/api/v1/delegated/externalaccountproviders/27/logo",
-            "enabled": true
+            id: 27,
+            name: 'Maui Medical Group',
+            category: 'Provider',
+            logoUrl: 'https://mydatahelps.dev/api/v1/delegated/externalaccountproviders/27/logo',
+            enabled: true
         } as ExternalAccountProvider
     ];
+
+    const externalAccounts: ExternalAccount[] = [];
+    if (previewState.startsWith('Connected Provider')) {
+        externalAccounts.push({
+            provider: providers[0],
+            status: previewState === 'Connected Provider - Unauthorized' ? 'unauthorized' : 'fetchComplete'
+        } as ExternalAccount);
+    }
+
+    return {
+        searchResults: providers,
+        externalAccounts: externalAccounts
+    };
+}

--- a/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.stories.tsx
@@ -1,328 +1,185 @@
-﻿import React from "react"
-import ProviderSearch, { ProviderSearchProps } from "./ProviderSearch"
-import Layout from "../../presentational/Layout"
-import { ExternalAccountProvider } from "@careevolution/mydatahelps-js"
-import { Meta, StoryObj } from "@storybook/react"
-import { Description } from "@storybook/blocks"
-import { Card } from "../../presentational"
+﻿import React from 'react'
+import ProviderSearch from './ProviderSearch'
+import Layout from '../../presentational/Layout'
+import { ExternalAccountProvider } from '@careevolution/mydatahelps-js'
+import { Meta, StoryObj } from '@storybook/react'
+import { Card } from '../../presentational'
+import { argTypesToHide } from "../../../../.storybook/helpers";
+import { createPreviewData } from "./ProviderSearch.previewdata";
 
-const meta: Meta<typeof ProviderSearch> = {
-	title: "Container/ProviderSearch",
-	component: ProviderSearch,
-	parameters: {
-		layout: 'fullscreen',
-		docs: {
-			Description: <Description />
-		}
-	}
+type ProviderSearchStoryArgs = React.ComponentProps<typeof ProviderSearch> & {
+    colorScheme: 'auto' | 'light' | 'dark';
+    featuredProviderSource: 'hard coded' | 'dynamic';
+    standaloneModeFinalRedirectPath: string;
 };
 
-export default meta;
-type Story = StoryObj<typeof ProviderSearch>;
+const meta: Meta<ProviderSearchStoryArgs> = {
+    title: 'Container/ProviderSearch',
+    component: ProviderSearch,
+    parameters: {
+        layout: 'fullscreen'
+    },
+    render: args => {
+        const previewProviders = createPreviewData('Default').searchResults;
 
-const render = (args: ProviderSearchProps) => <Layout colorScheme="auto">
-	<Card><ProviderSearch {...args} /></Card>
-</Layout>;
+        return <Layout colorScheme={args.colorScheme}>
+            <Card>
+                <ProviderSearch
+                    {...args}
+                    providerCategories={args.providerCategories!.length > 0 ? args.providerCategories : undefined}
+                    publicProviderSearchApiUrl={
+                        args.operatingMode === 'unauthenticated'
+                            ? 'https://designer.mydatahelps.dev/api/fhirpublicproviders'
+                            : undefined
+                    }
+                    featuredProviders={
+                        args.featuredProviderSource === 'hard coded'
+                            ? [
+                                { ...previewProviders[2], name: previewProviders[2].name + ' (Featured)' } as ExternalAccountProvider,
+                                { ...previewProviders[4], name: previewProviders[4].name + ' (Featured)' } as ExternalAccountProvider
+                            ]
+                            : undefined
+                    }
+                    publicFeaturedProvidersApiUrl={
+                        args.operatingMode === 'unauthenticated'
+                            ? 'https://designer.mydatahelps.dev/api/featuredfhirpublicproviders'
+                            : undefined
+                    }
+                    connectExternalAccountOptions={
+                        args.standaloneModeFinalRedirectPath
+                            ? {
+                                openNewWindow: false,
+                                standaloneModeFinalRedirectPath: args.standaloneModeFinalRedirectPath
+                            } : undefined
+                    }
+                />
+            </Card>
+        </Layout>;
+    }
+};
+export default meta;
+
+type Story = StoryObj<ProviderSearchStoryArgs>;
 
 export const Default: Story = {
-	args: {
-		previewState: "Default"
-	},
-	render: render
-}
-
-export const ProvidersOnly: Story = {
-	args: {
-		previewState: "Default",
-		providerCategories: ["Provider"]
-	},
-	render: render
-}
-
-export const HealthPlansOnly: Story = {
-	args: {
-		previewState: "Default",
-		providerCategories: ["Health Plan"]
-	},
-	render: render
-}
-
-export const DeviceManufacturersOnly: Story = {
-	args: {
-		previewState: "Default",
-		providerCategories: ["Device Manufacturer"]
-	},
-	render: render
-}
-
-export const onProviderConnected: Story = {
-	args: {
-		previewState: "Default",
-		onProviderConnected: (provider: ExternalAccountProvider) => alert(`You connected to ${provider.name}`)
-	},
-	render: render
-}
-
-export const publicEndpoint: Story = {
-	args: {
-		publicProviderSearchApiUrl: "https://designer.mydatahelps.dev/api/fhirpublicproviders",
-		onProviderSelected: (provider: ExternalAccountProvider) => alert(`You selected ${provider.name}`)
-	},
-	render: render
-}
-
-export const ProvidersAndHealthPlans: Story = {
-	args: {
-		previewState: "Default",
-		providerCategories: ["Provider", "Health Plan"]
-	},
-	render: render
-}
-
-export const ProvidersAndDeviceManufacturers: Story = {
-	args: {
-		previewState: "Default",
-		providerCategories: ["Provider", "Device Manufacturer"]
-	},
-	render: render
-}
-
-export const HealthPlansAndDeviceManufacturers: Story = {
-	args: {
-		previewState: "Default",
-		providerCategories: ["Health Plan", "Device Manufacturer"]
-	},
-	render: render
-}
-
-export const ProvidersAndHealthPlansAndDeviceManufacturers: Story = {
-	args: {
-		previewState: "Default",
-		providerCategories: ["Provider", "Health Plan", "Device Manufacturer"]
-	},
-	render: render
-}
-
-export const HideAddNewAction: Story = {
-	args: {
-		previewState: "Default",
-		hideRequestProviderButton: true
-	},
-	render: render
-}
-
-export const Searching: Story = {
-	args: {
-		previewState: "Searching"
-	},
-	render: render
+    args: {
+        colorScheme: 'auto',
+        previewState: 'Default',
+        providerCategories: [],
+        featuredProviderSource: false as any,
+        hideRequestProviderButton: false,
+        onProviderSelected: false as any
+    },
+    argTypes: {
+        colorScheme: {
+            name: 'color scheme',
+            control: 'radio',
+            options: ['auto', 'light', 'dark']
+        },
+        previewState: {
+            name: 'state',
+            control: 'radio',
+            options: [
+                'Default', 'Searching',
+                'Connected Provider', 'Connected Provider - Unauthorized',
+                'Disabled Provider - Same Endpoint', 'Disabled Provider - Same Managing Org', 'Disabled Provider - Unavailable'
+            ]
+        },
+        providerCategories: {
+            name: 'provider categories',
+            control: 'check',
+            options: ['Provider', 'Health Plan', 'Device Manufacturer']
+        },
+        featuredProviderSource: {
+            name: 'with featured providers?',
+            control: 'boolean',
+            mapping: {
+                true: 'hard coded',
+                false: undefined
+            }
+        },
+        hideRequestProviderButton: {
+            name: 'hide request provider button?',
+            control: 'boolean'
+        },
+        onProviderSelected: {
+            name: 'with custom provider selected handler?',
+            control: 'boolean',
+            mapping: {
+                true: (provider: ExternalAccountProvider) => alert(`Provider selected: ${provider.name}.`),
+                false: undefined
+            }
+        },
+        ...argTypesToHide([
+            'operatingMode', 'onProviderConnected', 'connectExternalAccountOptions', 'publicProviderSearchApiUrl', 'featuredProviders',
+            'featuredProvidersContext', 'publicFeaturedProvidersApiUrl', 'externalAccounts', 'innerRef'
+        ])
+    }
 }
 
 export const Live: Story = {
-	args: {
-		onProviderConnected: (provider: ExternalAccountProvider) => alert(`You connected to ${provider.name}`)
-	},
-	render: render
-}
-
-export const LiveStandalone: Story = {
-	args: {
-		connectExternalAccountOptions: {
-			openNewWindow: false,
-			standaloneModeFinalRedirectPath: "https://mydatahelps.org"// replace with actual redirect url for this to work
-		}
-	},
-	render: render
-}
-
-export const LiveOnProviderConnected: Story = {
-	args: {
-		onProviderConnected: (provider: ExternalAccountProvider) => alert(`Provider ${provider.name} connected.`)
-	},
-	render: render
-}
-
-export const FeaturedProviders: Story = {
-	args: {
-		previewState: "Default",
-		featuredProviders: [
-			{
-				"id": 430,
-				"name": "Medicare / CMS",
-				"category": "Health Plan",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/430/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 435,
-				"name": "Denver Health",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/435/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 567,
-				"name": "Kaiser Permanente - California - Southern",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/567/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 481,
-				"name": "Scripps Health",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/481/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 322,
-				"name": "Cleveland Clinic",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/322/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 1574,
-				"name": "United Healthcare (Medicare/Medicaid plans)",
-				"category": "Health Plan",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/1574/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 214,
-				"name": "Novant Health",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/214/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 170,
-				"name": "UNC Health Care",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/170/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 9403,
-				"name": "Athenahealth",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/9403/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 167,
-				"name": "Johns Hopkins Medicine",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/167/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 1457,
-				"name": "Aetna",
-				"category": "Health Plan",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/1457/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 1175,
-				"name": "Atrium Health",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/1175/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 250,
-				"name": "Providence Health & Services - Washington/Montana",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/250/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 546,
-				"name": "Duke Health",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/546/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 425,
-				"name": "UW Medicine (Washington)",
-				"category": "Provider",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/425/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 1459,
-				"name": "Cigna",
-				"category": "Health Plan",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/1459/logo",
-				"enabled": true
-			} as ExternalAccountProvider,
-			{
-				"id": 1456,
-				"name": "Humana",
-				"category": "Health Plan",
-				"logoUrl": "https://mydatahelps.org/api/v1/delegated/externalaccountproviders/1456/logo",
-				"enabled": true
-			} as ExternalAccountProvider
-		]
-	},
-	render: render
-}
-
-export const DisabledWithManagingOrganization: Story = {
     args: {
-        previewState: "Default",
-        featuredProviders: [
-            {
-                "id": 1,
-                "name": "Example Provider 1",
-                "category": "Provider",
-                "logoUrl": "https://example.com/logo1.png",
-                "enabled": false,
-                "managingOrganization": "Managing Organization ABC",
-                "message": "",
-                "relatedProvider": "Provider XYZ"
-            }
-        ]
+        colorScheme: 'auto',
+        operatingMode: 'unauthenticated',
+        providerCategories: [],
+        featuredProviderSource: 'dynamic',
+        featuredProvidersContext: 'Default',
+        hideRequestProviderButton: false,
+        onProviderSelected: false as any,
+        onProviderConnected: false as any,
+        standaloneModeFinalRedirectPath: ''
     },
-    render: render
-}
-
-export const DisabledWithoutManagingOrganization: Story = {
-    args: {
-        previewState: "Default",
-        featuredProviders: [
-            {
-                "id": 2,
-                "name": "Example Provider 2",
-                "category": "Provider",
-                "logoUrl": "https://example.com/logo2.png",
-                "enabled": false,
-                "managingOrganization": "",
-                "message": "",
-                "relatedProvider": "Provider XYZ"
+    argTypes: {
+        colorScheme: {
+            name: 'color scheme',
+            control: 'radio',
+            options: ['auto', 'light', 'dark']
+        },
+        operatingMode: {
+            name: 'operating mode',
+            control: 'radio',
+            options: ['unauthenticated', 'authenticated']
+        },
+        providerCategories: {
+            name: 'provider categories',
+            control: 'check',
+            options: ['Provider', 'Health Plan', 'Device Manufacturer']
+        },
+        featuredProviderSource: {
+            name: 'featured provider source',
+            control: 'radio',
+            options: ['hard coded', 'dynamic']
+        },
+        featuredProvidersContext: {
+            name: 'featured provider context',
+            if: { arg: 'featuredProviderSource', neq: 'hard coded' }
+        },
+        hideRequestProviderButton: {
+            name: 'hide request provider button?',
+            control: 'boolean'
+        },
+        onProviderSelected: {
+            name: 'with custom provider selected handler?',
+            control: 'boolean',
+            mapping: {
+                true: (provider: ExternalAccountProvider) => alert(`Provider selected: ${provider.name}.`),
+                false: undefined
             }
-        ]
-    },
-    render: render
-}
-
-export const DisabledWithoutManagingOrganizationAndMessageIsUnavailable: Story = {
-    args: {
-        previewState: "Default",
-        featuredProviders: [
-            {
-                "id": 2,
-                "name": "Example Provider 3",
-                "category": "Provider",
-                "logoUrl": "https://example.com/logo2.png",
-                "enabled": false,
-                "managingOrganization": "",
-                "message": "Unavailable",
-                "relatedProvider": "Provider XYZ",
+        },
+        onProviderConnected: {
+            name: 'with custom provider connected handler?',
+            control: 'boolean',
+            mapping: {
+                true: (provider: ExternalAccountProvider) => alert(`Provider connected: ${provider.name}.`),
+                false: undefined
             }
-        ]
-    },
-    render: render
+        },
+        standaloneModeFinalRedirectPath: {
+            name: 'standalone mode final redirect path'
+        },
+        ...argTypesToHide([
+            'previewState', 'connectExternalAccountOptions', 'publicProviderSearchApiUrl', 'featuredProviders',
+            'publicFeaturedProvidersApiUrl', 'externalAccounts', 'innerRef'
+        ])
+    }
 }

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -109,6 +109,14 @@ export default function ProviderSearch(props: ProviderSearchProps) {
         setExternalAccounts(operatingMode === 'authenticated' ? await MyDataHelps.getExternalAccounts() : []);
     };
 
+    const initialize = async (): Promise<void> => {
+        if (!featuredProviders) {
+            await loadFeaturedProviders();
+        }
+        await loadExternalAccounts();
+        setInitialized(true);
+    };
+
     useEffect(() => {
         if (initialized) return;
 
@@ -117,17 +125,7 @@ export default function ProviderSearch(props: ProviderSearchProps) {
             return;
         }
 
-        if (!featuredProviders) {
-            loadFeaturedProviders();
-            return;
-        }
-
-        if (!externalAccounts) {
-            loadExternalAccounts();
-            return;
-        }
-
-        setInitialized(true);
+        initialize();
     }, [initialized, featuredProviders, externalAccounts]);
 
     useEffect(() => {

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -98,7 +98,7 @@ export default function ProviderSearch(props: ProviderSearchProps) {
             const featuredProviders = operatingMode === 'authenticated'
                 ? await MyDataHelps.getFeaturedProviders(props.featuredProvidersContext)
                 : await getFeaturedPublicProviders(props.publicFeaturedProvidersApiUrl, props.featuredProvidersContext);
-            setFeaturedProviders(featuredProviders.sort((a, b) => a.name.localeCompare(b.name)));
+            setFeaturedProviders(featuredProviders);
         } catch (error) {
             console.error('Error loading featured providers.', error);
             setFeaturedProviders([]);

--- a/src/components/container/ProviderSearch/ProviderSearch.tsx
+++ b/src/components/container/ProviderSearch/ProviderSearch.tsx
@@ -1,125 +1,161 @@
-﻿import React, { useEffect, useMemo, useRef, useState } from 'react'
-import MyDataHelps, { ConnectExternalAccountOptions, ExternalAccount, ExternalAccountProvider } from "@careevolution/mydatahelps-js"
+﻿import React, { useEffect, useMemo, useRef, useState } from 'react';
+import MyDataHelps, { ConnectExternalAccountOptions, ExternalAccount, ExternalAccountProvider } from '@careevolution/mydatahelps-js';
 import { Action, LoadingIndicator, UnstyledButton } from '../../presentational';
-import { faSearch } from '@fortawesome/free-solid-svg-icons'
-import "./ProviderSearch.css"
-import language from "../../../helpers/language"
-import { previewProviders } from './ProviderSearch.previewdata';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import './ProviderSearch.css';
+import language from '../../../helpers/language';
+import { createPreviewData, ProviderSearchPreviewState } from './ProviderSearch.previewdata';
 import OnVisibleTrigger from '../../presentational/OnVisibleTrigger/OnVisibleTrigger';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { FontAwesomeSvgIcon } from 'react-fontawesome-svg-icon';
+import { getFeaturedPublicProviders, getPublicProviders } from '../../../helpers/public-providers';
+import debounce from 'lodash/debounce';
 
-const UNAVAILABLE_PROVIDER_MESSAGE = "Unavailable";
+export type ProviderSearchOperatingMode = 'authenticated' | 'unauthenticated';
 
 export interface ProviderSearchProps {
     previewState?: ProviderSearchPreviewState;
+    /**
+     * The mode this provider search should operate in.
+     *
+     * - The 'authenticated' mode uses delegated APIs to query for providers.  It also queries for existing external accounts.
+     * - The 'unauthenticated' mode uses public APIs to query for providers.  It does not attempt to load existing external accounts.
+     *
+     * The mode defaults to `authenticated` unless specified, or when either of the provider or featured provider public API URLs are specified.
+     */
+    operatingMode?: ProviderSearchOperatingMode;
     providerCategories?: string[];
     /** Callback function triggered when a provider is selected. If this function is defined it will override the normal action taken when selecting provider.*/
     onProviderSelected?: (provider: ExternalAccountProvider) => void;
     /** Callback function triggered after a provider is connected. */
     onProviderConnected?: (provider: ExternalAccountProvider) => void;
-    innerRef?: React.Ref<HTMLDivElement>;
     connectExternalAccountOptions?: ConnectExternalAccountOptions;
     hideRequestProviderButton?: boolean;
     /** URL for the public provider search API. If provided, this endpoint will be used instead of MyDataHelps.getExternalAccountProviders. */
     publicProviderSearchApiUrl?: string;
-    /** List of providers to display at the top when no search is active. */
+    /** List of providers to display at the top when no search is active. If populated, disables the dynamic featured provider lookup. */
     featuredProviders?: ExternalAccountProvider[];
+    /** The context to use when querying for featured providers.  Only used if featuredProviders is not set. */
+    featuredProvidersContext?: string;
+    /** URL for the public featured provider API. If provided, this endpoint will be used instead of MyDataHelps.getFeaturedProviders. */
+    publicFeaturedProvidersApiUrl?: string;
+    innerRef?: React.Ref<HTMLDivElement>;
 }
-
-export type ProviderSearchPreviewState = "Default" | "Searching";
 
 let currentRequestID = 0;
 
 /** Supports searching for Providers, and Health Plans for the purpose of connecting to participant data
  */
 export default function ProviderSearch(props: ProviderSearchProps) {
-    const [linkedExternalAccounts, setLinkedExternalAccounts] = useState<{ [id: number]: ExternalAccount; }>({});
+    const [featuredProviders, setFeaturedProviders] = useState<ExternalAccountProvider[] | undefined>(props.featuredProviders);
+    const [externalAccounts, setExternalAccounts] = useState<ExternalAccount[]>();
     const [searchResults, setSearchResults] = useState<ExternalAccountProvider[]>([]);
     const [searching, setSearching] = useState(true);
-    const [searchString, _setSearchString] = useState("");
+    const [searchString, setSearchString] = useState('');
     const [currentPage, setCurrentPage] = useState(0);
     const [totalResults, setTotalResults] = useState(0);
-    const addNewProviderUrl = "https://help.mydatahelps.org/hc/en-us/requests/new?ticket_form_id=34288897775635";
+    const [initialized, setInitialized] = useState<boolean>(false);
 
-    const searchStringRef = useRef(searchString);
-    const setSearchString = (data: string) => {
-        searchStringRef.current = data;
-        _setSearchString(data);
+    const pageSize = 45;
+
+    const operatingMode = props.operatingMode ?? ((props.publicProviderSearchApiUrl || props.publicFeaturedProvidersApiUrl) ? 'unauthenticated' : 'authenticated');
+
+    useEffect(() => {
+        setFeaturedProviders(props.featuredProviders);
+        setExternalAccounts(undefined);
+        setSearchResults([]);
+        setSearching(true);
+        setSearchString('');
+        setCurrentPage(0);
+        setTotalResults(0);
+        setInitialized(false);
+    }, [
+        props.previewState,
+        props.providerCategories, props.publicProviderSearchApiUrl,
+        props.featuredProviders, props.featuredProvidersContext, props.publicFeaturedProvidersApiUrl
+    ]);
+
+    const applyPreviewState = (previewState: ProviderSearchPreviewState): void => {
+        const previewData = createPreviewData(previewState);
+        if (!featuredProviders) {
+            setFeaturedProviders([]);
+            return;
+        }
+        if (!externalAccounts) {
+            setExternalAccounts(previewData.externalAccounts);
+            return;
+        }
+        if (previewState !== 'Searching') {
+            updateSearchResults(previewData.searchResults);
+            setTotalResults(previewData.searchResults.length);
+            setSearching(false);
+        }
+        setInitialized(true);
     };
 
-    const pageSize = 100;
+    const loadFeaturedProviders = async (): Promise<void> => {
+        try {
+            const featuredProviders = operatingMode === 'authenticated'
+                ? await MyDataHelps.getFeaturedProviders(props.featuredProvidersContext)
+                : await getFeaturedPublicProviders(props.publicFeaturedProvidersApiUrl, props.featuredProvidersContext);
+            setFeaturedProviders(featuredProviders.sort((a, b) => a.name.localeCompare(b.name)));
+        } catch (error) {
+            console.error('Error loading featured providers.', error);
+            setFeaturedProviders([]);
+        }
+    };
 
-    function initialize() {
+    const loadExternalAccounts = async (): Promise<void> => {
+        setExternalAccounts(operatingMode === 'authenticated' ? await MyDataHelps.getExternalAccounts() : []);
+    };
+
+    useEffect(() => {
+        if (initialized) return;
+
         if (props.previewState) {
-            if (props.previewState == "Default") {
-                updateSearchResults(previewProviders);
-                setSearching(false);
-            }
+            applyPreviewState(props.previewState);
             return;
         }
 
-        loadExternalAccounts().then(function () {
-            performSearch("");
-        });
-    }
-
-    async function loadExternalAccounts() {
-        MyDataHelps.getExternalAccounts().then(function (accounts) {
-            let externalAccounts: { [id: number]: ExternalAccount; } = {};
-            for (let i = 0; i < accounts.length; i++) {
-                externalAccounts[accounts[i].provider.id] = accounts[i];
-            }
-            setLinkedExternalAccounts(externalAccounts);
-        });
-    }
-
-    function performSearch(search: string) {
-        setSearching(true);
-        let requestID = ++currentRequestID;
-
-        if (!props.publicProviderSearchApiUrl) {
-            MyDataHelps.getExternalAccountProviders(search, props.providerCategories?.length == 1 ? props.providerCategories[0] : null, pageSize, currentPage).then(function (searchResultsResponse) {
-                if (requestID == currentRequestID) {
-                    updateSearchResults(searchResultsResponse.externalAccountProviders);
-                    setTotalResults(searchResultsResponse.totalExternalAccountProviders);
-                    setSearching(false);
-                }
-            }).catch(function (error) {
-                console.error("Error fetching external account providers", error);
-                setSearching(false);
-            });
-        } else {
-            const url = new URL(props.publicProviderSearchApiUrl);
-            url.searchParams.append('keyword', search);
-            url.searchParams.append('pageSize', String(pageSize));
-            url.searchParams.append('pageNumber', String(currentPage + 1));
-            fetch(url.toString(), {
-                method: "GET",
-                headers: { "Accept": "application/json" },
-            })
-                .then((response) => response.json())
-                .then(function (searchResultsResponse) {
-                    if (requestID == currentRequestID) {
-                        updateSearchResults(searchResultsResponse.Providers.map((p: any) => ({ id: p.ID, name: p.OrganizationName, logoUrl: p.LogoURL, category: p.Category } as ExternalAccountProvider)) || []);
-                        setTotalResults(searchResultsResponse.TotalCount);
-                        setSearching(false);
-                    }
-                })
-                .catch(function (error) {
-                    console.error("Error fetching external account providers", error);
-                    setSearching(false);
-                });
+        if (!featuredProviders) {
+            loadFeaturedProviders();
+            return;
         }
-    }
 
-    function updateSearchResults(providers: ExternalAccountProvider[]) {
-        let newResults: ExternalAccountProvider[] = searchResults;
-        if (searchStringRef.current === "" && props.featuredProviders) {
-            newResults = newResults.concat(props.featuredProviders);
-            providers = providers.filter(a => !props.featuredProviders!.find(b => b.id == a.id));
+        if (!externalAccounts) {
+            loadExternalAccounts();
+            return;
         }
-        const updatedSearchResults = newResults.concat(providers).filter(a => props.providerCategories?.indexOf(a.category) != -1 && a.message !== UNAVAILABLE_PROVIDER_MESSAGE);
+
+        setInitialized(true);
+    }, [initialized, featuredProviders, externalAccounts]);
+
+    useEffect(() => {
+        if (props.previewState) return;
+        MyDataHelps.on('applicationDidBecomeVisible', loadExternalAccounts);
+        return () => {
+            MyDataHelps.off('applicationDidBecomeVisible', loadExternalAccounts);
+        };
+    }, []);
+
+    const filterProviders = (providers: ExternalAccountProvider[], providersToExclude?: ExternalAccountProvider[]): ExternalAccountProvider[] => {
+        const providerIdsToExclude = providersToExclude?.map(provider => provider.id) ?? [];
+        return providers.filter(provider => {
+            if (providerIdsToExclude.includes(provider.id)) return false;
+            if (props.providerCategories && !props.providerCategories.includes(provider.category)) return false;
+            return provider.message !== 'Unavailable';
+        })
+    };
+
+    const updateSearchResults = (newProviders: ExternalAccountProvider[]): void => {
+        const updatedSearchResults: ExternalAccountProvider[] = [];
+
+        if (searchString === '' && searchResults.length === 0 && featuredProviders && featuredProviders.length > 0) {
+            updatedSearchResults.push(...filterProviders(featuredProviders));
+        } else if (searchResults.length > 0) {
+            updatedSearchResults.push(...searchResults);
+        }
+        updatedSearchResults.push(...filterProviders(newProviders, updatedSearchResults));
 
         // HACK: Temporarily default all provider enabled flags to true when they have not been set by the API.
         // This should remain while the API is not setting the enabled flag.
@@ -131,105 +167,120 @@ export default function ProviderSearch(props: ProviderSearchProps) {
         });
 
         setSearchResults(updatedSearchResults);
-    }
-
-    const debounce = (fn: Function, ms = 300) => {
-        let timeoutId: ReturnType<typeof setTimeout>;
-        return function (this: any, ...args: any[]) {
-            clearTimeout(timeoutId);
-            timeoutId = setTimeout(() => fn.apply(this, args), ms);
-        };
     };
 
-    const debouncedPerformSearch = useMemo(() => debounce(performSearch, 300), []);
+    const performSearch = async (): Promise<void> => {
+        setSearching(true);
+        const requestID = ++currentRequestID;
 
-    function updateSearch(event: React.ChangeEvent<HTMLInputElement>) {
+        try {
+            const searchCategory = props.providerCategories?.length === 1 ? props.providerCategories[0] : null;
+            const providersPage = operatingMode === 'authenticated'
+                ? await MyDataHelps.getExternalAccountProviders(searchString, searchCategory, pageSize, currentPage)
+                : await getPublicProviders(props.publicProviderSearchApiUrl, searchString, pageSize, currentPage)
+
+            if (requestID == currentRequestID) {
+                updateSearchResults(providersPage.externalAccountProviders);
+                setTotalResults(providersPage.totalExternalAccountProviders);
+                setSearching(false);
+            }
+        } catch (error) {
+            console.error('Error searching for providers.', error);
+            setSearching(false);
+        }
+    };
+
+    const performSearchRef = useRef(performSearch);
+    useEffect(() => {
+        performSearchRef.current = performSearch;
+    }, [performSearch]);
+    const debouncedPerformSearch = useMemo(() => debounce(() => performSearchRef.current(), 300), []);
+
+    useEffect(() => {
+        if (initialized && !props.previewState) {
+            debouncedPerformSearch();
+        }
+    }, [initialized, searchString, currentPage]);
+
+    const updateSearch = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setSearchString(event.target.value);
-        setSearchResults([]);
         setCurrentPage(0);
-        if (props.previewState) {
-            return;
-        }
-        debouncedPerformSearch(event.target.value);
-    }
+        setSearchResults([]);
+    };
 
-    function onApplicationDidBecomeVisible() {
-        loadExternalAccounts().then(function () {
-            performSearch(searchStringRef.current);
-        });
-    }
+    const canConnectToProvider = (provider: ExternalAccountProvider): boolean => {
+        return provider.enabled || externalAccountsById[provider.id]?.status === 'unauthorized';
+    };
 
-    function canLoadNextPage() {
-        return pageSize > 0 && (currentPage + 1) * pageSize < totalResults;
-    }
+    const connectToProvider = async (provider: ExternalAccountProvider): Promise<void> => {
+        if (props.previewState || !canConnectToProvider(provider)) return;
 
-    function loadNextPage() {
-        setCurrentPage(currentPage + 1);
-    }
+        await MyDataHelps.connectExternalAccount(provider.id, props.connectExternalAccountOptions ?? { openNewWindow: true });
+        props.onProviderConnected?.(provider);
+        loadExternalAccounts();
+    };
 
-    useEffect(() => {
-        initialize();
-        MyDataHelps.on("applicationDidBecomeVisible", onApplicationDidBecomeVisible);
-        return () => {
-            MyDataHelps.off("applicationDidBecomeVisible", onApplicationDidBecomeVisible);
-        }
-    }, []);
+    const getDisabledProviderStatus = (provider: ExternalAccountProvider): string => {
+        const key = provider.managingOrganization
+            ? 'provider-disabled-reason-with-managing-organization'
+            : 'provider-disabled-reason-without-managing-organization';
 
-    useEffect(() => {
-        if (!searching) {
-            performSearch(searchStringRef.current)
-        }
-    }, [currentPage]);
+        const args = {
+            provider: provider.name,
+            relatedProvider: provider.relatedProvider ?? '',
+            managingOrganization: provider.managingOrganization ?? ''
+        };
 
-    const supportsRequestProviderAction = (): boolean => {
-        return !props.providerCategories
-            || props.providerCategories.length == 0
-            || props.providerCategories.includes("Provider")
-            || props.providerCategories.includes("Health Plan");
+        return language(key, undefined, args);
     };
 
     const shouldShowRequestProviderAction = (): boolean => {
-        return !searching && !props.hideRequestProviderButton && supportsRequestProviderAction();
+        if (searching || props.hideRequestProviderButton) return false;
+        return !props.providerCategories
+            || props.providerCategories.length === 0
+            || props.providerCategories.includes('Provider')
+            || props.providerCategories.includes('Health Plan');
     };
 
     const buildRequestProviderActionTitle = (): string => {
-        let titleSuffix = "";
+        let titleSuffix = '';
 
-        if (!props.providerCategories || props.providerCategories.length == 0 || props.providerCategories.includes("Provider")) {
+        if (!props.providerCategories || props.providerCategories.length == 0 || props.providerCategories.includes('Provider')) {
             titleSuffix += language('external-accounts-title-providers');
         }
 
-        if (!props.providerCategories || props.providerCategories.length == 0 || props.providerCategories.includes("Health Plan")) {
+        if (!props.providerCategories || props.providerCategories.length == 0 || props.providerCategories.includes('Health Plan')) {
             if (titleSuffix.length > 0) {
                 titleSuffix += language('external-accounts-title-divider');
             }
             titleSuffix += language('external-accounts-title-health-plans');
         }
 
-        return `${(language("request-add"))} ${titleSuffix}`;
+        return `${(language('request-add'))} ${titleSuffix}`;
     };
 
     const requestProviderAction = (): void => {
-        MyDataHelps.openEmbeddedUrl(addNewProviderUrl);
+        MyDataHelps.openEmbeddedUrl('https://help.mydatahelps.org/hc/en-us/requests/new?ticket_form_id=34288897775635');
     };
 
-    const canConnectToProvider = (provider: ExternalAccountProvider): boolean => {
-        return provider.enabled || linkedExternalAccounts[provider.id]?.status === 'unauthorized';
+    const canLoadNextPage = (): boolean => {
+        return !searching && (currentPage + 1) * pageSize < totalResults;
     };
 
-    const connectToProvider = async (provider: ExternalAccountProvider): Promise<void> => {
-        if (props.previewState || !canConnectToProvider(provider)) return;
-
-        await MyDataHelps.connectExternalAccount(provider.id, props.connectExternalAccountOptions || { openNewWindow: true });
-        props.onProviderConnected?.(provider);
-        loadExternalAccounts();
+    const loadNextPage = (): void => {
+        setCurrentPage(currentPage + 1);
     };
+
+    const externalAccountsById = (externalAccounts ?? []).reduce((linkedExternalAccounts, externalAccount) => {
+        linkedExternalAccounts[externalAccount.provider.id] = externalAccount;
+        return linkedExternalAccounts;
+    }, {} as Record<number, ExternalAccount>);
 
     return (
         <div ref={props.innerRef} className="mdhui-provider-search">
             <div className="search-bar-wrapper">
                 <div className="search-bar">
-                    <input title={language("search")} type="text" value={searchString} onChange={(event) => updateSearch(event)} placeholder={language("search")} spellCheck="false" autoComplete="off" autoCorrect="off" autoCapitalize="off" />
+                    <input title={language('search')} type="text" value={searchString} onChange={updateSearch} placeholder={language('search')} spellCheck="false" autoComplete="off" autoCorrect="off" autoCapitalize="off" />
                     <FontAwesomeSvgIcon icon={faSearch} />
                 </div>
             </div>
@@ -244,35 +295,18 @@ export default function ProviderSearch(props: ProviderSearchProps) {
                     }}>
                         <div className="provider-info">
                             <div className="provider-name">{provider.name}</div>
-                            {linkedExternalAccounts[provider.id] && linkedExternalAccounts[provider.id].status == 'unauthorized' &&
-                                <div className="provider-status error-status">{language("expired-reconnect")}</div>
+                            {externalAccountsById[provider.id] && externalAccountsById[provider.id].status === 'unauthorized' &&
+                                <div className="provider-status error-status">{language('expired-reconnect')}</div>
                             }
-                            {linkedExternalAccounts[provider.id] && linkedExternalAccounts[provider.id].status != 'unauthorized' &&
-                                <div className="provider-status connected-status">{language("connected")}</div>
+                            {externalAccountsById[provider.id] && externalAccountsById[provider.id].status !== 'unauthorized' &&
+                                <div className="provider-status connected-status">{language('connected')}</div>
                             }
-                            {!linkedExternalAccounts[provider.id] && !provider.enabled &&
-                                <div className="provider-status connected-status">
-                                    {(() => {
-                                        const params: { provider: string; relatedProvider?: string; managingOrganization?: string } = {
-                                            "provider": provider.name
-                                        };
-                                        if (provider.relatedProvider) {
-                                            params.relatedProvider = provider.relatedProvider;
-                                        }
-                                        if (provider.managingOrganization) {
-                                            params.managingOrganization = provider.managingOrganization;
-                                        }
-                                        const key = provider.managingOrganization
-                                            ? "provider-disabled-reason-with-managing-organization"
-                                            : "provider-disabled-reason-without-managing-organization";
-
-                                        return language(key, undefined, params);
-                                    })()}
-                                </div>
+                            {!externalAccountsById[provider.id] && !provider.enabled &&
+                                <div className="provider-status connected-status">{getDisabledProviderStatus(provider)}</div>
                             }
                         </div>
                         {provider.logoUrl &&
-                            <div className="provider-logo" style={{ backgroundImage: "url('" + provider.logoUrl + "')" }}></div>
+                            <div className="provider-logo" style={{ backgroundImage: 'url(\'' + provider.logoUrl + '\')' }}></div>
                         }
                     </UnstyledButton>
                 )}

--- a/src/components/container/ProviderSearch/index.ts
+++ b/src/components/container/ProviderSearch/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./ProviderSearch";
+export { default } from './ProviderSearch';
+export { ProviderSearchPreviewState } from './ProviderSearch.previewdata';

--- a/src/components/step/ConnectEhrStep/ConnectEhrStep.tsx
+++ b/src/components/step/ConnectEhrStep/ConnectEhrStep.tsx
@@ -5,7 +5,7 @@ import StepNextButton from "../StepNextButton";
 import StepText from "../StepText";
 import StepTitle from "../StepTitle";
 import { ExternalAccountProvider } from "@careevolution/mydatahelps-js";
-import { ProviderSearchPreviewState } from "../../container/ProviderSearch/ProviderSearch";
+import { ProviderSearchPreviewState } from "../../container/ProviderSearch";
 
 import './ConnectEhrStep.css';
 

--- a/src/helpers/public-providers.ts
+++ b/src/helpers/public-providers.ts
@@ -1,0 +1,36 @@
+import { ExternalAccountProvider, ExternalAccountProvidersPage } from '@careevolution/mydatahelps-js';
+
+const toExternalAccountProvider = (provider: any): ExternalAccountProvider => {
+    return {
+        id: provider.ID,
+        name: provider.OrganizationName,
+        logoUrl: provider.LogoURL,
+        category: provider.Category,
+        enabled: true
+    };
+};
+
+export function getFeaturedPublicProviders(publicFeaturedProvidersApiUrl: string | undefined, featuredProvidersContext?: string): Promise<ExternalAccountProvider[]> {
+    const url = new URL(publicFeaturedProvidersApiUrl ?? 'https://designer.mydatahelps.org/api/featuredfhirpublicproviders');
+    if (featuredProvidersContext) {
+        url.searchParams.append('featuredProvidersContext', featuredProvidersContext);
+    }
+    return fetch(url.toString(), { method: 'GET', headers: { 'Accept': 'application/json' } })
+        .then(response => response.json())
+        .then(providers => providers.map(toExternalAccountProvider));
+}
+
+export function getPublicProviders(publicProviderSearchApiUrl: string | undefined, search: string, pageSize: number, currentPageIndex: number): Promise<ExternalAccountProvidersPage> {
+    const url = new URL(publicProviderSearchApiUrl ?? 'https://designer.mydatahelps.org/api/fhirpublicproviders');
+    url.searchParams.append('keyword', search);
+    url.searchParams.append('pageSize', String(pageSize));
+    url.searchParams.append('pageNumber', String(currentPageIndex + 1));
+    return fetch(url.toString(), { method: 'GET', headers: { 'Accept': 'application/json' }, })
+        .then((response) => response.json())
+        .then(pagedResult => {
+            return {
+                externalAccountProviders: pagedResult.Providers.map(toExternalAccountProvider),
+                totalExternalAccountProviders: pagedResult.TotalCount
+            };
+        });
+}


### PR DESCRIPTION
## Overview

This branch updates the `ProviderSearch` component to adjust how featured providers are supported.  It also introduces an "operating mode" concept and corrects a couple of timing/closure related bugs I found with paging while working on that update.

The storybook entries for the `ProviderSearch` were also overhauled.

## Operating Mode

This new property can be set to `authenticated` or `unauthenticated`.  If not specified, it will default to `authenticated` unless either the `publicProviderSearchApiUrl` or `publicFeaturedProvidersApiUrl` URLs are set.  In that case, it will default to `unauthenticated`.

In `authenticated` mode, the component will use the delegated APIs to load featured providers (if they have not been manually set), search for providers, and load existing external accounts.

In `unauthenticated` mode, the component will use the public APIs to load featured providers (if they have not been manually set) and search for providers.  When in `unauthenticated` mode, no attempt is made to load existing external accounts, since those are only available through the authentication-requiring delegated APIs.

Note that `unauthenticated` API querying used to require that the public URL was specified.  This is no longer the case.  When operating in `unauthenticated` mode, the component will use default public URLs (for featured providers and searching) unless they are overridden by the `publicProviderSearchApiUrl` and `publicFeaturedProvidersApiUrl` properties.

## Featured Providers

Previously, a featured provider list could be hard coded on the `ProviderSearch` component.  This is still supported.  However, if the hard coded featured provider list is not set, the component will attempt to load the list of featured providers from either the delegated or public API based on the operating mode.

A new `featuredProvidersContext` property can be set to select a specific featured provider list.

The new `publicFeaturedProvidersApiUrl` can be used to override the default public featured providers API URL.

## Bug Fixes

There were a couple paging issues related to timing and JS closures.

The `applicationDidBecomeVisible` listener, which was re-performing a search, was doing so with the correct up-to-date search string, but using an outdated version of the `performSearch` function, which had an outdated version of the `updateSearchResults` function, which had an outdated (empty) version of the `searchResults` state.  As a result, we were losing pages of results when returning from the background because the existing search results were empty each time.

In a related issue, the `OnVisibleTrigger` was not being disabled while a search was in progress, so it was allowing the `currentPage` to be updated again while a search was in progress.  The `useEffect` watching the `currentPage` value for changes was not performing a new search if a search was already in progress, but that also meant those pages were then lost.

I've done a fair bit of reorganization to the loading and lifecycle of the component to address these issues.  I've also done a fair amount of testing and believe that everything is working as expected now.  However, this component could use a good pass or two of regression testing by someone else to make sure I'm not overlooking something.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  This does introduce the use of another couple API endpoints, but those were already available outside this component.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [x] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

DESCRIBE YOUR TEST PLAN

- I have updated the storybook entries quite a bit to allow for testing of these updates, however, end-to-end testing of the connection and refresh flow will likely need a VB PR.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [x] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.
