### PR TITLE
Fix Google Health daily data provider tests after merge

### DIFF
--- a/.github/workflows/build-and-test-workflow.yml
+++ b/.github/workflows/build-and-test-workflow.yml
@@ -25,6 +25,11 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      # The rollup build (in particular the .d.ts generation step) peaks near
+      # Node's default ~4GB heap limit and intermittently OOMs. ubuntu-latest
+      # runners have 16GB of RAM, so give Node more headroom.
+      NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/__tests__/helpers/daily-data-providers/google-health-active-calories-burned.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-active-calories-burned.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthActiveCaloriesBurned from '../../../src/helpers/daily-data-providers/google-health-active-calories-burned';
 
 describe('Daily Data Provider - Google Health Active Calories Burned', () => {
     it('Should query activeEnergyBurned-daily and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'activeEnergyBurned-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthActiveCaloriesBurned(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-activity-minutes.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-activity-minutes.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import * as dailyDataQueryFunctions from '../../../src/helpers/daily-data-providers/daily-data/daily-data-query';
 import { fairlyActiveMinutes, lightlyActiveMinutes, sedentaryMinutes, totalActiveMinutes, veryActiveMinutes } from '../../../src/helpers/daily-data-providers/google-health-activity-minutes';
 
@@ -8,25 +8,25 @@ describe('Daily Data Provider - Google Health Activity Minutes', () => {
 
     it('Sedentary: should query sedentaryPeriod-daily with a seconds-to-minutes value function.', async () => {
         setupDailyDataV2('GoogleHealth', 'sedentaryPeriod-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult, valueFn => !!valueFn && valueFn({ value: '120' } as any) === 2);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult, valueFn => !!valueFn && valueFn({ value: '120' } as any) === 2);
         expect(await sedentaryMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Lightly active: should query activeMinutes-daily-light and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'activeMinutes-daily-light', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await lightlyActiveMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Fairly active: should query activeMinutes-daily-moderate and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'activeMinutes-daily-moderate', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await fairlyActiveMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Very active: should query activeMinutes-daily-vigorous and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'activeMinutes-daily-vigorous', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await veryActiveMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 

--- a/__tests__/helpers/daily-data-providers/google-health-breathing-rate.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-breathing-rate.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthBreathingRate from '../../../src/helpers/daily-data-providers/google-health-breathing-rate';
 
 describe('Daily Data Provider - Google Health Breathing Rate', () => {
     it('Should query the daily respiratory rate list and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'dailyRespiratoryRate-list-breathsPerMinute', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthBreathingRate(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-calories-burned.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-calories-burned.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthCaloriesBurned from '../../../src/helpers/daily-data-providers/google-health-calories-burned';
 
 describe('Daily Data Provider - Google Health Calories Burned', () => {
     it('Should query totalCalories-daily and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'totalCalories-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthCaloriesBurned(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-distance.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-distance.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthDistance from '../../../src/helpers/daily-data-providers/google-health-distance';
 
 describe('Daily Data Provider - Google Health Distance', () => {
     it('Should query distance-daily with a millimeters-to-meters value function.', async () => {
         setupDailyDataV2('GoogleHealth', 'distance-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult, valueFn => !!valueFn && valueFn({ value: '1000' } as any) === 1);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult, valueFn => !!valueFn && valueFn({ value: '1000' } as any) === 1);
         expect(await googleHealthDistance(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-elevated-heart-rate.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-elevated-heart-rate.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import * as dailyDataQueryFunctions from '../../../src/helpers/daily-data-providers/daily-data/daily-data-query';
 import { cardioMinutes, fatBurnMinutes, peakMinutes, totalElevatedHeartRateMinutes } from '../../../src/helpers/daily-data-providers/google-health-elevated-heart-rate';
 
@@ -8,19 +8,19 @@ describe('Daily Data Provider - Google Health Elevated Heart Rate', () => {
 
     it('Fat burn: should query activeZoneMinutes-daily-fat-burn and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'activeZoneMinutes-daily-fat-burn', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await fatBurnMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Cardio: should query activeZoneMinutes-daily-cardio and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'activeZoneMinutes-daily-cardio', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await cardioMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Peak: should query activeZoneMinutes-daily-peak and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'activeZoneMinutes-daily-peak', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await peakMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 

--- a/__tests__/helpers/daily-data-providers/google-health-floors.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-floors.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthFloors from '../../../src/helpers/daily-data-providers/google-health-floors';
 
 describe('Daily Data Provider - Google Health Floors', () => {
     it('Should query floors-daily and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'floors-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthFloors(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-heart-rate.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-heart-rate.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import { averageHeartRate, maxHeartRate, minHeartRate } from '../../../src/helpers/daily-data-providers/google-health-heart-rate';
 
 describe('Daily Data Provider - Google Health Heart Rate', () => {
     it('Max: should query heartRate-daily-max and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'heartRate-daily-max', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await maxHeartRate(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Min: should query heartRate-daily-min and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'heartRate-daily-min', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await minHeartRate(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Average: should query heartRate-daily-avg and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'heartRate-daily-avg', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await averageHeartRate(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-hrv.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-hrv.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthHrv from '../../../src/helpers/daily-data-providers/google-health-hrv';
 
 describe('Daily Data Provider - Google Health HRV', () => {
     it('Should query the daily heart rate variability list and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'dailyHeartRateVariability-list-averageRmssd', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthHrv(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-resting-heart-rate.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-resting-heart-rate.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthRestingHeartRate from '../../../src/helpers/daily-data-providers/google-health-resting-heart-rate';
 
 describe('Daily Data Provider - Google Health Resting Heart Rate', () => {
     it('Should query the daily resting heart rate list and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'dailyRestingHeartRate-list-beatsPerMinute', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthRestingHeartRate(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-sleep.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-sleep.test.ts
@@ -1,30 +1,30 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupTotalValueResult, sleepDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupTotalValueResult, sleepDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import { deepSleepMinutes, lightSleepMinutes, remSleepMinutes, totalSleepMinutes } from '../../../src/helpers/daily-data-providers/google-health-sleep';
 
 describe('Daily Data Provider - Google Health Sleep', () => {
     // Sleep is dated by getSleepDate (observationDate + 6h) so a night's sleep is attributed to the wake-up day.
     it('Total: should sum per-session asleep minutes into a total value result, dated to the wake-up day.', async () => {
         setupDailyDataV2('GoogleHealth', 'sleep-list-session-asleep', sampleStartDate, sampleEndDate, sleepDateFunctionEvaluator, sampleDailyDataV2);
-        setupTotalValueResult(sampleDailyData, sampleResult);
+        setupTotalValueResult(sampleDailyDataV2, sampleResult);
         expect(await totalSleepMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Light: should sum the light-stage summary minutes into a total value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'sleep-list-stages-summary-light-minutes', sampleStartDate, sampleEndDate, sleepDateFunctionEvaluator, sampleDailyDataV2);
-        setupTotalValueResult(sampleDailyData, sampleResult);
+        setupTotalValueResult(sampleDailyDataV2, sampleResult);
         expect(await lightSleepMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('REM: should sum the rem-stage summary minutes into a total value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'sleep-list-stages-summary-rem-minutes', sampleStartDate, sampleEndDate, sleepDateFunctionEvaluator, sampleDailyDataV2);
-        setupTotalValueResult(sampleDailyData, sampleResult);
+        setupTotalValueResult(sampleDailyDataV2, sampleResult);
         expect(await remSleepMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 
     it('Deep: should sum the deep-stage summary minutes into a total value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'sleep-list-stages-summary-deep-minutes', sampleStartDate, sampleEndDate, sleepDateFunctionEvaluator, sampleDailyDataV2);
-        setupTotalValueResult(sampleDailyData, sampleResult);
+        setupTotalValueResult(sampleDailyDataV2, sampleResult);
         expect(await deepSleepMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-spo2.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-spo2.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthSpO2 from '../../../src/helpers/daily-data-providers/google-health-spo2';
 
 describe('Daily Data Provider - Google Health SpO2', () => {
     it('Should query the daily oxygen saturation average and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'dailyOxygenSaturation-list-avg', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthSpO2(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-steps.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-steps.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthSteps from '../../../src/helpers/daily-data-providers/google-health-steps';
 
 describe('Daily Data Provider - Google Health Steps', () => {
     it('Should query steps-daily and build a most recent value result keyed by start date.', async () => {
         setupDailyDataV2('GoogleHealth', 'steps-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthSteps(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });

--- a/__tests__/helpers/daily-data-providers/google-health-wear-minutes.test.ts
+++ b/__tests__/helpers/daily-data-providers/google-health-wear-minutes.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { sampleDailyData, sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
+import { sampleDailyDataV2, sampleEndDate, sampleResult, sampleStartDate, setupDailyDataV2, setupMostRecentValueResult, startDateFunctionEvaluator } from '../../fixtures/daily-data-providers';
 import googleHealthWearMinutes from '../../../src/helpers/daily-data-providers/google-health-wear-minutes';
 
 describe('Daily Data Provider - Google Health Wear Minutes', () => {
     it('Should query wearTime-daily and build a most recent value result.', async () => {
         setupDailyDataV2('GoogleHealth', 'wearTime-daily', sampleStartDate, sampleEndDate, startDateFunctionEvaluator, sampleDailyDataV2);
-        setupMostRecentValueResult(sampleDailyData, sampleResult);
+        setupMostRecentValueResult(sampleDailyDataV2, sampleResult);
         expect(await googleHealthWearMinutes(sampleStartDate, sampleEndDate)).toBe(sampleResult);
     });
 });


### PR DESCRIPTION
## Overview

Commit fff626c split the daily-data test fixtures so sampleDailyData (V1) and sampleDailyDataV2 now carry distinct day keys, but the Google Health provider tests from #624 were written when the two fixtures were indistinguishable. Those providers query the V2 API, so the result builder is invoked with sampleDailyDataV2; the tests still asserted it was called with the V1 sampleDailyData, causing the mock to return {}.

Point the result-builder setup at sampleDailyDataV2 (and drop the now unused V1 import) across all Google Health provider tests.

## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.

## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

N/A

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
