### PR TITLE
TimeSeriesChart: Fix horizontal line rendering when gaps are present.

### DIFF
--- a/src/components/container/SurveyAnswerChart/SurveyAnswerChart.stories.tsx
+++ b/src/components/container/SurveyAnswerChart/SurveyAnswerChart.stories.tsx
@@ -294,3 +294,55 @@ export const DailyPain: Story = {
         </Layout>;
     }
 };
+
+export const HorizontalLines: Story = {
+    name: 'Horizontal Lines',
+    args: {
+        colorScheme: 'auto'
+    },
+    argTypes: {
+        colorScheme: {
+            name: 'color scheme',
+            control: 'radio',
+            options: ['auto', 'light', 'dark']
+        },
+        ...argTypesToHide([
+            'previewState', 'title', 'intervalType', 'dynamicIntervalEndType', 'weekStartsOn', 'series', 'chartType', 'options',
+            'expectedDataInterval', 'previewDataProvider', 'innerRef'
+        ])
+    },
+    render: (args: SurveyAnswerChartStoryArgs) => {
+        const props: SurveyAnswerChartProps = {
+            previewState: 'default',
+            title: 'Horizontal Lines',
+            intervalType: 'Week',
+            weekStartsOn: '6DaysAgo',
+            series: [
+                { dataKey: 'Pain Level', surveyName: 'Pain Survey', stepIdentifier: 'PainToday', resultIdentifier: 'PainToday' }
+            ],
+            chartType: 'Line',
+            options: {
+                yAxisOptions: {
+                    domain: [0, 'auto']
+                }
+            },
+            expectedDataInterval: { days: 1 },
+            previewDataProvider: async (startDate: Date, endDate: Date) => {
+                const surveyAnswers = generateSurveyAnswers(startDate, endDate, ['PainToday'], 0, 10, { days: 1 });
+                surveyAnswers.forEach(surveyAnswers => {
+                    surveyAnswers.forEach(surveyAnswer => {
+                        surveyAnswer.answers[0] = '5';
+                    });
+                    surveyAnswers.splice(2, 1);
+                });
+                return surveyAnswers;
+            }
+        };
+
+        return <Layout colorScheme={args.colorScheme}>
+            <Card>
+                <SurveyAnswerChart {...props} />
+            </Card>
+        </Layout>;
+    }
+};

--- a/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/components/presentational/TimeSeriesChart/TimeSeriesChart.tsx
@@ -51,7 +51,7 @@ export default function TimeSeriesChart(props: TimeSeriesChartProps) {
         const lines = chartRef.state.formattedGraphicalItems.filter((fgi: any) => fgi.props?.key?.startsWith("line-"));
         lines.forEach((line: any) => {
             const points: any[] = line.props?.points ?? [];
-            if (points.length > 1 && points.every((point: any) => point.y === points[0].y)) {
+            if (points.length > 1 && points.every((point: any) => point.y === null || point.y === points[0].y)) {
                 points[0].y += 0.001;
             }
         });


### PR DESCRIPTION
## Overview

This is a follow up to https://github.com/CareEvolution/MyDataHelpsUI/pull/576 to also fix horizontal line rendering when the line contains a gap.  When there is a gap in the line, the `y` coordinator of the point is `null`.  We need to ignore those points to correctly determine when to apply the "jitter".

## Security

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

No new security risk.  Just adjusting the logic used to determine when a horizontal line rendering hack should be applied.

## Testing

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

This can be tested with the Storybook.  I have added a story named `Horizontal Lines` that can be used to verify the corrected behavior.

### Documentation

- [x] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.
