### PR TITLE
Filter app download links by mobile web browser OS

### DIFF
--- a/src/components/container/AppDownload/AppDownload.stories.tsx
+++ b/src/components/container/AppDownload/AppDownload.stories.tsx
@@ -17,20 +17,25 @@ const Template: StoryFn<typeof AppDownload> = (args: AppDownloadProps) =>
 		<Card><AppDownload {...args} /></Card>
 	</Layout>;
 
-export const DesktopBoth = Template.bind({});
-DesktopBoth.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
+// On a desktop web browser both store links are shown, limited only by which
+// platforms the project itself supports.
+export const DesktopProjectSupportsAllPlatforms = Template.bind({});
+DesktopProjectSupportsAllPlatforms.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
 
-export const DesktopAndroidOnly = Template.bind({});
-DesktopAndroidOnly.args = {previewProjectPlatforms: ['Web', 'Android'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
+export const DesktopProjectSupportsAndroidOnly = Template.bind({});
+DesktopProjectSupportsAndroidOnly.args = {previewProjectPlatforms: ['Web', 'Android'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
 
-export const DesktopIOSOnly = Template.bind({});
-DesktopIOSOnly.args = {previewProjectPlatforms: ['Web', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
+export const DesktopProjectSupportsIOSOnly = Template.bind({});
+DesktopProjectSupportsIOSOnly.args = {previewProjectPlatforms: ['Web', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
 
-export const MobileAndroid = Template.bind({});
-MobileAndroid.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: 'Android'};
+// On a mobile web browser only the store link matching the device's OS is shown,
+// even when the project supports all platforms.
+export const MobileAndroidBrowser = Template.bind({});
+MobileAndroidBrowser.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: 'Android'};
 
-export const MobileIOS = Template.bind({});
-MobileIOS.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: 'iOS'};
+export const MobileIPhoneBrowser = Template.bind({});
+MobileIPhoneBrowser.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: 'iOS'};
 
-export const NativeApp = Template.bind({});
-NativeApp.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'iOS', previewOperatingSystem: 'iOS'};
+// In the native app the widget is hidden entirely (device platform is not Web).
+export const NativeAppHidden = Template.bind({});
+NativeAppHidden.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'iOS', previewOperatingSystem: 'iOS'};

--- a/src/components/container/AppDownload/AppDownload.stories.tsx
+++ b/src/components/container/AppDownload/AppDownload.stories.tsx
@@ -17,17 +17,20 @@ const Template: StoryFn<typeof AppDownload> = (args: AppDownloadProps) =>
 		<Card><AppDownload {...args} /></Card>
 	</Layout>;
 
-export const WebBoth = Template.bind({});
-WebBoth.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web'};
+export const DesktopBoth = Template.bind({});
+DesktopBoth.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
 
-export const WebAndroid = Template.bind({});
-WebAndroid.args = {previewProjectPlatforms: ['Web', 'Android'], previewDevicePlatform: 'Web'};
+export const DesktopAndroidOnly = Template.bind({});
+DesktopAndroidOnly.args = {previewProjectPlatforms: ['Web', 'Android'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
 
-export const WebIOS = Template.bind({});
-WebIOS.args = {previewProjectPlatforms: ['Web', 'iOS'], previewDevicePlatform: 'Web'};
+export const DesktopIOSOnly = Template.bind({});
+DesktopIOSOnly.args = {previewProjectPlatforms: ['Web', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: ''};
 
-export const Android = Template.bind({});
-Android.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Android'};
+export const MobileAndroid = Template.bind({});
+MobileAndroid.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: 'Android'};
 
-export const IOS = Template.bind({});
-IOS.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'iOS'};
+export const MobileIOS = Template.bind({});
+MobileIOS.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'Web', previewOperatingSystem: 'iOS'};
+
+export const NativeApp = Template.bind({});
+NativeApp.args = {previewProjectPlatforms: ['Web', 'Android', 'iOS'], previewDevicePlatform: 'iOS', previewOperatingSystem: 'iOS'};

--- a/src/components/container/AppDownload/AppDownload.tsx
+++ b/src/components/container/AppDownload/AppDownload.tsx
@@ -53,8 +53,8 @@ export default function (props: AppDownloadProps) {
 	// integrates with their device. On desktop (or when the OS can't be determined)
 	// show both. This only applies on the web platform; in the native app the whole
 	// widget is hidden by PlatformSpecificContent below.
-	let showAndroid = projectInfo.platforms.includes('Android') && operatingSystem !== 'iOS';
-	let showIOS = projectInfo.platforms.includes('iOS') && operatingSystem !== 'Android';
+	const showAndroid = projectInfo.platforms.includes('Android') && operatingSystem !== 'iOS';
+	const showIOS = projectInfo.platforms.includes('iOS') && operatingSystem !== 'Android';
 
 	return (
 		<PlatformSpecificContent platforms={['Web']} previewDevicePlatform={props.previewDevicePlatform} innerRef={props.innerRef}>

--- a/src/components/container/AppDownload/AppDownload.tsx
+++ b/src/components/container/AppDownload/AppDownload.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useState } from 'react'
+import React, { useState } from 'react'
 import './AppDownload.css'
 import MyDataHelps, { ProjectInfo } from '@careevolution/mydatahelps-js'
 import '@fortawesome/fontawesome-svg-core/styles.css';
@@ -11,6 +11,7 @@ import { CardTitle } from '../../presentational';
 export interface AppDownloadProps {
 	previewProjectPlatforms?: string[]
 	previewDevicePlatform?: string;
+	previewOperatingSystem?: string;
 	innerRef?: React.Ref<HTMLDivElement>;
 	title?: string;
 	text?: string;
@@ -18,25 +19,42 @@ export interface AppDownloadProps {
 
 export default function (props: AppDownloadProps) {
 	const [projectInfo, setProjectInfo] = useState<ProjectInfo>();
+	const [operatingSystem, setOperatingSystem] = useState<string>();
 
 	useInitializeView(() => {
 		if (props.previewProjectPlatforms) {
 			// @ts-ignore
 			setProjectInfo({ name: 'PROJECT', platforms: props.previewProjectPlatforms || [] });
-			return;
+		} else {
+			MyDataHelps.getProjectInfo().then(function (projectInfo) {
+				setProjectInfo(projectInfo);
+			});
 		}
 
-		MyDataHelps.getProjectInfo().then(function (projectInfo) {
-			setProjectInfo(projectInfo);
-		});
+		if (props.previewOperatingSystem !== undefined) {
+			setOperatingSystem(props.previewOperatingSystem);
+		} else {
+			MyDataHelps.getDeviceInfo().then(function (deviceInfo) {
+				setOperatingSystem(deviceInfo?.properties?.OperatingSystem ?? '');
+			}).catch(function () {
+				setOperatingSystem('');
+			});
+		}
 	});
 
-	if (!projectInfo) {
+	if (!projectInfo || operatingSystem === undefined) {
 		return null;
 	}
 
 	let title = props.title || language('app-download-title');
 	let text = props.text || language('app-download-subtitle').replace("@@PROJECT_NAME@@", projectInfo.name);
+
+	// When the participant is on a mobile web browser, only offer the store that
+	// integrates with their device. On desktop (or when the OS can't be determined)
+	// show both. This only applies on the web platform; in the native app the whole
+	// widget is hidden by PlatformSpecificContent below.
+	let showAndroid = projectInfo.platforms.includes('Android') && operatingSystem !== 'iOS';
+	let showIOS = projectInfo.platforms.includes('iOS') && operatingSystem !== 'Android';
 
 	return (
 		<PlatformSpecificContent platforms={['Web']} previewDevicePlatform={props.previewDevicePlatform} innerRef={props.innerRef}>
@@ -47,12 +65,12 @@ export default function (props: AppDownloadProps) {
 						{text}
 					</div>
 					<div className="mdhui-app-download-links">
-						{projectInfo.platforms.includes('Android') &&
+						{showAndroid &&
 							<a target="_blank" className="mdhui-app-download-link" href="https://play.google.com/store/apps/details?id=com.careevolution.mydatahelps&hl=en_US&gl=US">
 								<img src={`https://appstorebadges.careevolutionapps.com/images/google/black/logo-${getCurrentLocale()}.svg`} alt={language('app-download-google-play-link-alt')} />
 							</a>
 						}
-						{projectInfo.platforms.includes('iOS') &&
+						{showIOS &&
 							<a target="_blank" className="mdhui-app-download-link" href="https://apps.apple.com/us/app/mydatahelps/id1286789190">
 								<img src={`https://appstorebadges.careevolutionapps.com/images/apple/black/logo-${getCurrentLocale()}.svg`} alt={language('app-download-app-store-link-alt')} />
 							</a>


### PR DESCRIPTION
## Overview

The "Download the App" widget now uses the OperatingSystem property from GetDeviceInfo to only show the app store link that integrates with the participant's mobile web browser: iOS shows only the Apple App Store link, Android shows only the Google Play link, and desktop (or an undetermined OS) shows both. The widget continues to only render on the web platform (hidden in the native app).

## Security

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

Storybook should be sufficient; i've validated in the actual data the correct OperatingSystem keys here. 

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [x] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [ ] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
