### PR TITLE
Fix the meal image capture input's "accept" value.

### DIFF
--- a/src/components/container/MealEditor/MealEditor.tsx
+++ b/src/components/container/MealEditor/MealEditor.tsx
@@ -222,7 +222,7 @@ export default function MealEditor(props: MealEditorProps) {
         return <label>
             <input
                 type="file"
-                accept="image/*;capture=camera"
+                accept="image/*"
                 style={{ display: 'none' }}
                 onChange={event => onFileChanged(event.target.files?.[0])}
             />


### PR DESCRIPTION
## Overview

> Explain your changes, including any issues or relevant context about why they are needed.

This branch updates the meal image capture input's `accept` attribute to fix an issue we were seeing on Android.  The non-standard value with `;capture=camera` was causing a problem.

I have verified that the input works as expected now on Android, iOS, and Web after removing the `;capture=camera` portion.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  This branch just adjusts the accept attribute of the image file input to support capturing an image directly from the camera on Android.  This is the same mechanism we use for survey based image capture.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [x] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

This would be difficult to test using the storybook.  You'll need to launch a view with a meal editor on it, running in the mobile apps and on web MDH.
- Create a view with meal buttons and a meal log.  Configure the meal log to launch a view that has a meal editor on it.
- Configure an app layout tab with your meal log view.
- Visit the meal log with a test participant.  Add a meal and open the editor.
- Try to add an image.
- Verify that on both Android and iOS, you are prompted to select a file or capture a photo.  On web MDH, the file selector should open.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
