### PR TITLE
Meal log CSS tweaks.

### DIFF
--- a/src/components/presentational/MealLog/MealLog.css
+++ b/src/components/presentational/MealLog/MealLog.css
@@ -6,11 +6,11 @@
     padding: 0 16px;
 }
 
-.mdhui-meal-log .mdhui-loading-indicator {
+.mdhui-meal-log .mdhui-meal-log-loading.mdhui-loading-indicator {
     padding: 16px 16px 32px;
 }
 
-.mdhui-meal-log-empty-text {
+.mdhui-meal-log .mdhui-meal-log-empty-text {
     color: var(--mdhui-text-color-3);
     padding: 16px 16px 32px;
     text-align: center;

--- a/src/components/presentational/MealLog/MealLog.tsx
+++ b/src/components/presentational/MealLog/MealLog.tsx
@@ -46,7 +46,7 @@ export default function MealLog(props: MealLogProps) {
 
     return <div className="mdhui-meal-log" ref={props.innerRef}>
         <Title order={3}>{language('meal-log-title')}</Title>
-        {mealContext.loading && <LoadingIndicator />}
+        {mealContext.loading && <LoadingIndicator className="mdhui-meal-log-loading" />}
         {!mealContext.loading && mealContext.meals.length === 0 &&
             <div className="mdhui-meal-log-empty-text">{language('meal-log-no-data')}</div>
         }

--- a/src/components/presentational/SingleMeal/SingleMeal.css
+++ b/src/components/presentational/SingleMeal/SingleMeal.css
@@ -20,11 +20,11 @@
     box-sizing: border-box;
 }
 
-.mdhui-meal-content {
+.mdhui-meal .mdhui-meal-content {
     display: flex;
 }
 
-.mdhui-meal-thumbnail {
+.mdhui-meal .mdhui-meal-thumbnail {
     position: relative;
     height: 48px;
     width: 48px;
@@ -37,17 +37,18 @@
     margin: 16px 8px 16px 16px;
 }
 
-.mdhui-meal-thumbnail-image img {
+.mdhui-meal .mdhui-meal-thumbnail-image img {
     height: 48px;
     width: 48px;
     object-fit: cover;
+    border-radius: 5px;
 }
 
-.mdhui-meal-loading.mdhui-loading-indicator {
+.mdhui-meal .mdhui-meal-loading.mdhui-loading-indicator {
     padding: 0;
 }
 
-.mdhui-meal-number {
+.mdhui-meal .mdhui-meal-number {
     position: absolute;
     top: -6px;
     left: -6px;
@@ -61,7 +62,7 @@
     border-radius: 10px;
 }
 
-.mdhui-meal-number-old {
+.mdhui-meal .mdhui-meal-number-old {
     font-size: 0.8em;
     height: 24px;
     line-height: 24px;
@@ -71,37 +72,37 @@
     margin: 24px 8px 16px 16px;
 }
 
-.mdhui-meal-info {
+.mdhui-meal .mdhui-meal-info {
     margin: 16px 8px;
     flex: 1;
     color: var(--mdhui-text-color-2);
 }
 
-.mdhui-meal-type {
+.mdhui-meal .mdhui-meal-type {
     font-size: 0.9em;
     font-weight: bold;
 }
 
-.mdhui-meal-time {
+.mdhui-meal .mdhui-meal-time {
     color: var(--mdhui-text-color-1);
     font-size: 0.9em;
 }
 
-.mdhui-meal-description {
+.mdhui-meal .mdhui-meal-description {
     margin-top: 8px;
     font-size: 0.75em;
 }
 
-.mdhui-meal-items {
+.mdhui-meal .mdhui-meal-items {
     margin-top: 8px;
     font-size: 0.75em;
 }
 
-.mdhui-meal-actions {
+.mdhui-meal .mdhui-meal-actions {
     margin-top: 8px;
 }
 
-.mdhui-meal-edit-action {
+.mdhui-meal .mdhui-meal-edit-action {
     margin: 16px;
     color: var(--mdhui-text-color-2);
 }


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

This branch adjusts the meal log and single meal CSS to use more specific selectors to avoid a style collision in downstream apps.  Previously, the loading indicator style from the meal log could be applied to the single meal images depending on the order they were imported.

I've also added a border radius to the single meal thumbnail images to match their containers.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just adjusting some CSS rules in the UI.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

Testing of the thumbnail border radius can be done using the Storybook.  The loading indicator has been working correctly in the Storybook, even before the fix, and in past VB instances, so it will be difficult to confirm unless you have a VB instance where it is shown to be an issue.  I'll be verifying the fix in such a VB instance.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
