### PR TITLE
GlucoseDayCoordinator: Add support for a minimum date limit.

### DIFF
--- a/src/components/container/GlucoseDayCoordinator/GlucoseDayCoordinator.stories.tsx
+++ b/src/components/container/GlucoseDayCoordinator/GlucoseDayCoordinator.stories.tsx
@@ -2,11 +2,13 @@ import { Meta, StoryObj } from '@storybook/react';
 import React from 'react'
 import { DateRangeTitle, Layout } from '../../presentational'
 import GlucoseDayCoordinator from './GlucoseDayCoordinator';
-import { GlucoseDayCoordinatorPreviewState } from "./GlucoseDayCoordinator.previewData";
+import { GlucoseDayCoordinatorPreviewState } from './GlucoseDayCoordinator.previewData';
+import { argTypesToHide } from '../../../../.storybook/helpers';
 
 type GlucoseDayCoordinatorStoryArgs = React.ComponentProps<typeof GlucoseDayCoordinator> & {
     colorScheme: 'auto' | 'light' | 'dark'
     state: GlucoseDayCoordinatorPreviewState | 'live';
+    minimumDateMillis: number;
 };
 
 const meta: Meta<GlucoseDayCoordinatorStoryArgs> = {
@@ -17,7 +19,11 @@ const meta: Meta<GlucoseDayCoordinatorStoryArgs> = {
     },
     render: args => {
         return <Layout colorScheme={args.colorScheme}>
-            <GlucoseDayCoordinator {...args} previewState={args.state !== 'live' ? args.state as GlucoseDayCoordinatorPreviewState : undefined}>
+            <GlucoseDayCoordinator
+                {...args}
+                minimumDate={args.minimumDateMillis ? new Date(args.minimumDateMillis) : undefined}
+                previewState={args.state !== 'live' ? args.state as GlucoseDayCoordinatorPreviewState : undefined}
+            >
                 <DateRangeTitle defaultMargin />
             </GlucoseDayCoordinator>
         </Layout>;
@@ -30,7 +36,8 @@ type Story = StoryObj<GlucoseDayCoordinatorStoryArgs>;
 export const Default: Story = {
     args: {
         colorScheme: 'auto',
-        state: 'all data'
+        state: 'all data',
+        minimumDate: undefined
     },
     argTypes: {
         colorScheme: {
@@ -42,7 +49,11 @@ export const Default: Story = {
             name: 'state',
             control: 'radio',
             options: ['no data', 'some data', 'all data', 'live']
-        }
+        },
+        minimumDateMillis: {
+            name: 'minimum date',
+            control: 'date'
+        },
+        ...argTypesToHide(['minimumDate'])
     }
 };
-

--- a/src/components/container/GlucoseDayCoordinator/GlucoseDayCoordinator.tsx
+++ b/src/components/container/GlucoseDayCoordinator/GlucoseDayCoordinator.tsx
@@ -7,6 +7,7 @@ import { GlucoseDayCoordinatorPreviewState, previewData } from './GlucoseDayCoor
 
 export interface GlucoseDayCoordinatorProps {
     previewState?: GlucoseDayCoordinatorPreviewState;
+    minimumDate?: Date;
     children?: React.ReactNode;
     innerRef?: React.Ref<HTMLDivElement>;
 }
@@ -53,6 +54,7 @@ export default function (props: GlucoseDayCoordinatorProps) {
         <GlucoseContext.Provider value={{ readings: glucoseReadings, recentAverage: recentAverage }}>
             <DateRangeCoordinator initialIntervalStart={startOfToday()} intervalType="Day" useCustomNavigator={true}>
                 <GlucoseDayNavigator
+                    minimumDate={props.minimumDate}
                     loadData={loadData}
                     dayRenderer={dayRenderer}
                     dependencies={[props.previewState]}
@@ -64,6 +66,7 @@ export default function (props: GlucoseDayCoordinatorProps) {
 }
 
 interface GlucoseDayNavigatorProps {
+    minimumDate?: Date;
     loadData: (startDate: Date, endDate: Date) => Promise<void>;
     dayRenderer: (dayKey: string) => React.JSX.Element | null;
     dependencies?: DependencyList;
@@ -73,6 +76,7 @@ function GlucoseDayNavigator(props: GlucoseDayNavigatorProps) {
     const dateRangeContext = useContext(DateRangeContext)
 
     return <WeeklyDayNavigator
+        minimumDate={props.minimumDate}
         selectedDate={dateRangeContext!.intervalStart}
         loadData={props.loadData}
         dayRenderer={props.dayRenderer}

--- a/src/components/container/WeeklyDayNavigator/WeeklyDayNavigator.tsx
+++ b/src/components/container/WeeklyDayNavigator/WeeklyDayNavigator.tsx
@@ -5,6 +5,7 @@ import { useInitializeView } from '../../../helpers';
 import getDayKey from '../../../helpers/get-day-key';
 
 export interface WeeklyDayNavigatorProps {
+    minimumDate?: Date;
     selectedDate: Date;
     loadData: (startDate: Date, endDate: Date) => Promise<void>;
     dayRenderer: (dayKey: string) => React.JSX.Element | null;
@@ -28,7 +29,13 @@ export default function (props: WeeklyDayNavigatorProps) {
         }
 
         setLoading(true);
-        props.loadData(add(weekStart, { days: -7 }), add(weekStart, { days: 14 })).then(() => {
+
+        let startDate = add(weekStart, { days: -7 });
+        if ( props.minimumDate && startDate < props.minimumDate ){
+            startDate = props.minimumDate;
+        }
+
+        props.loadData(startDate, add(weekStart, { days: 14 })).then(() => {
             setLoading(false);
         });
     }, ['externalAccountSyncComplete'], [weekStart, ...(props.dependencies ?? [])]);
@@ -44,6 +51,7 @@ export default function (props: WeeklyDayNavigatorProps) {
 
     return <WeekCalendar
         innerRef={props.innerRef}
+        minimumDate={props.minimumDate}
         startDate={weekStart}
         onStartDateChange={onStartDateChanged}
         selectedDate={props.selectedDate}

--- a/src/components/presentational/WeekCalendar/WeekCalendar.css
+++ b/src/components/presentational/WeekCalendar/WeekCalendar.css
@@ -84,6 +84,7 @@
     font-weight: bold;
 }
 
+.mdhui-week-calendar .mdhui-week-calendar-day-disabled>*,
 .mdhui-week-calendar .mdhui-week-calendar-day-future>* {
     opacity: .4;
 }

--- a/src/components/presentational/WeekCalendar/WeekCalendar.tsx
+++ b/src/components/presentational/WeekCalendar/WeekCalendar.tsx
@@ -7,6 +7,7 @@ import debounce from 'lodash/debounce';
 import { getDayOfWeekLetter, getDayOfMonth } from "../../../helpers/date-helpers";
 
 export interface WeekCalendarProps {
+	minimumDate?: Date;
 	selectedDate?: Date;
 	hideDateLabel?: boolean;
 	startDate: Date;
@@ -20,13 +21,15 @@ export interface WeekCalendarProps {
 export default function WeekCalendar(props: WeekCalendarProps) {
 	const element = useRef<HTMLDivElement>(null);
 
+	const canScrollBackward = !props.minimumDate || props.startDate > props.minimumDate;
+
 	useEffect(() => {
 		if (props.onStartDateChange) {
 			var scrollListener = debounce(function (ev: Event) {
-				if (element.current?.scrollLeft == 0) {
+				if (canScrollBackward && element.current?.scrollLeft == 0) {
 					props.onStartDateChange!(add(props.startDate, { weeks: -1 }));
 					element.current?.removeEventListener("scroll", scrollListener);
-				} else if (element.current?.clientWidth && element.current?.scrollLeft == element.current.clientWidth * 2) {
+				} else if (element.current?.clientWidth && element.current?.scrollLeft == element.current.clientWidth * (canScrollBackward ? 2 : 1)) {
 					props.onStartDateChange!(add(props.startDate, { weeks: 1 }));
 					element.current?.removeEventListener("scroll", scrollListener);
 				}
@@ -36,7 +39,7 @@ export default function WeekCalendar(props: WeekCalendarProps) {
 				element.current?.removeEventListener("scroll", scrollListener);
 			}
 		}
-	}, [props.startDate])
+	}, [props.onStartDateChange, canScrollBackward, props.startDate]);
 
 	var previousWeek: Date[] = [];
 	var currentWeek: Date[] = [];
@@ -55,12 +58,12 @@ export default function WeekCalendar(props: WeekCalendarProps) {
 
 	useEffect(() => {
 		if (element.current) {
-			element.current.scrollLeft = window.innerWidth;
+			element.current.scrollLeft = canScrollBackward ? window.innerWidth : 0;
 		}
 	});
 
 	if (element.current) {
-		element.current.scrollLeft = window.innerWidth;
+		element.current.scrollLeft = canScrollBackward ? window.innerWidth : 0;
 	}
 
 	function getLabel(date: Date) {
@@ -72,7 +75,9 @@ export default function WeekCalendar(props: WeekCalendarProps) {
 
 	function getDayClasses(date: Date) {
 		var classes = ["mdhui-week-calendar-day"];
-		if (date > new Date()) {
+		if (props.minimumDate && date < props.minimumDate) {
+			classes.push("mdhui-week-calendar-day-disabled");
+		} else if (date > new Date()) {
 			classes.push("mdhui-week-calendar-day-future");
 		}
 		else if (props.onDateSelected) {
@@ -85,6 +90,9 @@ export default function WeekCalendar(props: WeekCalendarProps) {
 	}
 
 	function selectDate(date: Date) {
+		if (props.minimumDate && date < props.minimumDate) {
+			return;
+		}
 		if (date > new Date()) {
 			return;
 		}
@@ -101,14 +109,16 @@ export default function WeekCalendar(props: WeekCalendarProps) {
 					<LoadingIndicator />
 				</div>
 			}
-			<div className="mdhui-week-calendar-week">
-				{previousWeek.map((d) =>
-					<div key={d.getTime()} className="mdhui-week-calendar-day">
-						{props.dayRenderer(d.getFullYear(), d.getMonth(), d.getDate(), false)}
-						{!props.hideDateLabel && getLabel(d)}
-					</div>
-				)}
-			</div>
+			{canScrollBackward &&
+				<div className="mdhui-week-calendar-week">
+					{previousWeek.map((d) =>
+						<div key={d.getTime()} className="mdhui-week-calendar-day">
+							{props.dayRenderer(d.getFullYear(), d.getMonth(), d.getDate(), false)}
+							{!props.hideDateLabel && getLabel(d)}
+						</div>
+					)}
+				</div>
+			}
 			<div className="mdhui-week-calendar-week">
 				{currentWeek.map((d) =>
 					<UnstyledButton key={d.getTime()}


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

This branch updates the `GlucoseDayCoordinator`, `WeeklyDayNavigator`, and `WeekCalendar` to support a minimum date.

Currently, we allow for unlimited scrolling into the past.  However, given our increase in the use of V2 data, which has a more limited retention/availability period, there are situations where we'll want to be able to limit how far a user can scroll into the past.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just adding an optional limit to how far a user can scroll into the past.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

DESCRIBE YOUR TEST PLAN

- Open the Storybook.
- Visit the `GlucoseDayCoordinator` story.
- Set a minimum date.
- Verify that you cannot scroll back beyond the week which renders that date.
- Verify that dates prior to the minimum date are grayed out and are not selectable.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [x] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.
