### PR TITLE
GlucoseChart Steps - Avoid querying for Fitbit and Garmin half hour steps when their intraday types are not enabled in V2.

### DIFF
--- a/src/helpers/glucose-and-meals/steps.ts
+++ b/src/helpers/glucose-and-meals/steps.ts
@@ -90,10 +90,11 @@ export async function getSteps(date: Date): Promise<Reading[]> {
     const providers: Promise<Reading[]>[] = [];
 
     const { settings, deviceDataV2Types } = await getCombinedDataCollectionSettings(true);
-    if (settings.fitbitEnabled) {
+
+    if (settings.fitbitEnabled && deviceDataV2Types.some(ddt => ddt.namespace === 'Fitbit' && ddt.type === 'activities-steps-intraday')) {
         providers.push(fitbitHalfHourStepsDataProvider(date));
     }
-    if (settings.garminEnabled) {
+    if (settings.garminEnabled && deviceDataV2Types.some(ddt => ddt.namespace === 'Garmin' && ddt.type === 'epoch-steps')) {
         providers.push(garminHalfHourStepsDataProvider(date));
     }
     if (settings.appleHealthEnabled && settings.queryableDeviceDataTypes.some(ddt => ddt.namespace === 'AppleHealth' && ddt.type === 'HalfHourSteps')) {


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

Added a couple filters to the combined half hour steps data provider used by the `GlucoseChart` to avoid querying for Fitbit and/or Garmin half hour step aggregates when their respective data types have not been enabled in the V2 API.

The API returns an error in those scenarios.  The client side code already handles those errors gracefully, but there is no need to make the query in the first place when we know it will fail.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just an update to avoid making some unnecessary API queries.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [x] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

This could probably be tested using the storybook in live mode, but it is pretty simple to test via ViewBuilder as well.

- Create a view with the glucose chart.
- Configure that view in your test App Layout.
- Verify that the Fitbit and Garmin queries are bypassed if those sources are enabled, but their respective intraday step data types have not be enabled in V2.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.