### PR TITLE
Raise Node heap limit in the publish (CICD) job to prevent rollup OOM

### DIFF
--- a/.github/workflows/cicd-publish.yml
+++ b/.github/workflows/cicd-publish.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
     run:
         runs-on: ubuntu-latest
+        env:
+            # The rollup build (in particular the .d.ts generation step) peaks near
+            # Node's default ~4GB heap limit and intermittently OOMs. ubuntu-latest
+            # runners have 16GB of RAM, so give Node more headroom.
+            NODE_OPTIONS: --max-old-space-size=8192
         steps:
             -   uses: actions/checkout@v4
             -   uses: actions/setup-node@v4


### PR DESCRIPTION
## Overview

The Publish to npmjs and ProGet workflow runs `npm run rollup` in its `run` job, the same rollup build (notably the .d.ts declaration-bundling step) that intermittently fails with "JavaScript heap out of memory" near Node's default ~4GB old-space limit. Commit 6220410 added NODE_OPTIONS=--max-old-space-size=8192 to the build-and-test job but missed this publish job, so the v3.21.1 tag push OOM'd during build and never published to npm.

Set the same job-level NODE_OPTIONS here so the publish build has the same headroom (ubuntu-latest runners have 16GB of RAM).


## Security

> Consider potential security impacts and complete the following checklist. 
> **REMINDER:** All file contents are public.

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
  - [x] Please verify that you double checked that .storybook/preview.js does not contain your participant access key details. 
  - [x] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] These changes do not introduce any security risks, or any such risks have been properly mitigated.


## Testing

> Consider whether the changes might have device-specific behaviors (screen padding, new APIs, etc.) and check one of the following boxes:

- [x] This change can be adequately tested using the MDH Storybook.
- [ ] This change requires additional testing in the MDH iOS/Android/Web apps. (Create a pre-release tag/build and test in a ViewBuilder PR.)

N/A

### Documentation

> Consider whether there are any documentation impacts and check one of the following boxes:

- [ ] I have added relevant Storybook updates to this PR.
- [ ] If this feature requires a developer doc update, I have tagged `@CareEvolution/api-docs`.
- [x] This change does not impact documentation or Storybook.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.
