### PR TITLE
Meals: Fix an issue with the thumbnail loading indicator on the analysis review worklist.

### DIFF
--- a/src/components/presentational/SingleMeal/SingleMeal.tsx
+++ b/src/components/presentational/SingleMeal/SingleMeal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useRef, useState } from 'react'
 import './SingleMeal.css'
 import UnstyledButton from '../UnstyledButton';
 import { ColorDefinition, getMealTypeDisplayText, language, Meal, resolveColor } from '../../../helpers';
@@ -28,10 +28,22 @@ export default function (props: SingleMealProps) {
     const layoutContext = useContext(LayoutContext);
 
     const [imageLoading, setImageLoading] = useState<boolean>(true);
+    const imgRef = useRef<HTMLImageElement>(null);
 
     useEffect(() => {
-        setImageLoading(!!props.mealImageUrl);
-    }, [props.mealImageUrl])
+        if (imgRef.current) {
+            const img = imgRef.current;
+            if (img.complete) {
+                setImageLoading(false);
+            } else {
+                const onLoad = () => setImageLoading(false);
+                img.addEventListener('load', onLoad);
+                return () => img.removeEventListener('load', onLoad);
+            }
+        } else {
+            setImageLoading(!!props.mealImageUrl);
+        }
+    }, [imgRef.current, props.mealImageUrl])
 
     return <div className={'mdhui-meal' + (props.onClick ? ' clickable' : '')} onClick={props.onClick} ref={props.innerRef}>
         <div className="mdhui-meal-content">
@@ -47,7 +59,7 @@ export default function (props: SingleMealProps) {
                     {props.mealImageUrl &&
                         <>
                             <div className="mdhui-meal-thumbnail-image" style={{ display: imageLoading ? 'none' : 'block' }}>
-                                <img alt={language('meal-thumbnail-alt')} src={props.mealImageUrl} onLoad={() => setImageLoading(false)} />
+                                <img ref={imgRef} alt={language('meal-thumbnail-alt')} src={props.mealImageUrl} />
                             </div>
                             {imageLoading &&
                                 <LoadingIndicator className="mdhui-meal-loading" />


### PR DESCRIPTION
## Overview

This branch has a fix for an issue I saw with the thumbnail loading indicator on the analysis review worklist in the mobile apps.

When completing the review of some meal analysis on the worklist, I noticed that thumbnail images from other meals were switching to an indefinite loading indicator.

It seems that when cached images are loaded into the thumbnails, they do not necessarily fire the `onLoad` handler.  Therefore, it is necessary to check the `img` tag's `complete` property to know if they have been loaded immediately.

This update checks the `complete` flag and only adds an `onLoad` handler when it is necessary to do so.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just adjusting the handling of image loading state determination to ensure the loading indicator is always in the correct state.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [ ] This change can be adequately tested using the MDH Storybook.
- [x] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

This can be tested with a VB view.
- Add meal analysis to some meals on a test participant.  At least one should have an image captured.
- Configure an App Layout tab to point to the `https://{vb-host}/library-views/meal-analysis`.
- Visit the tab.
- Click "Add All" on a meal that does not have the thumbnail (or at least make sure another meal with a thumbnail is present on the list).
- Verify that the thumbnail on the remaining meal loads and does not get stuck with a loading spinner.

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
