### PR TITLE
Correct the combined steps availability check sources.

### DIFF
--- a/src/helpers/daily-data-types/combined.tsx
+++ b/src/helpers/daily-data-types/combined.tsx
@@ -35,14 +35,17 @@ const STEPS_SOURCES = sources(
     ["AppleHealth", "HourlySteps"],
     ["Fitbit", "Steps"],
     ["Garmin", "Daily"],
-    ["Oura", "steps", true]
+    ["HealthConnect", "steps-daily", true],
+    ["Oura", "daily-activity", true]
 );
 
 const STEPS_WITH_GOOGLE_FIT_SOURCES = sources(
     ["AppleHealth", "HourlySteps"],
     ["GoogleFit", "Steps"],
     ["Fitbit", "Steps"],
-    ["Garmin", "Daily"]
+    ["Garmin", "Daily"],
+    ["HealthConnect", "steps-daily", true],
+    ["Oura", "daily-activity", true]
 );
 
 const SLEEP_MINUTES_SOURCES = sources(


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

During some data provider testing, I noticed that the combined steps data provider availability sources were not correct.

While adding the new HC steps data provider https://github.com/CareEvolution/MyDataHelpsUI/pull/483, I forgot to update the sources.

I also noticed that the Oura source was missing from the one definition and was incorrect in the other, so that has been fixed as well.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just fixing the data types the combined steps provider will use when querying for data availability.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [x] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

Create a view builder view with the combined steps provider.  Verify that it queries for available data using the correct data types.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.

