### PR TITLE
Couple minor adjustments to the document library preview component.

### DIFF
--- a/src/components/container/DocumentLibraryPreview/DocumentLibraryPreview.css
+++ b/src/components/container/DocumentLibraryPreview/DocumentLibraryPreview.css
@@ -6,6 +6,10 @@
     margin-bottom: 2px;
 }
 
+.mdhui-document-library-preview .mdhui-action .mdhui-loading-indicator {
+    height: 17px;
+}
+
 .mdhui-document-library-preview .mdhui-document-library-preview-documents {
     margin-top: 8px;
 }

--- a/src/components/container/DocumentLibraryPreview/DocumentLibraryPreview.stories.tsx
+++ b/src/components/container/DocumentLibraryPreview/DocumentLibraryPreview.stories.tsx
@@ -29,7 +29,8 @@ type Story = StoryObj<DocumentLibraryPreviewStoryArgs>;
 export const Default: Story = {
     args: {
         colorScheme: 'auto',
-        previewState: 'some documents'
+        previewState: 'some documents',
+        useFullLoadingIndicator: false
     },
     argTypes: {
         colorScheme: {
@@ -41,6 +42,10 @@ export const Default: Story = {
             name: 'state',
             control: 'radio',
             options: ['loading', 'no documents', 'some documents']
+        },
+        useFullLoadingIndicator: {
+           name: 'full loading indicator?',
+           control: 'boolean'
         },
         ...argTypesToHide(['surveySpecification', 'documentLibraryViewBaseUrl', 'innerRef'])
     }

--- a/src/components/container/DocumentLibraryPreview/DocumentLibraryPreview.tsx
+++ b/src/components/container/DocumentLibraryPreview/DocumentLibraryPreview.tsx
@@ -11,6 +11,7 @@ export interface DocumentLibraryPreviewProps {
     previewState?: 'loading' | DocumentLibraryPreviewPreviewState;
     surveySpecification: LibraryDocumentSurveySpecification;
     documentLibraryViewBaseUrl: string;
+    useFullLoadingIndicator?: boolean;
     innerRef?: React.Ref<HTMLDivElement>;
 }
 
@@ -51,7 +52,8 @@ export default function DocumentLibraryPreview(props: DocumentLibraryPreviewProp
     };
 
     return <div className="mdhui-document-library-preview" ref={props.innerRef}>
-        {(!documents || documents.length === 0) &&
+        {!documents && props.useFullLoadingIndicator && <LoadingIndicator />}
+        {((!documents && !props.useFullLoadingIndicator) || documents?.length === 0) &&
             <Action
                 title={language('document-library-preview-title')}
                 subtitle={language('document-library-preview-instructions')}
@@ -61,7 +63,6 @@ export default function DocumentLibraryPreview(props: DocumentLibraryPreviewProp
                         {language('document-library-preview-upload-button-text')}
                     </Button> : <LoadingIndicator />
                 }
-                indicatorPosition="topRight"
                 renderAs="div"
             />
         }


### PR DESCRIPTION
## Overview

This branch includes a couple minor adjustments to the document library preview component.

- By default, the component renders with a small internal spinner while loading.  We have a need to use this component downstream along side a bunch of sibling components that all render as spinners only while loading.  I've added an optional flag named `useFullLoadingIndicator` which tells this component to render as a spinner only while loading.
- The upload button was rendering over the text when the component was being used at mobile width.  To fix this, I set the indicator position back to the default, so it would render inline instead of absolutely, which fixes the overlapping issue.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

DESCRIBE BRIEFLY WHAT SECURITY RISKS YOU CONSIDERED, WHY THEY DON'T APPLY, OR HOW THEY'VE BEEN MITIGATED.

- No new security risk.  Just rendering adjustments.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [x] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.
