### PR TITLE
Fix some daily data provider UTs.

### DIFF
--- a/__tests__/fixtures/daily-data-providers.ts
+++ b/__tests__/fixtures/daily-data-providers.ts
@@ -15,19 +15,19 @@ export const sampleStartDate = add(today, { days: -6 });
 export const sampleEndDate = today;
 
 export const sampleDailyData: DailyData = {
-    'SomeDate': [{} as DeviceDataPoint]
+    'SomeDateV1': [{} as DeviceDataPoint]
 };
 
 export const sampleDailyDataV2: DailyDataV2 = {
-    'SomeDate': [{} as DeviceDataV2Point]
+    'SomeDateV2': [{} as DeviceDataV2Point]
 };
 
 export const sampleDataPoints: DeviceDataPoint[] = [
-    {} as DeviceDataPoint
+    { identifier: "DataPointV1" } as DeviceDataPoint
 ];
 
 export const sampleDataPointsV2: DeviceDataV2Point[] = [
-    {} as DeviceDataV2Point
+    { identifier: "DataPointV2" } as DeviceDataV2Point
 ];
 
 export const sampleResult: DailyDataQueryResult = {

--- a/__tests__/helpers/daily-data-providers/health-connect-active-calories-burned.test.ts
+++ b/__tests__/helpers/daily-data-providers/health-connect-active-calories-burned.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import healthConnectActiveCaloriesBurned from '../../../src/helpers/daily-data-providers/health-connect-active-calories-burned';
 
 describe('Daily Data Provider - Health Connect Active Calories Burned', () => {
     it('Should query for daily data and build a most recent value result keyed by start date.', async () => {
         setupDailyDataV2('HealthConnect', 'active-calories-burned-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await healthConnectActiveCaloriesBurned(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/health-connect-distance.test.ts
+++ b/__tests__/helpers/daily-data-providers/health-connect-distance.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import healthConnectDistance from '../../../src/helpers/daily-data-providers/health-connect-distance';
 
 describe('Daily Data Provider - Health Connect Distance', () => {
     it('Should query for daily data and build a most recent value result keyed by start date.', async () => {
         setupDailyDataV2('HealthConnect', 'distance-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await healthConnectDistance(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/health-connect-max-heart-rate.test.ts
+++ b/__tests__/helpers/daily-data-providers/health-connect-max-heart-rate.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import healthConnectMaxHeartRate from '../../../src/helpers/daily-data-providers/health-connect-max-heart-rate';
 
 describe('Daily Data Provider - Health Connect Max Heart Rate', () => {
     it('Should query for daily data and build a most recent value result keyed by start date.', async () => {
         setupDailyDataV2('HealthConnect', 'heart-rate-daily-maximum', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await healthConnectMaxHeartRate(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/health-connect-min-heart-rate.test.ts
+++ b/__tests__/helpers/daily-data-providers/health-connect-min-heart-rate.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import healthConnectMinHeartRate from '../../../src/helpers/daily-data-providers/health-connect-min-heart-rate';
 
 describe('Daily Data Provider - Health Connect Min Heart Rate', () => {
     it('Should query for daily data and build a most recent value result keyed by start date.', async () => {
         setupDailyDataV2('HealthConnect', 'heart-rate-daily-minimum', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await healthConnectMinHeartRate(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/health-connect-steps.test.ts
+++ b/__tests__/helpers/daily-data-providers/health-connect-steps.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import healthConnectSteps from '../../../src/helpers/daily-data-providers/health-connect-steps';
 
 describe('Daily Data Provider - Health Connect Steps', () => {
     it('Should query for daily data and build a most recent value result keyed by start date.', async () => {
         setupDailyDataV2('HealthConnect', 'steps-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await healthConnectSteps(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/health-connect-total-calories-burned.test.ts
+++ b/__tests__/helpers/daily-data-providers/health-connect-total-calories-burned.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import healthConnectTotalCaloriesBurned from '../../../src/helpers/daily-data-providers/health-connect-total-calories-burned';
 
 describe('Daily Data Provider - Health Connect Total Calories Burned', () => {
     it('Should query for daily data and build a most recent value result keyed by start date.', async () => {
         setupDailyDataV2('HealthConnect', 'total-calories-burned-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await healthConnectTotalCaloriesBurned(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });


### PR DESCRIPTION
## Overview

This branch fixes some daily data provider UTs that were passing, but with incorrect setup.

The root issue was that the sample data values being used resolved to identical objects once they became JS, despite having different types as Typescript objects.

They now have some differentiating data that ensures they are not considered equal in the UT assertions.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

No new security risk.  Just fixing some UT setup.

## Testing

Run the UT suite.

### Documentation

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.
