### PR TITLE
Localize the no notifications message.

### DIFF
--- a/src/components/presentational/SingleNotification/SingleNotification.tsx
+++ b/src/components/presentational/SingleNotification/SingleNotification.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import "./SingleNotification.css";
 import { Notification } from "@careevolution/mydatahelps-js";
 import { getRelativeDateString } from '../../../helpers/date-helpers';
+import { language } from "../../../helpers/language";
 
 export interface SingleNotificationProps {
 	notification: Notification | null
@@ -12,7 +13,7 @@ export default function (props: SingleNotificationProps) {
 	if (!props.notification) {
 		return (
 			<div ref={props.innerRef} className="mdhui-single-notification">
-				<div className="notification-body">No notifications received</div>
+				<div className="notification-body">{language('no-notifications-received')}</div>
 			</div>
 		)
 	}


### PR DESCRIPTION
## Overview

The "no notifications" message in SingleNotification isn't translated:

Use [SingleNotification](https://ui.mydatahelps.org/?path=/docs/presentational-singlenotification--docs) story with the raw notification data set to null.

<img width="1083" height="427" alt="image" src="https://github.com/user-attachments/assets/5b11b980-0c09-4694-87f6-69c725c2e187" />


## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [X] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Just using the translations.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [X] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [X] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
